### PR TITLE
Bugfix/initial miller shift

### DIFF
--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -353,6 +353,9 @@ class Miller(LocalGeometry):
         R0 = self.Rmaj
         rmin = self.rho
 
+        if not hasattr(self, 'theta'):
+            self.theta = np.linspace(0, 2 * pi, 128)
+
         theta = self.theta
         kappa = self.kappa
         delta = self.delta

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -113,7 +113,7 @@ class Miller(LocalGeometry):
         delta = (R_major - R_upper) / r_minor
 
         drho_dpsi = eq.rho.derivative()(psi_n)
-        shift = eq.R_major.derivative()(psi_n) / drho_dpsi
+        shift = eq.R_major.derivative()(psi_n) / drho_dpsi / eq.a_minor
 
         pressure = eq.pressure(psi_n)
         q = eq.q(psi_n)
@@ -173,6 +173,10 @@ class Miller(LocalGeometry):
         if verbose:
             print("Miller :: Fit to Bpoloidal obtained "+
                   "with residual {r}".format(r=fits.cost))
+
+        if fits.cost > 1:
+            import warnings
+            warnings.warn(f"Warning Fit to Bpoloidal in Miller::load_from_eq is poor with residual of {fits.cost}")
 
         self.s_kappa = fits.x[0]
         self.s_delta = fits.x[1]
@@ -349,8 +353,6 @@ class Miller(LocalGeometry):
         R0 = self.Rmaj
         rmin = self.rho
 
-        self.theta = np.linspace(0, 2 * pi, 128)
-
         theta = self.theta
         kappa = self.kappa
         delta = self.delta
@@ -383,3 +385,4 @@ class Miller(LocalGeometry):
                'shift': 0.0, 'btccw': -1, 'ipccw': -1, 'beta_prime': 0.0, 'local_geometry': 'Miller'}
 
         super(Miller, self).__init__(mil)
+

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -247,6 +247,7 @@ class Pyro:
 
     def load_local_geometry(self,
                             psi_n=None,
+                            **kwargs
                             ):
         """ 
         Loads local geometry parameters
@@ -263,7 +264,7 @@ class Pyro:
             raise ValueError('Please specify local geometry type')
 
         # Load local geometry
-        self.local_geometry.load_from_eq(self.eq, psi_n=psi_n)
+        self.local_geometry.load_from_eq(self.eq, psi_n=psi_n, **kwargs)
 
     def load_local(self,
                    psi_n=None,


### PR DESCRIPTION
Missing `a_minor` in guess of `shift` 

Leads to poor fits when examining large devices.

Add in Warning if fit is poor.