### PR TITLE
Made generator for outer product a class method

### DIFF
--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -378,8 +378,10 @@ class PyroScan:
         """
         Creates generator of outer product for all parameter permutations
         """
-        return (dict(zip(self.parameter_dict, x))
-            for x in product(*self.parameter_dict.values()))
+        return (
+            dict(zip(self.parameter_dict, x))
+            for x in product(*self.parameter_dict.values())
+        )
 
 
 def get_from_dict(data_dict, map_list):

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -100,16 +100,10 @@ class PyroScan:
         # Get len of values for each parameter
         self.value_size = [len(value) for value in self.parameter_dict.values()]
 
-        # Outer product of input dictionaries - could get very large
-        self.outer_product = (
-            dict(zip(self.parameter_dict, x))
-            for x in product(*self.parameter_dict.values())
-        )
-
         pyro_dict = {}
 
         # Iterate through all runs and create dictionary
-        for run in self.outer_product:
+        for run in self.outer_product():
             single_run_name = ""
             # Param value for each run written accordingly
             for param, value in run.items():
@@ -158,7 +152,7 @@ class PyroScan:
 
         # Iterate through all runs and write output
         for parameter, run_dir, pyro in zip(
-            self.outer_product, self.run_directories, self.pyro_dict.values()
+            self.outer_product(), self.run_directories, self.pyro_dict.values()
         ):
             # Param value for each run written accordingly
             for param, value in parameter.items():
@@ -379,6 +373,13 @@ class PyroScan:
 
         self.pyroscan_json["file_name"] = value
         self._file_name = value
+
+    def outer_product(self):
+        """
+        Creates generator of outer product for all parameter permutations
+        """
+        return (dict(zip(self.parameter_dict, x))
+            for x in product(*self.parameter_dict.values()))
 
 
 def get_from_dict(data_dict, map_list):


### PR DESCRIPTION
Previously the outer product of all the parameters was saved as a generator but once you loop through a generator there's no way to reset it. It gets loop through once to create all the run directory names and then a a second time to create and write to the directories. On the second loop nothing was actually happening

Options are to 
1) Save the full generator as a list (could lead to large memory requirements)
2) Have the generator used a method that gets called (If generator takes a long time to make then could result in long process times)

Basically this problem - https://newbedev.com/resetting-generator-object-in-python
At the moment I've implemented option 2. Option 1 was originally implemented but was swapped out for this in f17d405c9d7a6c79a72a141b341c3c50847116b7