### PR TITLE
LocalGeometry plugin architecture

### DIFF
--- a/pyrokinetics/factory.py
+++ b/pyrokinetics/factory.py
@@ -1,0 +1,64 @@
+"""
+Defines generic Factory object.
+Factory objects used throughout this project may inherit this class and add additional
+features, such as filetype inference.
+"""
+
+from typing import Type
+from collections import UserDict
+
+
+class Factory(UserDict):
+    """
+    Given a key as a string, returns an object object derived from BaseClass, which
+    is provided to __init__. By default, BaseClass is 'object', meaning the factory
+    can produce any type.
+
+    Factory behaves like a dict. Types may be registered by calling:
+    `my_factory[type_key] = Type`
+    where `type_key` is a string. If types take no arguments to their __init__
+    functions, they may be created using:
+    `my_type = my_factory[type_key]`
+    Alternatively, they may be be created by calling the factory as a function:
+    `my_type = my_factory(type_key, *args, **kwargs)`
+    """
+
+    def __init__(self, BaseClass: Type = object):
+        super().__init__()
+        self.BaseClass = BaseClass
+
+    def get_type(self, key: str):
+        """
+        Returns type, but does not instantiate. Derived classes may override this to
+        change behaviour for both __getitem__ and __call__ functions
+        """
+        try:
+            return self.data[key]
+        except KeyError:
+            raise KeyError(
+                f"{self.__class__.__name__} has not registered the key {key}."
+            )
+
+    def __getitem__(self, key: str):
+        """Gets type, then instantiates with no args passed"""
+        return self.get_type(key)()
+
+    def __call__(self, key: str, *args, **kwargs):
+        """Gets type, then instantiates with args/kwargs"""
+        return self.get_type(key)(*args, **kwargs)
+
+    def __setitem__(self, key: str, value: Type):
+        try:
+            if issubclass(value, self.BaseClass):
+                self.data[key] = value
+            else:
+                raise ValueError(
+                    f"Classes registered to {self.__class__.__name__} must "
+                    f"subclass {self.BaseClass.__name__}"
+                )
+        except TypeError as e:
+            raise TypeError(
+                f"Only classes may be registered to {self.__class__.__name__}"
+            ) from e
+        except ValueError as e:
+            raise TypeError(str(e))

--- a/pyrokinetics/local_geometry/LocalGeometry.py
+++ b/pyrokinetics/local_geometry/LocalGeometry.py
@@ -1,5 +1,6 @@
 from cleverdict import CleverDict
-from .decorators import not_implemented
+from ..decorators import not_implemented
+from ..factory import Factory
 
 
 class LocalGeometry(CleverDict):
@@ -54,3 +55,7 @@ class LocalGeometry(CleverDict):
             setattr(new_localgeometry, key, value)
 
         return new_localgeometry
+
+
+# Create global factory for LocalGeometry objects
+local_geometries = Factory(LocalGeometry)

--- a/pyrokinetics/local_geometry/LocalGeometryMiller.py
+++ b/pyrokinetics/local_geometry/LocalGeometryMiller.py
@@ -1,9 +1,9 @@
 from scipy.optimize import least_squares  # type: ignore
-from .constants import pi
+from ..constants import pi
 import numpy as np
-from .local_geometry import LocalGeometry
-from .equilibrium import Equilibrium
-from .typing import Scalar, ArrayLike
+from .LocalGeometry import LocalGeometry
+from ..equilibrium import Equilibrium
+from ..typing import Scalar, ArrayLike
 from typing import Tuple
 
 
@@ -141,7 +141,7 @@ def b_poloidal(
     return dpsi_dr / R * grad_r(kappa, delta, s_kappa, s_delta, shift, theta)
 
 
-class Miller(LocalGeometry):
+class LocalGeometryMiller(LocalGeometry):
     r"""
     Miller Object representing local Miller fit parameters
 
@@ -194,7 +194,11 @@ class Miller(LocalGeometry):
 
         s_args = list(args)
 
-        if args and not isinstance(args[0], Miller) and isinstance(args[0], dict):
+        if (
+            args
+            and not isinstance(args[0], LocalGeometryMiller)
+            and isinstance(args[0], dict)
+        ):
             s_args[0] = sorted(args[0].items())
 
             super(LocalGeometry, self).__init__(*s_args, **kwargs)
@@ -445,4 +449,4 @@ class Miller(LocalGeometry):
             "local_geometry": "Miller",
         }
 
-        super(Miller, self).__init__(mil)
+        super(LocalGeometryMiller, self).__init__(mil)

--- a/pyrokinetics/local_geometry/__init__.py
+++ b/pyrokinetics/local_geometry/__init__.py
@@ -1,0 +1,7 @@
+from .LocalGeometry import LocalGeometry, local_geometries
+from .LocalGeometryMiller import LocalGeometryMiller
+
+# Register LocalGeometry objects with factory
+local_geometries["Miller"] = LocalGeometryMiller
+
+__all__ = ["LocalGeometry"]

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -1,9 +1,8 @@
 from path import Path
 from .gk_code import GKCode, gk_codes, GKOutput
-from .local_geometry import LocalGeometry
+from .local_geometry import LocalGeometry, local_geometries
 from .equilibrium import Equilibrium
 from .kinetics import Kinetics
-from .miller import Miller
 import warnings
 from typing import Optional
 
@@ -16,7 +15,7 @@ class Pyro:
 
     # Define class level info
     supported_gk_codes = [*gk_codes, None]
-    supported_local_geometries = ["Miller", None]
+    supported_local_geometries = [*local_geometries, None]
 
     def __init__(
         self,
@@ -101,17 +100,12 @@ class Pyro:
         """
         Sets the local geometry type
         """
-
         if value in self.supported_local_geometries:
-
             self.local_geometry_type = value
-
-            if self.local_geometry_type == "Miller":
-                self._local_geometry = Miller()
-
-            elif value is None:
+            if value is None:
                 self._local_geometry = LocalGeometry()
-
+            else:
+                self._local_geometry = local_geometries[value]
         else:
             raise NotImplementedError(f"LocalGeometry {value} not yet supported")
 

--- a/pyrokinetics/tests/local_geometry/test_local_geometry_factory.py
+++ b/pyrokinetics/tests/local_geometry/test_local_geometry_factory.py
@@ -1,0 +1,14 @@
+from pyrokinetics.local_geometry import local_geometries, LocalGeometryMiller
+import pytest
+
+
+def test_miller():
+    """Ensure a miller object is created successfully"""
+    miller = local_geometries["Miller"]
+    assert isinstance(miller, LocalGeometryMiller)
+
+
+def test_non_local_geometry():
+    """Ensure failure when getting a non-existent LocalGeometry"""
+    with pytest.raises(KeyError):
+        local_geometries["Hello world"]

--- a/pyrokinetics/tests/local_geometry/test_miller.py
+++ b/pyrokinetics/tests/local_geometry/test_miller.py
@@ -1,5 +1,10 @@
 from pyrokinetics import template_dir
-from pyrokinetics.miller import Miller, grad_r, flux_surface, b_poloidal
+from pyrokinetics.local_geometry import LocalGeometryMiller
+from pyrokinetics.local_geometry.LocalGeometryMiller import (
+    grad_r,
+    flux_surface,
+    b_poloidal,
+)
 from pyrokinetics.equilibrium import Equilibrium
 
 import numpy as np
@@ -65,7 +70,7 @@ def test_flux_surface_long_triangularity():
 
 
 def test_default_bunit_over_b0():
-    miller = Miller()
+    miller = LocalGeometryMiller()
     print(miller.get_bunit_over_b0())
     assert np.isclose(miller.get_bunit_over_b0(), 1.0481789952353437)
 
@@ -115,7 +120,7 @@ def test_load_from_eq():
     """Golden answer test"""
 
     eq = Equilibrium(template_dir / "test.geqdsk", "GEQDSK")
-    miller = Miller()
+    miller = LocalGeometryMiller()
     miller.load_from_eq(eq, 0.5)
 
     assert miller["local_geometry"] == "Miller"


### PR DESCRIPTION
Similar to pull requests https://github.com/pyro-kinetics/pyrokinetics/pull/58, https://github.com/pyro-kinetics/pyrokinetics/pull/61, and https://github.com/pyro-kinetics/pyrokinetics/pull/65, this implements a plugin architecture for LocalGeometry classes, anticipating the addition of a Fourier type in some future commit. This completes issue https://github.com/pyro-kinetics/pyrokinetics/issues/42.

I generalised the ReaderFactory from previous commits to a generic Factory class, which ReaderFactory now subclasses. It behaves similarly, but now also works in cases where we don't need file type inference.

The Miller class has been renamed LocalGeometryMiller to make it clearer that it belongs to the 'LocalGeometry' family, but I'm happy to revert that change if it seems too verbose.