### PR TITLE
Bugfix/jetto multiple impurities

### DIFF
--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -40,7 +40,7 @@ class KineticsReaderJETTO(KineticsReader):
             electron_temp_data = kinetics_data["TE"][-1, :].data
             electron_temp_func = InterpolatedUnivariateSpline(psi_n, electron_temp_data)
 
-            electron_dens_data = kinetics_data["NE"][-1, :].data
+            electron_dens_data = kinetics_data["NETF"][-1, :].data
             electron_dens_func = InterpolatedUnivariateSpline(psi_n, electron_dens_data)
 
             rotation_data = kinetics_data["VTOR"][-1, :].data
@@ -62,16 +62,6 @@ class KineticsReaderJETTO(KineticsReader):
             ion_temp_data = kinetics_data["TI"][-1, :].data
             ion_temp_func = InterpolatedUnivariateSpline(psi_n, ion_temp_data)
 
-            # Go through each species output in JETTO
-            try:
-                impurity_charge = int(kinetics_data["ZIA1"][-1, 0].data)
-                impurity_mass = (
-                    self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
-                )
-            except IndexError:
-                impurity_charge = 0
-                impurity_mass = 0
-
             possible_species = [
                 {
                     "species_name": "deuterium",
@@ -91,13 +81,27 @@ class KineticsReaderJETTO(KineticsReader):
                     "charge": 2,
                     "mass": 4 * hydrogen_mass,
                 },
-                {
-                    "species_name": "impurity",
-                    "jetto_name": "NIMP",
-                    "charge": impurity_charge,
-                    "mass": impurity_mass,
-                },
             ]
+
+            # Go through each species output in JETTO
+            impurity_keys = [
+                key for key in kinetics_data.variables.keys() if "ZIA" in key
+            ]
+
+            for i_imp, impurity_z in enumerate(impurity_keys):
+                impurity_charge = int(kinetics_data[impurity_z][-1, 0].data)
+                impurity_mass = (
+                    self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
+                )
+
+                possible_species.append(
+                    {
+                        "species_name": f"impurity{i_imp+1}",
+                        "jetto_name": f"NIM{i_imp+1}",
+                        "charge": impurity_charge,
+                        "mass": impurity_mass,
+                    }
+                )
 
             for species in possible_species:
                 density_data = kinetics_data[species["jetto_name"]][-1, :].data

--- a/pyrokinetics/tests/kinetics/test_kinetics.py
+++ b/pyrokinetics/tests/kinetics/test_kinetics.py
@@ -104,15 +104,15 @@ def test_read_jetto(jetto_file, kinetics_type):
     assert jetto.nspec == 5
     assert np.array_equal(
         sorted(jetto.species_names),
-        sorted(["electron", "deuterium", "tritium", "impurity", "helium"]),
+        sorted(["electron", "deuterium", "tritium", "impurity1", "helium"]),
     )
     check_species(
         jetto.species_data["electron"],
         "electron",
         -1,
         electron_mass,
-        midpoint_density=2.078282391282811e20,
-        midpoint_density_gradient=0.7407566857690338,
+        midpoint_density=2.0855866269392273e+20,
+        midpoint_density_gradient=0.7441534371204437,
         midpoint_temperature=7520.436894799198,
         midpoint_temperature_gradient=2.4903881194905755,
         midpoint_velocity=0.0,
@@ -143,8 +143,8 @@ def test_read_jetto(jetto_file, kinetics_type):
         midpoint_velocity_gradient=0.0,
     )
     check_species(
-        jetto.species_data["impurity"],
-        "impurity",
+        jetto.species_data["impurity1"],
+        "impurity1",
         54,
         132 * hydrogen_mass,
         midpoint_density=5.809315337899827e16,

--- a/pyrokinetics/tests/kinetics/test_kinetics.py
+++ b/pyrokinetics/tests/kinetics/test_kinetics.py
@@ -111,7 +111,7 @@ def test_read_jetto(jetto_file, kinetics_type):
         "electron",
         -1,
         electron_mass,
-        midpoint_density=2.0855866269392273e+20,
+        midpoint_density=2.0855866269392273e20,
         midpoint_density_gradient=0.7441534371204437,
         midpoint_temperature=7520.436894799198,
         midpoint_temperature_gradient=2.4903881194905755,


### PR DESCRIPTION
Handles multiple impurities with JETTO output.

Now uses `NETF` for the electron density as this includes the fast alphas which are under `NALF`. This ensure quasineutrality is maintained. Currently the alpha species is treated as a thermalised species but in the future we should examine how to deal with adiabatic/tracer species as well as fast ions.