### PR TITLE
Switched CGYRO frequency sign to match pyrokinetics convention

### DIFF
--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -702,7 +702,7 @@ class CGYRO(GKCode):
                     )
 
                     complex_field = (
-                        field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
+                        field_data[0, :, :, :, :] - 1j * field_data[1, :, :, :, :]
                     )
 
                     fields[ifield, :, :, :, :] = np.swapaxes(
@@ -763,14 +763,14 @@ class CGYRO(GKCode):
                         )
 
                         complex_field = (
-                            field_data[0, :, :, :, :] + 1j * field_data[1, :, :, :, :]
+                            field_data[0, :, :, :, :] - 1j * field_data[1, :, :, :, :]
                         )
 
                         # Poisson Sum
                         for i_radial in range(nradial):
                             nx = -nradial // 2 + (i_radial - 1)
                             complex_field[i_radial, :, :, :] *= np.exp(
-                                -2 * pi * 1j * nx * pyro.local_geometry.q
+                                2 * pi * 1j * nx * pyro.local_geometry.q
                             )
 
                         fields[ifield, :, :, :, :] = np.reshape(

--- a/pyrokinetics/cgyro.py
+++ b/pyrokinetics/cgyro.py
@@ -701,6 +701,7 @@ class CGYRO(GKCode):
                         / gk_output.rho_star
                     )
 
+                    # Using -1j here to match pyrokinetics frequency convention (-ve is electron direction)
                     complex_field = (
                         field_data[0, :, :, :, :] - 1j * field_data[1, :, :, :, :]
                     )
@@ -762,11 +763,12 @@ class CGYRO(GKCode):
                             / gk_output.rho_star
                         )
 
+                        # Using -1j here to match pyrokinetics frequency convention (-ve is electron direction)
                         complex_field = (
                             field_data[0, :, :, :, :] - 1j * field_data[1, :, :, :, :]
                         )
 
-                        # Poisson Sum
+                        # Poisson Sum (no negative in exponent to match frequency convention)
                         for i_radial in range(nradial):
                             nx = -nradial // 2 + (i_radial - 1)
                             complex_field[i_radial, :, :, :] *= np.exp(


### PR DESCRIPTION
CGYRO uses positive to denote the electron diagmagnetic direction whereas pyrokinetics (along with GS2 and GENE) use negative to denote electron direction. Bugfix switches CGYRO to this convention.