### PR TITLE
Merge gk_output into main

### DIFF
--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -522,19 +522,19 @@ class CGYRO(GKCode):
         nspecies = int(grid_data[1])
         nfield = int(grid_data[2])
         nkx = int(grid_data[3])
-        ntheta = int(grid_data[4])
+        ntheta_grid = int(grid_data[4])
         nenergy = int(grid_data[5])
         npitch = int(grid_data[6])
         box_size = int(grid_data[7])
         length_x = grid_data[8]
         ntheta_plot = int(grid_data[10])
 
-        ntheta_ballooning = ntheta * int(nkx / box_size)
+        ntheta_ballooning = ntheta_grid * int(nkx / box_size)
 
         starting_point = 11 + nkx
 
-        theta = grid_data[starting_point:starting_point + ntheta]
-        starting_point += ntheta
+        theta_grid = grid_data[starting_point:starting_point + ntheta_grid]
+        starting_point += ntheta_grid
 
         energy = grid_data[starting_point:starting_point + nenergy]
         starting_point += nenergy
@@ -547,25 +547,25 @@ class CGYRO(GKCode):
 
         ky = grid_data[starting_point:starting_point + nky]
 
-        # Output data actually given on theta_plot grid
-        stride = ntheta // ntheta_plot
-
         # Convert to ballooning co-ordinate so only 1 kx
         if not pyro.numerics.nonlinear:
-            ntheta_plot = ntheta_plot * nkx
-            theta_plot = np.empty(ntheta_plot)
 
-            for i in range(ntheta_plot):
-                theta_plot[i] = theta_ballooning[stride * i]
+            theta = theta_ballooning
+            ntheta = ntheta_ballooning
 
             kx = [0.0]
             nkx = 1
 
         else:
+            # Output data actually given on theta_plot grid
+            stride = ntheta_grid // ntheta_plot
 
-            for i in range(ntheta_plot):
-                theta_plot = np.empty(ntheta_plot)
-                theta_plot[i] = theta[stride * i]
+            ntheta = ntheta_plot
+            theta = np.empty(ntheta_plot)
+
+            # Calculate sub-sampled theta grid theta grid
+            for i in range(ntheta):
+                theta[i] = theta_grid[stride * i]
 
             kx = 2 * pi * np.linspace(-int(nkx / 2), int(nkx / 2) - 1, nkx) / length_x
 
@@ -579,18 +579,18 @@ class CGYRO(GKCode):
         gk_output.nkx = nkx
         gk_output.nenergy = nenergy
         gk_output.npitch = npitch
-        gk_output.ntheta = ntheta_plot
-        gk_output.ntheta_ballooning = ntheta_ballooning
+        gk_output.ntheta = ntheta
         gk_output.nspecies = nspecies
         gk_output.nfield = nfield
+        gk_output.ntheta_plot = ntheta_plot
+        gk_output.ntheta_grid = ntheta_grid
 
         # Grid values
         gk_output.ky = ky
         gk_output.kx = kx
         gk_output.energy = energy
         gk_output.pitch = pitch
-        gk_output.theta = theta_plot
-        gk_output.theta_ballooning = theta_ballooning
+        gk_output.theta = theta
         gk_output.rho_star = rho_star
 
         # Store grid data as xarray DataSet
@@ -600,8 +600,7 @@ class CGYRO(GKCode):
                                 "species": species,
                                 "kx": kx,
                                 "ky": ky,
-                                "theta": theta_plot,
-                                "theta_ballooning": theta_ballooning
+                                "theta": theta,
                                 }
                         )
 
@@ -625,7 +624,14 @@ class CGYRO(GKCode):
 
         field_appendices = ['phi', 'apar', 'bpar']
 
-        # Loop through all fields and add field in it exists
+        # Linear and theta_plot != theta_grid load field structure from eigenfunction file
+        if not pyro.numerics.nonlinear and gk_output.ntheta_plot != gk_output.ntheta_grid:
+            self.load_eigenfunctions(pyro, no_fields=True)
+
+            for ifield in range(gk_output.nfield):
+                fields[ifield, :, 0, 0, :] = data['eigenfunctions'].isel(field=ifield)
+
+        # Loop through all fields and add field in if it exists
         for ifield, field_appendix in enumerate(field_appendices):
 
             field_file = f"{base_file}{field_appendix}"
@@ -634,30 +640,42 @@ class CGYRO(GKCode):
                 raw_field = self.read_binary_file(field_file)
                 sliced_field = raw_field[:2 * gk_output.nkx * gk_output.ntheta * gk_output.nky * gk_output.ntime]
 
+                # Load in non-linear field
                 if pyro.numerics.nonlinear:
                     field_data = np.reshape(sliced_field, (2, gk_output.nkx, gk_output.ntheta, gk_output.nky,
                                                            gk_output.ntime), 'F') / gk_output.rho_star
 
                     complex_field = field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
 
-                # Convert from kx to ballooning space
+                    fields[ifield, :, :, :, :] = np.reshape(complex_field, (gk_output.ntheta, gk_output.nkx,
+                                                                        gk_output.nky, gk_output.ntime))
+                # Linear convert from kx to ballooning space
                 else:
                     nradial = pyro.cgyro_input['N_RADIAL']
 
-                    # Figure about what theta_plot is
-                    ntheta = gk_output.ntheta // nradial
+                    # If theta_plot != theta_grid get amplitude of fields from binary files
+                    if gk_output.ntheta_plot != gk_output.ntheta_grid:
+                        field_amplitude = np.reshape(sliced_field, (2, nradial, gk_output.ntheta_plot, gk_output.nky,
+                                                                    gk_output.ntime), 'F') / gk_output.rho_star
 
-                    field_data = np.reshape(sliced_field, (2, nradial, ntheta, gk_output.nky,
-                                                           gk_output.ntime), 'F') / gk_output.rho_star
+                        middle_kx = int(nradial/2) + 1
+                        field_amplitude = field_amplitude[0, middle_kx, 0, 0, :]
 
-                    complex_field = field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
+                        fields[ifield, :, 0, 0, :] *= field_amplitude
 
-                    # Poisson Sum
-                    for i_radial in range(nradial):
-                        nx = -nradial // 2 + (i_radial - 1)
-                        complex_field[i_radial, :, :, :] *= np.exp(-2 * pi * 1j * nx * pyro.local_geometry.q)
+                    # If all theta point are there then read in data
+                    else:
+                        field_data = np.reshape(sliced_field, (2, nradial, gk_output.ntheta_plot, gk_output.nky,
+                                                               gk_output.ntime), 'F') / gk_output.rho_star
 
-                fields[ifield, :, :, :, :] = np.reshape(complex_field, (gk_output.ntheta, gk_output.nkx,
+                        complex_field = field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
+
+                        # Poisson Sum
+                        for i_radial in range(nradial):
+                            nx = -nradial // 2 + (i_radial - 1)
+                            complex_field[i_radial, :, :, :] *= np.exp(-2 * pi * 1j * nx * pyro.local_geometry.q)
+
+                        fields[ifield, :, :, :, :] = np.reshape(complex_field, (gk_output.ntheta, gk_output.nkx,
                                                                         gk_output.nky, gk_output.ntime))
 
             else:
@@ -723,7 +741,7 @@ class CGYRO(GKCode):
             data['mode_frequency'] = (("ky", "time"), mode_frequency)
             data['eigenvalues'] = (("ky", "time"), eigenvalue)
 
-    def load_eigenfunctions(self, pyro):
+    def load_eigenfunctions(self, pyro, no_fields=False):
 
         """
         Loads eigenfunctions into GKOutput.data Dataset
@@ -732,9 +750,12 @@ class CGYRO(GKCode):
         gk_output = pyro.gk_output
         data = gk_output.data
 
-        no_nan = not np.isnan(data['fields'].data).any()
+        if no_fields:
+            no_nan = False
+        else:
+            no_nan = not np.isnan(data['fields'].data).any()
 
-        if gk_output.ntheta_ballooning == gk_output.ntheta:
+        if gk_output.ntheta_plot == gk_output.ntheta_grid:
             all_ballooning = True
         else:
             all_ballooning = False
@@ -749,7 +770,7 @@ class CGYRO(GKCode):
 
             base_file = os.path.join(run_directory, 'bin.cgyro.')
 
-            eigenfunctions = np.empty((gk_output.nfield, gk_output.ntheta_ballooning, gk_output.ntime),
+            eigenfunctions = np.empty((gk_output.nfield, gk_output.ntheta, gk_output.ntime),
                                       dtype=np.complex)
 
             field_appendices = ['phi', 'apar', 'bpar']
@@ -760,17 +781,17 @@ class CGYRO(GKCode):
                 eigenfunction_file = f"{base_file}{field_appendix}b"
 
                 if os.path.exists(eigenfunction_file):
-                    raw_eigenfunction = self.read_binary_file(eigenfunction_file)[:2 * gk_output.ntheta_ballooning *
-                                                                                   gk_output.ntime]
+                    raw_eigenfunction = self.read_binary_file(eigenfunction_file)[:2 * gk_output.ntheta *
+                                                                                  gk_output.ntime]
 
-                    sliced_eigenfunction = raw_eigenfunction[:2 * gk_output.ntheta_ballooning * gk_output.ntime]
+                    sliced_eigenfunction = raw_eigenfunction[:2 * gk_output.ntheta * gk_output.ntime]
                     eigenfunction_data = np.reshape(sliced_eigenfunction,
-                                                    (2, gk_output.ntheta_ballooning, gk_output.ntime),
+                                                    (2, gk_output.ntheta, gk_output.ntime),
                                                     'F')
 
                     eigenfunctions[ifield, :, :] = eigenfunction_data[0, :, :] + 1j * eigenfunction_data[1, :, :]
 
-            data['eigenfunctions'] = (("field", "theta_ballooning", "time"), eigenfunctions)
+            data['eigenfunctions'] = (("field", "theta", "time"), eigenfunctions)
 
     def read_binary_file(self, file_name):
         """

--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -148,14 +148,15 @@ class CGYRO(GKCode):
 
             # Find BETA_STAR_SCALE from beta and p_prime
             if pyro.local_geometry_type == 'Miller':
-                beta_prime_scale = - miller.beta_prime / (local_species.a_lp * beta * (miller.Bunit/miller.B0)**2)
+                beta_prime_scale = - miller.beta_prime / (local_species.a_lp * beta * (miller.Bunit / miller.B0) ** 2)
 
         # Calculate beta from existing value from input
         else:
             if pyro.local_geometry_type == 'Miller':
                 if miller.Bunit is not None:
                     beta = 1.0 / miller.Bunit ** 2
-                    beta_prime_scale = - miller.beta_prime / (local_species.a_lp * beta * (miller.Bunit/miller.B0)**2)
+                    beta_prime_scale = - miller.beta_prime / (
+                                local_species.a_lp * beta * (miller.Bunit / miller.B0) ** 2)
                 else:
                     beta = 0.0
                     beta_prime_scale = 1.0
@@ -329,7 +330,6 @@ class CGYRO(GKCode):
 
         # Normalise to pyrokinetics normalisations and calculate total pressure gradient
         for name in local_species.names:
-
             species_data = local_species[name]
 
             species_data.temp = species_data.temp / te
@@ -474,13 +474,17 @@ class CGYRO(GKCode):
 
         pyro.gk_output = GKOutput()
 
-        self.read_grids(pyro)
+        self.load_grids(pyro)
 
-        self.read_eigenvalues(pyro)
+        self.load_eigenvalues(pyro)
 
-        self.read_fluxes(pyro)
+        self.load_eigenfunctions(pyro)
 
-    def read_grids(self, pyro):
+        self.load_fields(pyro)
+
+        self.load_fluxes(pyro)
+
+    def load_grids(self, pyro):
         """
         Loads CGYRO grids to GKOutput
 
@@ -488,6 +492,8 @@ class CGYRO(GKCode):
         Output is in a standardised order
 
         """
+
+        import xarray as xr
 
         gk_output = pyro.gk_output
 
@@ -497,13 +503,20 @@ class CGYRO(GKCode):
         time = np.loadtxt(time_file)[:, 0]
 
         gk_output.time = time
+        gk_output.ntime = len(time)
+
+        eq_file = os.path.join(run_directory, 'out.cgyro.equilibrium')
+
+        eq_data = np.loadtxt(eq_file)
+
+        rho_star = eq_data[23]
 
         grids_file = os.path.join(run_directory, 'out.cgyro.grids')
 
         grid_data = np.loadtxt(grids_file)
 
         nky = int(grid_data[0])
-        nspec = int(grid_data[1])
+        nspecies = int(grid_data[1])
         nfield = int(grid_data[2])
         nkx = int(grid_data[3])
         ntheta = int(grid_data[4])
@@ -511,14 +524,21 @@ class CGYRO(GKCode):
         npitch = int(grid_data[6])
         box_size = int(grid_data[7])
         length_x = grid_data[8]
-        theta_plot = int(grid_data[10])
+        ntheta_plot = int(grid_data[10])
 
-        ntheta_ballooning = theta_plot * int(nkx / box_size)
+        ntheta_ballooning = ntheta * int(nkx / box_size)
 
         starting_point = 11 + nkx
 
         theta = grid_data[starting_point:starting_point + ntheta]
         starting_point += ntheta
+
+        # Output data actually given on theta_plot grid
+        theta_plot = np.empty(ntheta_plot)
+
+        stride = ntheta // ntheta_plot
+        for i in range(ntheta_plot):
+            theta_plot[i] = theta[stride * i]
 
         energy = grid_data[starting_point:starting_point + nenergy]
         starting_point += nenergy
@@ -529,18 +549,22 @@ class CGYRO(GKCode):
         theta_ballooning = grid_data[starting_point:starting_point + ntheta_ballooning]
         starting_point += ntheta_ballooning
 
-        ky = grid_data[starting_point:starting_point+nky]
+        ky = grid_data[starting_point:starting_point + nky]
 
-        kx = 2 * pi * np.linspace(-int(nkx / 2), int(nkx / 2)-1, nkx) / length_x
+        kx = 2 * pi * np.linspace(-int(nkx / 2), int(nkx / 2) - 1, nkx) / length_x
+
+        field = ['phi', 'apar', 'bpar']
+        moment = ['particle', 'energy', 'momentum']
+        species = pyro.local_species.names
 
         # Grid sizes
         gk_output.nky = nky
         gk_output.nkx = nkx
         gk_output.nenergy = nenergy
         gk_output.npitch = npitch
-        gk_output.ntheta = ntheta
+        gk_output.ntheta = ntheta_plot
         gk_output.ntheta_ballooning = ntheta_ballooning
-        gk_output.nspec = nspec
+        gk_output.nspecies = nspecies
         gk_output.nfield = nfield
 
         # Grid values
@@ -550,27 +574,146 @@ class CGYRO(GKCode):
         gk_output.pitch = pitch
         gk_output.theta = theta
         gk_output.theta_ballooning = theta_ballooning
+        gk_output.rho_star = rho_star
 
-    def read_eigenvalues(self, pyro):
-        """
-        Loads eigenvalues into GKOutput
-        """
-        pass
+        # Store grid data as xarray DataSet
+        ds = xr.Dataset(coords={"time": time,
+                                "field": field,
+                                "moment": moment,
+                                "species": species,
+                                "kx": kx,
+                                "ky": ky,
+                                "theta": theta_plot,
+                                "theta_ballooning": theta_ballooning
+                                }
+                        )
 
-    def read_eigenfunctions(self):
-        """
-        reads in eigenfunction
-        """
-        pass
+        gk_output.data = ds
 
-    def read_fields(self):
+    def load_eigenvalues(self, pyro):
         """
-        reads in 3D fields
+        Loads eigenvalues into GKOutput.data DataSet
         """
-        pass
 
-    def read_fluxes(self, pyro):
+        gk_output = pyro.gk_output
+        data = gk_output.data
+
+        run_directory = pyro.run_directory
+
+        eigenvalue_file = os.path.join(run_directory, 'bin.cgyro.freq')
+
+        if os.path.exists(eigenvalue_file):
+            raw_data = self.read_binary_file(eigenvalue_file)
+            sliced_data = raw_data[:2 * gk_output.nky * gk_output.ntime]
+            eigenvalue_over_time = np.reshape(sliced_data, (2, gk_output.nky, gk_output.ntime), 'F')
+        else:
+            eigenvalue_file = os.path.join(run_directory, 'out.cgyro.freq')
+            raw_data = np.loadtxt(eigenvalue_file).transpose()
+            sliced_data = raw_data[:, :gk_output.ntime]
+            eigenvalue_over_time = np.reshape(sliced_data, (2, gk_output.nky, gk_output.ntime))
+
+        mode_frequency = eigenvalue_over_time[0, :, :]
+        growth_rate = eigenvalue_over_time[1, :, :]
+        eigenvalue = mode_frequency + 1j * growth_rate
+
+        data['growth_rate'] = (("ky", "time"), growth_rate)
+        data['mode_frequency'] = (("ky", "time"), mode_frequency)
+        data['eigenvalues'] = (("ky", "time"), eigenvalue)
+
+    def load_eigenfunctions(self, pyro):
+
         """
-        Loads eigenvalues into GKOutput
+        Loads eigenfunctions into GKOutput.data Dataset
         """
-        pass
+
+        gk_output = pyro.gk_output
+        data = gk_output.data
+
+        run_directory = pyro.run_directory
+
+        base_file = os.path.join(run_directory, 'bin.cgyro.')
+
+        eigenfunctions = np.empty((gk_output.nfield, gk_output.ntheta_ballooning, gk_output.ntime), dtype=np.complex)
+
+        field_appendices = ['phi', 'apar', 'bpar']
+
+        # Loop through all fields and add eigenfunction if it exists
+        for ifield, field_appendix in enumerate(field_appendices):
+
+            eigenfunction_file = f"{base_file}{field_appendix}b"
+
+            if os.path.exists(eigenfunction_file):
+                raw_eigenfunction = self.read_binary_file(eigenfunction_file)[:2 * gk_output.ntheta_ballooning *
+                                                                               gk_output.ntime]
+                sliced_eigenfunction = raw_eigenfunction[:2 * gk_output.ntheta_ballooning * gk_output.ntime]
+                eigenfunction_data = np.reshape(sliced_eigenfunction, (2, gk_output.ntheta_ballooning, gk_output.ntime),
+                                                'F')
+
+                # Select final time slice
+                eigenfunctions[ifield, :, :] = eigenfunction_data[0, :, :] + 1j * eigenfunction_data[1, :, :]
+
+        data['eigenfunctions'] = (("field", "theta_ballooning", "time"), eigenfunctions)
+
+    def load_fields(self, pyro):
+        """
+        Loads 3D fields into GKOutput.data DataSet
+        """
+
+        gk_output = pyro.gk_output
+        data = gk_output.data
+
+        run_directory = pyro.run_directory
+
+        base_file = os.path.join(run_directory, 'bin.cgyro.kxky_')
+
+        fields = np.empty((gk_output.nfield, gk_output.nkx, gk_output.ntheta, gk_output.nky, gk_output.ntime),
+                          dtype=np.complex)
+
+        field_appendices = ['phi', 'apar', 'bpar']
+
+        # Loop through all fields and add field in it exists
+        for ifield, field_appendix in enumerate(field_appendices):
+
+            field_file = f"{base_file}{field_appendix}"
+
+            if os.path.exists(field_file):
+                raw_field = self.read_binary_file(field_file)
+                sliced_field = raw_field[:2 * gk_output.nkx * gk_output.ntheta * gk_output.nky * gk_output.ntime]
+
+                field_data = np.reshape(sliced_field, (2, gk_output.nkx, gk_output.ntheta, gk_output.nky,
+                                                       gk_output.ntime), 'F') / gk_output.rho_star
+
+                # Select final time slice
+                fields[ifield, :, :, :, :] = field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
+
+        data['fields'] = (('field', 'kx', 'theta', 'ky', 'time'), fields)
+
+    def load_fluxes(self, pyro):
+        """
+        Loads fluxes into GKOutput.data DataSet
+        """
+        gk_output = pyro.gk_output
+        data = gk_output.data
+
+        run_directory = pyro.run_directory
+
+        flux_file = os.path.join(run_directory, 'bin.cgyro.ky_flux')
+
+        fluxes = np.empty((gk_output.nspecies, 3, gk_output.nfield, gk_output.nky, gk_output.ntime))
+
+        if os.path.exists(flux_file):
+            raw_flux = self.read_binary_file(flux_file)
+            sliced_flux = raw_flux[:gk_output.nspecies * 3 * gk_output.nfield * gk_output.nky * gk_output.ntime]
+            fluxes = np.reshape(sliced_flux, (gk_output.nspecies, 3, gk_output.nfield, gk_output.nky, gk_output.ntime),
+                                'F')
+
+        data['fluxes'] = (("species", "moment", "field", "ky", "time"), fluxes)
+
+    def read_binary_file(self, file_name):
+        """
+        Read CGYRO binary files
+        """
+
+        raw_data = np.fromfile(file_name, dtype='float32')
+
+        return raw_data

--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -119,7 +119,7 @@ class CGYRO(GKCode):
             for key, val in pyro_cgyro_miller.items():
                 cgyro_input[val] = miller[key]
 
-            cgyro_input['S_DELTA'] = miller.s_delta * np.sqrt(1 - miller.delta**2)
+            cgyro_input['S_DELTA'] = miller.s_delta * np.sqrt(1 - miller.delta ** 2)
 
         else:
             raise NotImplementedError
@@ -158,7 +158,7 @@ class CGYRO(GKCode):
                 if miller.Bunit is not None:
                     beta = 1.0 / miller.Bunit ** 2
                     beta_prime_scale = - miller.beta_prime / (
-                                local_species.a_lp * beta * (miller.Bunit / miller.B0) ** 2)
+                            local_species.a_lp * beta * (miller.Bunit / miller.B0) ** 2)
                 else:
                     beta = 0.0
                     beta_prime_scale = 1.0
@@ -665,7 +665,6 @@ class CGYRO(GKCode):
                     print(f'No field file for {field_appendix}')
                     fields[ifield, :, :, :, :] = None
 
-
         data['fields'] = (('field', 'theta', 'kx', 'ky', 'time'), fields)
 
     def load_fluxes(self, pyro):
@@ -750,7 +749,8 @@ class CGYRO(GKCode):
 
             base_file = os.path.join(run_directory, 'bin.cgyro.')
 
-            eigenfunctions = np.empty((gk_output.nfield, gk_output.ntheta_ballooning, gk_output.ntime), dtype=np.complex)
+            eigenfunctions = np.empty((gk_output.nfield, gk_output.ntheta_ballooning, gk_output.ntime),
+                                      dtype=np.complex)
 
             field_appendices = ['phi', 'apar', 'bpar']
 
@@ -761,10 +761,11 @@ class CGYRO(GKCode):
 
                 if os.path.exists(eigenfunction_file):
                     raw_eigenfunction = self.read_binary_file(eigenfunction_file)[:2 * gk_output.ntheta_ballooning *
-                                                                                  gk_output.ntime]
+                                                                                   gk_output.ntime]
 
                     sliced_eigenfunction = raw_eigenfunction[:2 * gk_output.ntheta_ballooning * gk_output.ntime]
-                    eigenfunction_data = np.reshape(sliced_eigenfunction, (2, gk_output.ntheta_ballooning, gk_output.ntime),
+                    eigenfunction_data = np.reshape(sliced_eigenfunction,
+                                                    (2, gk_output.ntheta_ballooning, gk_output.ntime),
                                                     'F')
 
                     eigenfunctions[ifield, :, :] = eigenfunction_data[0, :, :] + 1j * eigenfunction_data[1, :, :]

--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -741,6 +741,8 @@ class CGYRO(GKCode):
             data['mode_frequency'] = (("ky", "time"), mode_frequency)
             data['eigenvalues'] = (("ky", "time"), eigenvalue)
 
+            self.get_growth_rate_tolerance(pyro)
+
     def load_eigenfunctions(self, pyro, no_fields=False):
 
         """

--- a/pyrokinetics/examples/example_read_cgyro_output.py
+++ b/pyrokinetics/examples/example_read_cgyro_output.py
@@ -1,0 +1,45 @@
+from pyrokinetics import Pyro
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Point to CGYRO input file
+cgyro_template = 'input.cgyro'
+
+# Load in file
+pyro = Pyro(gk_file=cgyro_template, gk_type='CGYRO')
+
+# Load in CGYRO output data
+pyro.load_gk_output()
+data = pyro.gk_output.data
+
+# Get eigenvalues
+eigenvalues = data['eigenvalues']
+growth_rate = data['growth_rate']
+mode_freq = data['mode_frequency']
+
+# Plot growth and mode frequency
+growth_rate.plot(x='time')
+plt.show()
+
+mode_freq.plot(x='time')
+plt.show()
+
+# Plot eigenfunction
+phi_eig = np.real(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_eig.plot(x='theta')
+
+phi_i_eig = np.imag(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_i_eig.plot(x='theta')
+plt.show()
+
+# Plot electron energy flux
+energy_flux = data['fluxes'].sel(field='phi', species='electron', moment='energy').sum(dim="ky").plot.line()
+plt.show()
+
+# Plot phi
+phi = data['fields'].sel(field='phi').sel(theta=0.0, method='nearest').isel(ky=0).isel(kx=0)
+phi = np.abs(phi)
+phi.plot.line(x="time")
+
+plt.yscale('log')
+plt.show()

--- a/pyrokinetics/examples/example_read_gene_output.py
+++ b/pyrokinetics/examples/example_read_gene_output.py
@@ -1,0 +1,45 @@
+from pyrokinetics import Pyro
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Point to GENE input file
+gene_template = 'parameters_0005'
+
+# Load in file
+pyro = Pyro(gk_file=gene_template, gk_type='GENE')
+
+# Load in GENE output data
+pyro.load_gk_output(gene_output_number='0005')
+data = pyro.gk_output.data
+
+# Get eigenvalues
+eigenvalues = data['eigenvalues']
+growth_rate = data['growth_rate']
+mode_freq = data['mode_frequency']
+
+# Plot growth and mode frequency
+growth_rate.plot(x='time')
+plt.show()
+
+mode_freq.plot(x='time')
+plt.show()
+
+# Plot eigenfunction
+phi_eig = np.real(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_eig.plot(x='theta')
+
+phi_i_eig = np.imag(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_i_eig.plot(x='theta')
+plt.show()
+
+# Plot electron energy flux
+energy_flux = data['fluxes'].sel(species='electron', moment='energy').sum(dim=['field']).plot.line()
+plt.show()
+
+# Plot phi
+phi = data['fields'].sel(field='phi').isel(ky=0).isel(kx=0).sel(theta=0.0, method='nearest')
+phi = np.abs(phi)
+phi.plot.line(x="time")
+
+plt.yscale('log')
+plt.show()

--- a/pyrokinetics/examples/example_read_gs2_output.py
+++ b/pyrokinetics/examples/example_read_gs2_output.py
@@ -18,7 +18,10 @@ growth_rate = data['growth_rate']
 mode_freq = data['mode_frequency']
 
 # Plot growth and mode frequency
+
+growth_rate_tolerance = data['growth_rate_tolerance'].values
 growth_rate.plot(x='time')
+plt.title(f'Growth rate tolerance = {growth_rate_tolerance:.2e}')
 plt.show()
 
 mode_freq.plot(x='time')

--- a/pyrokinetics/examples/example_read_gs2_output.py
+++ b/pyrokinetics/examples/example_read_gs2_output.py
@@ -1,0 +1,46 @@
+from pyrokinetics import Pyro
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Point to GS2 input file
+gs2_template = 'step_aky_0.5.in'
+
+# Load in file
+pyro = Pyro(gk_file=gs2_template, gk_type='GS2')
+
+# Load in GS2 output data
+pyro.load_gk_output()
+data = pyro.gk_output.data
+
+# Get eigenvalues
+eigenvalues = data['eigenvalues']
+growth_rate = data['growth_rate']
+mode_freq = data['mode_frequency']
+
+# Plot growth and mode frequency
+growth_rate.plot(x='time')
+plt.show()
+
+mode_freq.plot(x='time')
+plt.show()
+
+# Plot eigenfunction
+phi_eig = np.real(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_eig.plot(x='theta')
+
+phi_i_eig = np.imag(data['eigenfunctions'].sel(field='phi').isel(time=-1))
+phi_i_eig.plot(x='theta')
+plt.show()
+
+# Plot electron energy flux
+energy_flux = data['fluxes'].sel(field='phi', species='electron', moment='energy').sum(dim="ky").plot.line()
+plt.show()
+
+# Plot phi
+phi = data['fields'].sel(field='phi').sel(theta=0.0, method='nearest').isel(ky=0).isel(kx=0)
+phi = np.abs(phi)
+phi.plot.line(x="time")
+
+plt.yscale('log')
+plt.show()
+

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -451,7 +451,7 @@ class GENE(GKCode):
         nkx = nml['box']['nx0']
 
         ntheta = nml['box']['nz0']
-        theta = np.linspace(-pi, pi, ntheta)
+        theta = np.linspace(-pi, pi, ntheta, endpoint=False)
 
         nenergy = nml['box']['nv0']
         energy = np.linspace(-1, 1, nenergy)

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -465,25 +465,21 @@ class GENE(GKCode):
         if not pyro.numerics.nonlinear:
 
             # Set up ballooning angle
-            ntheta_ballooning = ntheta * (nkx - 1)
-            theta_ballooning = np.empty(ntheta_ballooning)
+            single_theta_loop = theta
+            single_ntheta_loop = ntheta
+
+            ntheta = ntheta * (nkx - 1)
+            theta = np.empty(ntheta)
             start = 0
             for i in range(nkx-1):
                 pi_segment = i - nkx // 2 + 1
-                theta_ballooning[start:start+ntheta] = theta + pi_segment * 2 * pi
-                start += ntheta
+                theta[start:start+single_ntheta_loop] = single_theta_loop + pi_segment * 2 * pi
+                start += single_ntheta_loop
 
             ky = [nml['box']['kymin']]
 
             kx = [0.0]
             nkx = 1
-
-            ntheta = ntheta_ballooning
-            theta = theta_ballooning
-
-        else:
-            theta_ballooning = theta
-            ntheta_ballooning = ntheta
 
         # Grid sizes
         gk_output.nky = nky
@@ -491,7 +487,6 @@ class GENE(GKCode):
         gk_output.nenergy = nenergy
         gk_output.npitch = npitch
         gk_output.ntheta = ntheta
-        gk_output.ntheta_ballooning = ntheta_ballooning
         gk_output.nspecies = pyro.local_species.nspec
         gk_output.nfield = nfield
 
@@ -501,7 +496,6 @@ class GENE(GKCode):
         gk_output.energy = energy
         gk_output.pitch = pitch
         gk_output.theta = theta
-        gk_output.theta_ballooning = theta_ballooning
 
         # Store grid data as xarray DataSet
         ds = xr.Dataset(coords={"time": time,
@@ -511,7 +505,6 @@ class GENE(GKCode):
                                 "kx": kx,
                                 "ky": ky,
                                 "theta": theta,
-                                "theta_ballooning": theta_ballooning
                                 }
                         )
 

--- a/pyrokinetics/gk_code.py
+++ b/pyrokinetics/gk_code.py
@@ -151,4 +151,4 @@ class GKCode:
         eigenfunctions = eigenfunctions / field_amplitude
         eigenfunctions = eigenfunctions.squeeze(dim=['kx', 'ky'], drop=True)
 
-        data['eigenfunctions'] = (("field", "theta_ballooning", "time"), eigenfunctions.data)
+        data['eigenfunctions'] = (("field", "theta", "time"), eigenfunctions.data)

--- a/pyrokinetics/gk_output.py
+++ b/pyrokinetics/gk_output.py
@@ -1,5 +1,6 @@
 from cleverdict import CleverDict
 from .decorators import not_implemented
+from xarray import Dataset
 
 
 class GKOutput(CleverDict):
@@ -9,13 +10,16 @@ class GKOutput(CleverDict):
         s_args = list(args)
 
         if (args and not isinstance(args[0], CleverDict)
-            and isinstance(args[0], dict)):
+                and isinstance(args[0], dict)):
             s_args[0] = sorted(args[0].items())
 
         if args:
             super(GKOutput, self).__init__(*s_args, **kwargs)
         else:
             self.default()
+
+            # All output data stored in Xarray Dataset
+            self.data = Dataset()
 
     def default(self):
 
@@ -24,45 +28,44 @@ class GKOutput(CleverDict):
         super(GKOutput, self).__init__(_data_dict)
 
     @not_implemented
-    def read_grids(self):
+    def load_grids(self):
         """
         reads in numerical grids
         """
         pass
 
     @not_implemented
-    def read_output_data(self,
-                    ):
+    def load_gk_output(self,
+                       pyro):
         """
         reads in data not currently read in by default
         """
         pass
 
     @not_implemented
-    def read_eigenvalues(self):
+    def load_eigenvalues(self):
         """
         reads in eigenvalue
         """
         pass
 
     @not_implemented
-    def read_eigenfunctions(self):
+    def load_eigenfunctions(self):
         """
         reads in eigenfunction
         """
         pass
 
     @not_implemented
-    def read_fields(self):
+    def load_fields(self):
         """
         reads in 3D fields
         """
         pass
 
     @not_implemented
-    def read_fluxes(self):
+    def load_fluxes(self):
         """
-        reads in fluxes
+        reads in fields
         """
         pass
-

--- a/pyrokinetics/gk_output.py
+++ b/pyrokinetics/gk_output.py
@@ -43,13 +43,6 @@ class GKOutput(CleverDict):
         pass
 
     @not_implemented
-    def load_eigenvalues(self):
-        """
-        reads in eigenvalue
-        """
-        pass
-
-    @not_implemented
     def load_eigenfunctions(self):
         """
         reads in eigenfunction

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -530,14 +530,18 @@ class GS2(GKCode):
         gk_output.kx = kx
         gk_output.nkx = len(kx)
 
-        nspecies = netcdf_data['nspecies'][:]
+        nspecies = netcdf_data.dimensions['species'].size
         gk_output.nspecies = nspecies
 
         theta = netcdf_data['theta'][:]
         gk_output.theta = theta
         gk_output.ntheta = len(theta)
 
-        energy = netcdf_data['egrid'][:]
+        try:
+            energy = netcdf_data['egrid'][:]
+        except IndexError:
+            energy = netcdf_data['energy'][:]
+
         gk_output.energy = energy
         gk_output.nenergy = len(energy)
 

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -495,7 +495,7 @@ class GS2(GKCode):
 
     def load_grids(self, pyro):
         """
-        Loads CGYRO grids to GKOutput
+        Loads GS2 grids to GKOutput
 
         out.cgyro.grids stores all the grid data in one long 1D array
         Output is in a standardised order

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -536,8 +536,6 @@ class GS2(GKCode):
         theta = netcdf_data['theta'][:]
         gk_output.theta = theta
         gk_output.ntheta = len(theta)
-        gk_output.theta_ballooning = gk_output.theta
-        gk_output.ntheta_ballooning = gk_output.ntheta
 
         energy = netcdf_data['egrid'][:]
         gk_output.energy = energy
@@ -572,7 +570,6 @@ class GS2(GKCode):
                                 "kx": kx,
                                 "ky": ky,
                                 "theta": theta,
-                                "theta_ballooning": theta
                                 }
                         )
 

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -307,12 +307,12 @@ class Pyro:
 
         self.local_species = local_species
 
-    def load_gk_output(self):
+    def load_gk_output(self, **kwargs):
         """
         Loads GKOutput object
         """
 
-        self.gk_code.load_gk_output(self)
+        self.gk_code.load_gk_output(self, **kwargs)
 
     @property
     def float_format(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ scipy>=1.6.3
 sphinx==3.5.4
 myst_parser==0.14.0
 cleverdict>=1.9.1
+xarray>=0.10
 # Not required for Python>=3.8, but included because conda does not support
 # conditional expressions in --file arguments.
 # This file should only be used by developers, so the odd extra package is not


### PR DESCRIPTION
This branch allows for the reading in of GK output data as xarray Dataarray

For nonlinear runs:

- Fluxes[species, ky, time, moment] (except for GENE which is [species, time, moment] for now)
- Fields[field, kx, ky, theta, time]

For a linear runs:

- Fluxes[species, ky, time, moment] (except for GENE which is [species, time, moment] for now)
- Fields[field, kx, ky, theta, time]
- Eigenvalues[time]
- Eigenfunction[field, theta]

- The eigenvalues and eigenfunctions are calculated from the fields Dataarray IF the full field is available (field[kx, ky, theta, time]) is available
- The eigenvalues are calculated using the GKDB definition and a tolerance is defined. 
- The field is converted to ballooning space (CGYRO/GENE have the field in flux tube by default)
- kx = 0 by default

Example scripts to read in the data are included in examples i.e. example_read_gs2_output.py

Future development:
Can include the moments
