### PR TITLE
Data in each Pyro in PyroScan now a deepcopy

### DIFF
--- a/pyrokinetics/gk_output.py
+++ b/pyrokinetics/gk_output.py
@@ -70,3 +70,19 @@ class GKOutput(CleverDict):
         reads in fields
         """
         pass
+
+    def __deepcopy__(self, memodict):
+        """
+        Allows for deepcopy of a GKOutput object
+
+        Returns
+        -------
+        Copy of GKOutput object
+        """
+
+        new_gkoutput = GKOutput()
+
+        for key, value in self.items():
+            setattr(new_gkoutput, key, value)
+
+        return new_gkoutput

--- a/pyrokinetics/kinetics.py
+++ b/pyrokinetics/kinetics.py
@@ -39,6 +39,8 @@ class Kinetics:
             self.read_jetto()
         elif self.kinetics_type == "TRANSP":
             self.read_transp()
+        elif self.kinetics_type == None:
+            pass
         else:
             raise ValueError(
                 f"{self.kinetics_type} as a source of Kinetic profiles not currently supported"
@@ -318,6 +320,28 @@ class Kinetics:
 
         self.nspec = len(self.species_data)
         self.species_names = [*self.species_data.keys()]
+
+    def __deepcopy__(self, memodict):
+        """
+        Allows for deepcopy of a Kinetics object
+
+        Returns
+        -------
+        Copy of kinetics object
+        """
+
+        new_kinetics = Kinetics()
+
+        for key, value in self.__dict__.items():
+            if key == "species_data":
+                pass
+            else:
+                setattr(new_kinetics, key, value)
+
+        # Manually add each species
+        for name, species in self.species_data.items():
+            new_kinetics.species_data["name"] = species
+        return new_kinetics
 
 
 def get_impurity_mass(Z=None):

--- a/pyrokinetics/local_geometry.py
+++ b/pyrokinetics/local_geometry.py
@@ -39,7 +39,7 @@ class LocalGeometry(CleverDict):
 
         pass
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict):
         """
         Allows for deepcopy of a LocalGeometry object
 

--- a/pyrokinetics/local_geometry.py
+++ b/pyrokinetics/local_geometry.py
@@ -38,3 +38,19 @@ class LocalGeometry(CleverDict):
         """
 
         pass
+
+    def __deepcopy__(self, memodict={}):
+        """
+        Allows for deepcopy of a LocalGeometry object
+
+        Returns
+        -------
+        Copy of LocalGeometry object
+        """
+
+        new_localgeometry = LocalGeometry()
+
+        for key, value in self.items():
+            setattr(new_localgeometry, key, value)
+
+        return new_localgeometry

--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -233,10 +233,22 @@ class LocalSpecies(CleverDict):
 
         # Add in each species
         for name in self["names"]:
-            dict_keys = {"name": "name", "mass": "mass", "z": "z", "nu": "nu", "vel": "vel",
-                         "a_lv": "a_lv", "_dens": "dens", "_temp":"temp",
-                         "_a_ln": "a_ln", "_a_lt": "a_lt"}
-            species_data = dict((new_key, self[name][old_key]) for (new_key, old_key) in dict_keys.items())
+            dict_keys = {
+                "name": "name",
+                "mass": "mass",
+                "z": "z",
+                "nu": "nu",
+                "vel": "vel",
+                "a_lv": "a_lv",
+                "_dens": "dens",
+                "_temp": "temp",
+                "_a_ln": "a_ln",
+                "_a_lt": "a_lt",
+            }
+            species_data = dict(
+                (new_key, self[name][old_key])
+                for (new_key, old_key) in dict_keys.items()
+            )
 
             new_local_species.add_species(name, species_data)
 

--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -214,7 +214,7 @@ class LocalSpecies(CleverDict):
         self.names.append(name)
         self.update_pressure()
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict):
         """
         Allows for deepcopy of a LocalSpecies object
 

--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -214,6 +214,34 @@ class LocalSpecies(CleverDict):
         self.names.append(name)
         self.update_pressure()
 
+    def __deepcopy__(self, memodict={}):
+        """
+        Allows for deepcopy of a LocalSpecies object
+
+        Returns
+        -------
+        Copy of local_species object
+        """
+
+        new_local_species = LocalSpecies()
+
+        for key, value in self.items():
+            if key == "names" or isinstance(value, self.SingleLocalSpecies):
+                pass
+            else:
+                setattr(new_local_species, key, value)
+
+        # Add in each species
+        for name in self["names"]:
+            dict_keys = {"name": "name", "mass": "mass", "z": "z", "nu": "nu", "vel": "vel",
+                         "a_lv": "a_lv", "_dens": "dens", "_temp":"temp",
+                         "_a_ln": "a_ln", "_a_lt": "a_lt"}
+            species_data = dict((new_key, self[name][old_key]) for (new_key, old_key) in dict_keys.items())
+
+            new_local_species.add_species(name, species_data)
+
+        return new_local_species
+
     class SingleLocalSpecies:
         """
         Dictionary of local species parameters for one species

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -41,7 +41,7 @@ class Numerics(CleverDict):
 
         super(Numerics, self).__init__(_data_dict)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict):
         """
         Allows for deepcopy of a Numerics object
 

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -52,7 +52,7 @@ class Numerics(CleverDict):
 
         new_numerics = Numerics()
 
-        for key, value in self.__dict__.items():
+        for key, value in self.items():
             setattr(new_numerics, key, value)
 
         return new_numerics

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -40,3 +40,19 @@ class Numerics(CleverDict):
         }
 
         super(Numerics, self).__init__(_data_dict)
+
+    def __deepcopy__(self, memodict={}):
+        """
+        Allows for deepcopy of a Numerics object
+
+        Returns
+        -------
+        Copy of Numerics object
+        """
+
+        new_numerics = Numerics()
+
+        for key, value in self.__dict__.items():
+            setattr(new_numerics, key, value)
+
+        return new_numerics

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -321,7 +321,7 @@ class Pyro:
         new_pyro = Pyro()
 
         for key, value in self.__dict__.items():
-            if key in ["numerics", "local_species", "_local_geometry"]:
+            if key in ["numerics", "local_species", "_local_geometry", f"{self.gk_type.lower()}_input"]:
                 setattr(new_pyro, key, deepcopy(value))
             else:
                 setattr(new_pyro, key, value)

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -321,7 +321,12 @@ class Pyro:
         new_pyro = Pyro()
 
         for key, value in self.__dict__.items():
-            if key in ["numerics", "local_species", "_local_geometry", f"{self.gk_type.lower()}_input"]:
+            if key in [
+                "numerics",
+                "local_species",
+                "_local_geometry",
+                f"{self.gk_type.lower()}_input",
+            ]:
                 setattr(new_pyro, key, deepcopy(value))
             else:
                 setattr(new_pyro, key, value)

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -308,7 +308,7 @@ class Pyro:
 
         self._float_format = value
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict):
         """
         Allows for deepcopy of a Pyro object
 
@@ -321,14 +321,6 @@ class Pyro:
         new_pyro = Pyro()
 
         for key, value in self.__dict__.items():
-            if key in [
-                "numerics",
-                "local_species",
-                "_local_geometry",
-                f"{self.gk_type.lower()}_input",
-            ]:
-                setattr(new_pyro, key, deepcopy(value))
-            else:
-                setattr(new_pyro, key, value)
+            setattr(new_pyro, key, deepcopy(value))
 
         return new_pyro

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -316,10 +316,14 @@ class Pyro:
         -------
         Copy of pyro object
         """
+        from copy import deepcopy
 
         new_pyro = Pyro()
 
         for key, value in self.__dict__.items():
-            setattr(new_pyro, key, value)
+            if key in ["numerics", "local_species", "_local_geometry"]:
+                setattr(new_pyro, key, deepcopy(value))
+            else:
+                setattr(new_pyro, key, value)
 
         return new_pyro

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -402,7 +402,7 @@ def set_in_dict(data_dict, map_list, value):
     """
     Sets item in dict given location as a list of string
     """
-    from copy import deepcopy, copy
+    from copy import deepcopy
 
     get_from_dict(data_dict, map_list[:-1])[map_list[-1]] = deepcopy(value)
 

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -238,6 +238,11 @@ class PyroScan:
         parameter_attr = "local_species"
         parameter_location = ["deuterium", "a_ln"]
         self.add_parameter_key(parameter_key, parameter_attr, parameter_location)
+        # Elongation
+        parameter_key = "kappa"
+        parameter_attr = "local_geometry"
+        parameter_location = ["kappa"]
+        self.add_parameter_key(parameter_key, parameter_attr, parameter_location)
 
     def load_gk_output(self):
         """

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -282,7 +282,7 @@ class PyroScan:
                     fluxes.append(
                         pyro.gk_output.data["fluxes"]
                         .isel(time=-1)
-                    .sum(dim="ky")
+                        .sum(dim="ky")
                         .drop_vars(["time"])
                     )
 

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -290,7 +290,7 @@ class PyroScan:
                     growth_rate_tolerance.append(
                         pyro.gk_output.data["growth_rate_tolerance"]
                     )
-                except (FileNotFoundError, OSError) as e:
+                except (FileNotFoundError, OSError):
                     growth_rate.append(np.nan)
                     mode_frequency.append(np.nan)
                     growth_rate_tolerance.append(np.nan)

--- a/pyrokinetics/tests/test_deepcopy.py
+++ b/pyrokinetics/tests/test_deepcopy.py
@@ -1,0 +1,85 @@
+from pyrokinetics import Pyro, PyroScan
+from pyrokinetics.examples import example_SCENE
+import numpy as np
+from copy import deepcopy
+import operator
+from functools import reduce
+
+def get_from_dict(data_dict, map_list):
+    """
+    Gets item in dict given location as a list of string
+    """
+    return reduce(operator.getitem, map_list, data_dict)
+
+def pyro_scan_check(pyro, param_dict, tmp_path):
+    pyro_scan = PyroScan(pyro, param_dict, base_directory=tmp_path)
+    pyro_scan.write()
+    param = list(param_dict.keys())[0]
+
+    (attr_name, keys_to_param) = pyro_scan.parameter_map[param]
+
+    # Get attribute in Pyro storing the parameter
+    pyro_attr = getattr(pyro, attr_name)
+
+    original_value = get_from_dict(pyro_attr, keys_to_param)
+
+    for pyro_run in pyro_scan.pyro_dict.values():
+        scan_attr = getattr(pyro_run, attr_name)
+        scan_value = get_from_dict(scan_attr, keys_to_param)
+        assert id(scan_value) != id(original_value)
+
+
+def test_deepcopy_pyro(tmp_path):
+    pyro = example_SCENE.main(tmp_path)
+
+    copy_pyro = deepcopy(pyro)
+
+    for name, old_component, new_component in zip(pyro.__dict__.keys(),
+                                                  pyro.__dict__.values(),
+                                                  copy_pyro.__dict__.values()):
+
+        if name not in [
+                "eq",
+                "kinetics",
+                "gk_output"
+        ]:
+            if not isinstance(old_component, (str, type(None), bool)):
+                assert id(old_component) != id(new_component)
+
+def test_deepcopy_pyroscan_numerics(tmp_path):
+    pyro = example_SCENE.main(tmp_path)
+
+    # Test value in Numerics
+    param = "ky"
+    values = np.arange(0.1, 0.3, 0.1)
+
+    # Dictionary of param and values
+    param_dict = {param: values}
+
+    pyro_scan_check(pyro, param_dict, tmp_path)
+
+def test_deepcopy_pyroscan_local_geometry(tmp_path):
+    pyro = example_SCENE.main(tmp_path)
+
+    # Test value in Numerics
+    param = "kappa"
+    values = np.arange(0.1, 0.3, 0.1)
+
+    # Dictionary of param and values
+    param_dict = {param: values}
+
+    pyro_scan_check(pyro, param_dict, tmp_path)
+
+
+def test_deepcopy_pyroscan_local_species(tmp_path):
+    pyro = example_SCENE.main(tmp_path)
+
+    # Test value in Numerics
+    param = "electron_temp_gradient"
+    values = np.arange(0.1, 0.3, 0.1)
+
+    # Dictionary of param and values
+    param_dict = {param: values}
+
+    pyro_scan_check(pyro, param_dict, tmp_path)
+

--- a/pyrokinetics/tests/test_deepcopy.py
+++ b/pyrokinetics/tests/test_deepcopy.py
@@ -5,11 +5,13 @@ from copy import deepcopy
 import operator
 from functools import reduce
 
+
 def get_from_dict(data_dict, map_list):
     """
     Gets item in dict given location as a list of string
     """
     return reduce(operator.getitem, map_list, data_dict)
+
 
 def pyro_scan_check(pyro, param_dict, tmp_path):
     pyro_scan = PyroScan(pyro, param_dict, base_directory=tmp_path)
@@ -34,17 +36,14 @@ def test_deepcopy_pyro(tmp_path):
 
     copy_pyro = deepcopy(pyro)
 
-    for name, old_component, new_component in zip(pyro.__dict__.keys(),
-                                                  pyro.__dict__.values(),
-                                                  copy_pyro.__dict__.values()):
+    for name, old_component, new_component in zip(
+        pyro.__dict__.keys(), pyro.__dict__.values(), copy_pyro.__dict__.values()
+    ):
 
-        if name not in [
-                "eq",
-                "kinetics",
-                "gk_output"
-        ]:
+        if name not in ["eq", "kinetics", "gk_output"]:
             if not isinstance(old_component, (str, type(None), bool)):
                 assert id(old_component) != id(new_component)
+
 
 def test_deepcopy_pyroscan_numerics(tmp_path):
     pyro = example_SCENE.main(tmp_path)
@@ -57,6 +56,7 @@ def test_deepcopy_pyroscan_numerics(tmp_path):
     param_dict = {param: values}
 
     pyro_scan_check(pyro, param_dict, tmp_path)
+
 
 def test_deepcopy_pyroscan_local_geometry(tmp_path):
     pyro = example_SCENE.main(tmp_path)
@@ -82,4 +82,3 @@ def test_deepcopy_pyroscan_local_species(tmp_path):
     param_dict = {param: values}
 
     pyro_scan_check(pyro, param_dict, tmp_path)
-


### PR DESCRIPTION
Before all the data in each pyro object in pyroscan was actually pointing to the same value so now Numerics, LocalSpecies and LocalGeometry now have `__deepcopy__` ensuring when data is set, it is set independently