### PR TITLE
Remove Bunit from miller object and define everything from B0 instead

### DIFF
--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -240,16 +240,15 @@ class GENE(GKCode):
         # Get beta normalised to R_major(in case R_geo != R_major)
         beta = gene['general']['beta'] * (miller.Rmaj / miller.Rgeo) ** 2
 
+        # Can only know Bunit/B0 from local Miller
+        miller.bunit_over_b0 = miller.get_bunit_over_b0()
+
         # Assume pref*8pi*1e-7 = 1.0
         if beta != 0.0:
             miller.B0 = np.sqrt(1.0 / beta)
-            # Can only know Bunit/B0 from local Miller
-            miller.Bunit = miller.get_bunit_over_b0() * miller.B0
-
         else:
             # If beta = 0
             miller.B0 = None
-            miller.Bunit = None
 
         pyro.miller = miller
 

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -273,16 +273,15 @@ class GS2(GKCode):
         # Get beta normalised to R_major(in case R_geo != R_major)
         beta = gs2['parameters']['beta'] * (miller.Rmaj / miller.Rgeo) ** 2
 
+        # Can only know Bunit/B0 from local Miller
+        miller.bunit_over_b0 = miller.get_bunit_over_b0()
+
         # Assume pref*8pi*1e-7 = 1.0
         if beta != 0.0:
             miller.B0 = np.sqrt(1.0 / beta)
-            # Can only know Bunit/B0 from local Miller
-            miller.Bunit = miller.get_bunit_over_b0() * miller.B0
-
         else:
             # If beta = 0
             miller.B0 = None
-            miller.Bunit = None
 
     def load_local_species(self, pyro, gs2):
         """

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -28,8 +28,8 @@ class Miller(LocalGeometry):
         Torodial field function
     B0 : Float
         Toroidal field at major radius (f_psi / Rmajor) [T]
-    Bunit : Float
-        GACODE normalising field = :math:`q/r \partial \psi/\partial r` [T]
+    bunit_over_b0 : Float
+        Ratio of GACODE normalising field = :math:`q/r \partial \psi/\partial r` [T] to B0
     kappa : Float
         Elongation
     delta : Float
@@ -193,7 +193,7 @@ class Miller(LocalGeometry):
         self.tri = np.arcsin(self.delta)
 
         # Bunit for GACODE codes
-        self.Bunit = self.get_bunit_over_b0() * self.B0
+        self.bunit_over_b0 = self.get_bunit_over_b0()
 
     def minimise_b_poloidal(self, params):
         """
@@ -373,9 +373,9 @@ class Miller(LocalGeometry):
 
         integral = np.sum(dL / (R * grad_r))
 
-        Bunit = integral * R0 / (2 * pi * rmin)
+        bunit_over_b0 = integral * R0 / (2 * pi * rmin)
 
-        return Bunit
+        return bunit_over_b0
 
     def default(self):
         """


### PR DESCRIPTION
Currently there are two fields being stored in the Miller object `B0` and `Bunit`. They are both used when defining `beta` in CGYRO but if I do a scan in `B0`, that won't change `Bunit` which will also mess up the setting of the equilibrium pressure gradient `BETA_STAR_SCALE` in CGYRO.

This defines everything in terms of `B0` and stores the ratio of `Bunit/B0`, from which everything is calculated. This allows for more consistent scan in `B0` (`beta`) without having to change two things at once