### PR TITLE
Bugfix/miller float point error

### DIFF
--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -257,8 +257,14 @@ class Miller(LocalGeometry):
 
         beta_prime = 8 * pi * 1e-7 * dpressure_drho / B0**2
 
-        theta = np.arcsin((Z - Zmid) / (kappa * r_minor))
+        normalised_height  = (Z - Zmid) / (kappa * r_minor)
 
+        # Floating point error can lead to >|1.0|
+        normalised_height = np.where(np.isclose(normalised_height, 1.0), 1.0, normalised_height)
+        normalised_height = np.where(np.isclose(normalised_height, -1.0), -1.0, normalised_height)
+
+        theta = np.arcsin(normalised_height)
+        print(theta)
         for i in range(len(theta)):
             if R[i] < R_upper:
                 if Z[i] >= 0:

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -264,7 +264,7 @@ class Miller(LocalGeometry):
         normalised_height = np.where(np.isclose(normalised_height, -1.0), -1.0, normalised_height)
 
         theta = np.arcsin(normalised_height)
-        print(theta)
+
         for i in range(len(theta)):
             if R[i] < R_upper:
                 if Z[i] >= 0:

--- a/pyrokinetics/miller.py
+++ b/pyrokinetics/miller.py
@@ -257,11 +257,15 @@ class Miller(LocalGeometry):
 
         beta_prime = 8 * pi * 1e-7 * dpressure_drho / B0**2
 
-        normalised_height  = (Z - Zmid) / (kappa * r_minor)
+        normalised_height = (Z - Zmid) / (kappa * r_minor)
 
         # Floating point error can lead to >|1.0|
-        normalised_height = np.where(np.isclose(normalised_height, 1.0), 1.0, normalised_height)
-        normalised_height = np.where(np.isclose(normalised_height, -1.0), -1.0, normalised_height)
+        normalised_height = np.where(
+            np.isclose(normalised_height, 1.0), 1.0, normalised_height
+        )
+        normalised_height = np.where(
+            np.isclose(normalised_height, -1.0), -1.0, normalised_height
+        )
 
         theta = np.arcsin(normalised_height)
         print(theta)


### PR DESCRIPTION
Handle floating point error preventing `arcsin(>1.0)` when setting up `theta` grid in `miller.py`