### PR TITLE
Do line integral of path in psi contour fit to find closed loop for s…

### DIFF
--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -161,6 +161,9 @@ class Equilibrium:
         import matplotlib as mpl
         import matplotlib.pyplot as plt
 
+        if psi_n > 1.0 or psi_n < 0.0:
+            raise ValueError("You must have 0.0 <= psi_n <= 1.0")
+
         # Generate 2D mesh of normalised psi
         psi_2d = np.transpose(self.psi_RZ(self.R, self.Z))
 

--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -107,8 +107,8 @@ class Equilibrium:
         self.psi_axis = gdata["simagx"]
         self.psi_bdry = gdata["sibdry"]
 
-        self.R_axis = gdata['rmagx']
-        self.Z_axis = gdata['zmagx']
+        self.R_axis = gdata["rmagx"]
+        self.Z_axis = gdata["zmagx"]
 
         psi_n = linspace(0.0, psi_n_lcfs, self.nr)
 
@@ -188,8 +188,17 @@ class Equilibrium:
             )
 
         # Find smallest path integral to find closed loop
-        closest_path = np.argmin([np.mean(np.sqrt((path.vertices[:, 0] - self.R_axis) ** 2 +
-                                                 (path.vertices[:, 1] - self.Z_axis) ** 2)) for path in paths])
+        closest_path = np.argmin(
+            [
+                np.mean(
+                    np.sqrt(
+                        (path.vertices[:, 0] - self.R_axis) ** 2
+                        + (path.vertices[:, 1] - self.Z_axis) ** 2
+                    )
+                )
+                for path in paths
+            ]
+        )
 
         path = paths[closest_path]
 

--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -186,7 +186,7 @@ class Equilibrium:
         for path in paths:
             x = path.vertices[:, 0]
             y = path.vertices[:, 1]
-            l = np.sqrt(x**2 + y**2)
+            l = np.sqrt(x ** 2 + y ** 2)
             dl = np.diff(l)
             integral = np.abs(np.sum(l[:-1] * dl))
             loop_integrals.append(integral)

--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -107,6 +107,9 @@ class Equilibrium:
         self.psi_axis = gdata["simagx"]
         self.psi_bdry = gdata["sibdry"]
 
+        self.R_axis = gdata['rmagx']
+        self.Z_axis = gdata['zmagx']
+
         psi_n = linspace(0.0, psi_n_lcfs, self.nr)
 
         # Set up 1D profiles as interpolated functions
@@ -185,17 +188,10 @@ class Equilibrium:
             )
 
         # Find smallest path integral to find closed loop
-        loop_integrals = []
-        for path in paths:
-            x = path.vertices[:, 0]
-            y = path.vertices[:, 1]
-            line = np.sqrt(x ** 2 + y ** 2)
-            dl = np.diff(line)
-            integral = np.abs(np.sum(line[:-1] * dl))
-            loop_integrals.append(integral)
+        closest_path = np.argmin([np.mean(np.sqrt((path.vertices[:, 0] - self.R_axis) ** 2 +
+                                                 (path.vertices[:, 1] - self.Z_axis) ** 2)) for path in paths])
 
-        closed_path = np.argmin(loop_integrals)
-        path = paths[closed_path]
+        path = paths[closest_path]
 
         R_con, Z_con = path.vertices[:, 0], path.vertices[:, 1]
 

--- a/pyrokinetics/equilibrium.py
+++ b/pyrokinetics/equilibrium.py
@@ -186,9 +186,9 @@ class Equilibrium:
         for path in paths:
             x = path.vertices[:, 0]
             y = path.vertices[:, 1]
-            l = np.sqrt(x ** 2 + y ** 2)
-            dl = np.diff(l)
-            integral = np.abs(np.sum(l[:-1] * dl))
+            line = np.sqrt(x ** 2 + y ** 2)
+            dl = np.diff(line)
+            integral = np.abs(np.sum(line[:-1] * dl))
             loop_integrals.append(integral)
 
         closed_path = np.argmin(loop_integrals)


### PR DESCRIPTION
…urface.

Reset MPL backend rather than overwriting

For certain files, the wrong contour was being chosen when reading in GEQDSK files like below

The yellow shows the lines of constant psi in the GEQDSK file and the dash line shows the contour it chose for the surface. Clearly it has chosen the wrong contour.

 
![image](https://user-images.githubusercontent.com/15210802/150533870-a0ee0897-9db5-4bf1-86f2-6d70b7f495a9.png)

I’ve added a fix that does a line integral along the contours and looks for the smallest absolute value (which a closed loop should be). Doing so finds the right contour
 
![image](https://user-images.githubusercontent.com/15210802/150533883-e253f4a4-e410-4238-87f0-11ec98a7e3db.png)


Also ensured matplotlib backend doesn't get changed during contour fitting

