### PR TITLE
Flake8 fixes from #58

### DIFF
--- a/pyrokinetics/kinetics/Kinetics.py
+++ b/pyrokinetics/kinetics/Kinetics.py
@@ -1,8 +1,7 @@
 from pathlib import Path
-from typing import Union, Dict, Optional
+from typing import Union, Optional
 from cleverdict import CleverDict
 
-from ..species import Species
 from .KineticsReader import kinetics_readers
 
 
@@ -63,13 +62,13 @@ class Kinetics:
 
     @property
     def kinetics_type(self):
-        return _kinetics_type
+        return self._kinetics_type
 
     @kinetics_type.setter
     def kinetics_type(self, value):
         if value not in self.supported_kinetics_types:
             raise ValueError(f"Kinetics type {value} is not currently supported.")
-        _kinetics_type = value
+        self._kinetics_type = value
 
     @property
     def nspec(self):

--- a/pyrokinetics/kinetics/KineticsReaderTRANSP.py
+++ b/pyrokinetics/kinetics/KineticsReaderTRANSP.py
@@ -146,7 +146,7 @@ class KineticsReaderTRANSP(KineticsReader):
             ) from e
         # Given it is a netcdf, check it has the attribute TRANSP_version
         try:
-            version = data.TRANSP_version
+            data.TRANSP_version
         except AttributeError:
             # Failing this, check for expected data_vars
             var_names = ["TIME3", "PLFLX", "RMNMP", "TE", "TI", "NE"]

--- a/pyrokinetics/kinetics/__init__.py
+++ b/pyrokinetics/kinetics/__init__.py
@@ -1,8 +1,5 @@
-# Import main Kinetics class
-from .Kinetics import Kinetics
-
 # Import KineticsReaders
-from .KineticsReader import kinetics_readers
+from .KineticsReader import KineticsReader, kinetics_readers
 from .KineticsReaderSCENE import KineticsReaderSCENE
 from .KineticsReaderJETTO import KineticsReaderJETTO
 from .KineticsReaderTRANSP import KineticsReaderTRANSP
@@ -12,4 +9,7 @@ kinetics_readers["SCENE"] = KineticsReaderSCENE
 kinetics_readers["JETTO"] = KineticsReaderJETTO
 kinetics_readers["TRANSP"] = KineticsReaderTRANSP
 
-__all__ = ["Kinetics"]
+# Import main Kinetics class
+from .Kinetics import Kinetics
+
+__all__ = ["Kinetics", "KineticsReader"]

--- a/pyrokinetics/kinetics/__init__.py
+++ b/pyrokinetics/kinetics/__init__.py
@@ -10,6 +10,6 @@ kinetics_readers["JETTO"] = KineticsReaderJETTO
 kinetics_readers["TRANSP"] = KineticsReaderTRANSP
 
 # Import main Kinetics class
-from .Kinetics import Kinetics
+from .Kinetics import Kinetics  # noqa: E402
 
 __all__ = ["Kinetics", "KineticsReader"]

--- a/pyrokinetics/kinetics/__init__.py
+++ b/pyrokinetics/kinetics/__init__.py
@@ -1,5 +1,8 @@
+# Import main Kinetics class
+from .Kinetics import Kinetics
+
 # Import KineticsReaders
-from .KineticsReader import KineticsReader, kinetics_readers
+from .KineticsReader import kinetics_readers
 from .KineticsReaderSCENE import KineticsReaderSCENE
 from .KineticsReaderJETTO import KineticsReaderJETTO
 from .KineticsReaderTRANSP import KineticsReaderTRANSP
@@ -9,5 +12,4 @@ kinetics_readers["SCENE"] = KineticsReaderSCENE
 kinetics_readers["JETTO"] = KineticsReaderJETTO
 kinetics_readers["TRANSP"] = KineticsReaderTRANSP
 
-# Import main Kinetics class
-from .Kinetics import Kinetics
+__all__ = ["Kinetics"]

--- a/pyrokinetics/readers.py
+++ b/pyrokinetics/readers.py
@@ -1,7 +1,7 @@
 """readers.py
 
 Defines utilities for creating the various 'reader' objects used throughout
-Pyrokinetics. 
+Pyrokinetics.
 """
 
 from pathlib import Path

--- a/pyrokinetics/tests/test_reader_factory.py
+++ b/pyrokinetics/tests/test_reader_factory.py
@@ -60,7 +60,7 @@ class TestReaderFactory:
 
     def test_bad_key(self, reader_factory):
         with pytest.raises(KeyError) as excinfo:
-            reader = reader_factory["OtherReader"]
+            reader_factory["OtherReader"]
         assert "OtherReader" in str(excinfo.value)
 
     def test_infer_type(self, reader_factory):


### PR DESCRIPTION
Addresses a few `flake8` issues from #58 

This still currently fails a few `flake8` tests.

```
flake8 --exit-zero
./pyrokinetics/kinetics/__init__.py:2:1: F401 '.KineticsReader.KineticsReader' imported but unused
./pyrokinetics/kinetics/__init__.py:13:1: F401 '.Kinetics.Kinetics' imported but unused
./pyrokinetics/kinetics/__init__.py:13:1: E402 module level import not at top of file
```

 @LiamPattinson is there any reason I can't remove those imports/shuffle them around