### PR TITLE
Fix flake8 warnings and add linting to CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Apply black
+dfa5cac7268ada9249d96262dd3bbd8a04866f3e
+
+# Apply dos2unix
+0fd71813361824a01fbf2f22c8267777650bfef5

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,9 @@
 name: black
 
-on: push
+on:
+  push:
+    paths:
+      - '*.py'
 
 defaults:
   run:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pwd
         ls
-        $HOME/.local/bin/black ford setup.py
+        $HOME/.local/bin/black pyrokinetics setup.py
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "[skip ci] Apply black changes"

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,24 @@
+name: Flake8
+
+on:
+  push:
+    paths:
+      - '*.py'
+
+jobs:
+  flake8_py3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - uses: actions/checkout@v2
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'flake8_py3'   # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyrokinetics/__init__.py
+++ b/pyrokinetics/__init__.py
@@ -27,3 +27,5 @@ __version__ = "0.0.0"
 
 from .pyro import Pyro
 from .pyroscan import PyroScan
+
+__all__ = ["Pyro", "PyroScan"]

--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy as np
 
-from .constants import *
+from .constants import electron_charge, pi
 from .local_species import LocalSpecies
 from .numerics import Numerics
 from .gk_code import GKCode

--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -162,7 +162,6 @@ class Equilibrium:
         psi_n=None,
     ):
 
-        from numpy import meshgrid, array
         import matplotlib as mpl
 
         mpl.use("Agg")

--- a/pyrokinetics/examples/example_JETTO.py
+++ b/pyrokinetics/examples/example_JETTO.py
@@ -1,6 +1,5 @@
 from pyrokinetics import Pyro
 import os
-import numpy as np
 
 # Point to input files
 templates = os.path.join("..", "pyrokinetics", "pyrokinetics", "templates")

--- a/pyrokinetics/examples/example_TRANSP.py
+++ b/pyrokinetics/examples/example_TRANSP.py
@@ -1,6 +1,5 @@
 from pyrokinetics import Pyro
 import os
-import numpy as np
 
 templates = os.path.join("..", "pyrokinetics", "pyrokinetics", "templates")
 

--- a/pyrokinetics/examples/example_addflags.py
+++ b/pyrokinetics/examples/example_addflags.py
@@ -1,6 +1,5 @@
 from pyrokinetics import Pyro
 import os
-import numpy as np
 
 # Point to input files
 home = os.environ["HOME"]

--- a/pyrokinetics/examples/example_gene.py
+++ b/pyrokinetics/examples/example_gene.py
@@ -1,7 +1,5 @@
 import pyrokinetics
 import os
-import sys
-
 
 templates = os.path.join("..", "pyrokinetics", "pyrokinetics", "templates")
 

--- a/pyrokinetics/examples/example_geqdsk.py
+++ b/pyrokinetics/examples/example_geqdsk.py
@@ -1,6 +1,5 @@
 from pyrokinetics import Pyro
 import os
-import numpy as np
 
 home = os.environ["HOME"]
 base = home + "/pyrokinetics/pyrokinetics/templates/"

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -616,7 +616,7 @@ class GENE(GKCode):
                         raw_field, (nx, gk_output.nky, nz), "F"
                     )
 
-                    dummy = struct.unpack("i", file.read(int_size))
+                    dummy = struct.unpack("i", file.read(int_size))  # noqa
 
             if pyro.numerics.nonlinear:
                 fields = np.reshape(
@@ -692,7 +692,7 @@ class GENE(GKCode):
 
             for i_time in range(gk_output.ntime):
 
-                time = next(nrg_data)
+                time = next(nrg_data)  # noqa
 
                 for i_species in range(gk_output.nspecies):
                     nrg_line = np.array(next(nrg_data), dtype=np.float)

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -3,7 +3,7 @@ import copy
 
 import numpy as np
 
-from .constants import *
+from .constants import deuterium_mass, electron_charge, electron_mass, pi
 from .local_species import LocalSpecies
 from .numerics import Numerics
 from .gk_code import GKCode

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -118,7 +118,6 @@ class GENE(GKCode):
             # Reference B field
             bref = miller.B0
 
-            shat = miller.shat
             # Assign Miller values to input file
             pyro_gene_miller = self.pyro_to_code_miller()
 
@@ -277,8 +276,6 @@ class GENE(GKCode):
 
         ion_count = 0
 
-        nu_ei = gene["general"]["coll"]
-
         # Load each species into a dictionary
         for i_sp in range(nspec):
 
@@ -287,8 +284,6 @@ class GENE(GKCode):
             gene_key = "species"
 
             gene_data = gene[gene_key][i_sp]
-
-            gene_type = gene_data["name"]
 
             for pyro_key, gene_key in pyro_gene_species.items():
                 species_data[pyro_key] = gene_data[gene_key]

--- a/pyrokinetics/gene.py
+++ b/pyrokinetics/gene.py
@@ -458,7 +458,6 @@ class GENE(GKCode):
         import xarray as xr
 
         gk_output = pyro.gk_output
-        numerics = pyro.numerics
 
         parameters_file = os.path.join(
             f"{pyro.run_directory}", f"parameters_{pyro.gene_output_number}"

--- a/pyrokinetics/gk_code.py
+++ b/pyrokinetics/gk_code.py
@@ -1,5 +1,6 @@
 from .decorators import not_implemented
-from .constants import *
+from .constants import pi
+import numpy as np
 
 
 class GKCode:
@@ -107,7 +108,6 @@ class GKCode:
         pyro.gk_output.data['growth_rate'] = growth_rate(ky, time)
 
         """
-        import numpy as np
 
         gk_output = pyro.gk_output
         data = gk_output.data

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -326,8 +326,6 @@ class GS2(GKCode):
 
             gs2_data = gs2[gs2_key]
 
-            gs2_type = gs2_data["type"]
-
             for pyro_key, gs2_key in pyro_gs2_species.items():
                 species_data[pyro_key] = gs2_data[gs2_key]
 

--- a/pyrokinetics/gs2.py
+++ b/pyrokinetics/gs2.py
@@ -3,7 +3,7 @@ import copy
 
 import numpy as np
 
-from .constants import *
+from .constants import electron_charge, pi, sqrt2
 from .local_species import LocalSpecies
 from .numerics import Numerics
 from .gk_code import GKCode

--- a/pyrokinetics/kinetics.py
+++ b/pyrokinetics/kinetics.py
@@ -419,9 +419,7 @@ def get_impurity_mass(Z=None):
     Zlist = [2, 6, 8, 10, 18, 54, 74]
     Mlist = [4, 12, 16, 20, 40, 132, 184]
 
-    M = Mlist[Zlist.index(Z)]
-
-    return M
+    return Mlist[Zlist.index(Z)]
 
 
 def get_impurity_charge(M=None):
@@ -430,4 +428,4 @@ def get_impurity_charge(M=None):
     Zlist = [2, 6, 8, 10, 18, 54, 74]
     Mlist = [4, 12, 16, 20, 40, 132, 184]
 
-    Z = Zlist[Mlist.index(M)]
+    return Zlist[Mlist.index(M)]

--- a/pyrokinetics/kinetics.py
+++ b/pyrokinetics/kinetics.py
@@ -1,5 +1,5 @@
 from scipy.interpolate import InterpolatedUnivariateSpline
-from .constants import *
+from .constants import electron_mass, deuterium_mass, hydrogen_mass
 import netCDF4 as nc
 from .species import Species
 from cleverdict import CleverDict

--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -1,5 +1,5 @@
 from cleverdict import CleverDict
-from .constants import *
+from .constants import electron_charge, eps0, pi
 import numpy as np
 
 

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -1,5 +1,5 @@
 from scipy.optimize import least_squares
-from .constants import *
+from .constants import pi
 import numpy as np
 from .local_geometry import LocalGeometry
 

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -5,7 +5,7 @@ from .local_geometry import LocalGeometry
 
 
 class Miller(LocalGeometry):
-    """
+    r"""
     Miller Object representing local Miller fit parameters
 
     Data stored in a CleverDict Object
@@ -64,7 +64,7 @@ class Miller(LocalGeometry):
             self.default()
 
     def load_from_eq(self, eq, psi_n=None, verbose=False):
-        """
+        r"""
         Loads Miller object from a GlobalEquilibrium Object
 
         Flux surface contours are fitted from 2D psi grid
@@ -310,7 +310,7 @@ class Miller(LocalGeometry):
         return R, Z
 
     def test_safety_factor(self):
-        """
+        r"""
         Calculate safety fractor from Miller Object b poloidal field
         :math:`q = \\frac{1}{2\pi} \\oint \\frac{f dl}{R^2 B_{\\theta}}`
 

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -1,4 +1,3 @@
-import numpy as np
 from cleverdict import CleverDict
 
 

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -1,9 +1,4 @@
-import numpy as np
 from path import Path
-from . import numerics
-from . import gs2
-from . import cgyro
-from . import gene
 from .gk_code import GKCode
 from .local_geometry import LocalGeometry
 from .equilibrium import Equilibrium
@@ -118,8 +113,6 @@ class Pyro:
             self.local_geometry_type = value
 
             if self.local_geometry_type == "Miller":
-                from .miller import Miller
-
                 self._local_geometry = Miller()
 
             elif value is None:

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -1,5 +1,4 @@
 import numpy as np
-from .constants import *
 from .pyro import Pyro
 import os
 from itertools import product

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 160
+extend-ignore = E203, W503


### PR DESCRIPTION
- Fix lots of flake8 warnings, mostly about `from foo import *`
- Add Github Action to run flake8 automatically
- Add flake8 config to allow longer lines (160)
- Add file to ignore certain commits when running `git blame` (locally, not sure it works on github yet)
  - Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to do this automatically
  - Useful to ignore the changes from applying `black` to everything!

@bpatel2107 You probably want to have a look at 8db3f6e in particular

