### PR TITLE
Enable recreating `PyroScan` instances

### DIFF
--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -105,17 +105,7 @@ class PyroScan:
 
         # Iterate through all runs and create dictionary
         for run in self.outer_product():
-            single_run_name = ""
-            # Param value for each run written accordingly
-            for param, value in run.items():
-                single_run_name += (
-                    f"{param}{self.value_separator}{value:{self.value_fmt}}"
-                )
-
-                single_run_name += self.parameter_separator
-
-            # Remove last instance of parameter_separator
-            single_run_name = single_run_name[: -len(self.parameter_separator)]
+            single_run_name = self.format_single_run_name(run)
 
             # Store copy of each pyro in a dictionary and set file_name/directory
             pyro_dict[single_run_name] = copy.deepcopy(self.base_pyro)
@@ -128,6 +118,17 @@ class PyroScan:
         self.pyro_dict = pyro_dict
 
         self.run_directories = [pyro.run_directory for pyro in pyro_dict.values()]
+
+    def format_single_run_name(self, parameters):
+        """
+        Concatenate parameter names/values with separator
+        """
+        return self.parameter_separator.join(
+            (
+                f"{param}{self.value_separator}{value:{self.value_fmt}}"
+                for param, value in parameters.items()
+            )
+        )
 
     def write(self, file_name=None, base_directory=None, template_file=None):
         """

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -98,24 +98,10 @@ class PyroScan:
         # Get len of values for each parameter
         self.value_size = [len(value) for value in self.parameter_dict.values()]
 
-        pyro_dict = {}
-
-        # Iterate through all runs and create dictionary
-        for run in self.outer_product():
-            single_run_name = self.format_single_run_name(run)
-
-            # Store copy of each pyro in a dictionary and set file_name/directory
-            pyro_dict[single_run_name] = copy.deepcopy(self.base_pyro)
-
-            pyro_dict[single_run_name].file_name = self.file_name
-            pyro_dict[single_run_name].run_directory = (
-                self.base_directory / single_run_name
-            )
-            pyro_dict[single_run_name].run_parameters = copy.deepcopy(run)
-
-        self.pyro_dict = pyro_dict
-
-        self.run_directories = [pyro.run_directory for pyro in pyro_dict.values()]
+        self.pyro_dict = dict(
+            self.create_single_run(run) for run in self.outer_product()
+        )
+        self.run_directories = [pyro.run_directory for pyro in self.pyro_dict.values()]
 
     def format_single_run_name(self, parameters):
         """
@@ -127,6 +113,17 @@ class PyroScan:
                 for param, value in parameters.items()
             )
         )
+
+    def create_single_run(self, parameters: dict):
+        """
+        Create a new Pyro instance from the PyroScan base with new run parameters
+        """
+        name = self.format_single_run_name(parameters)
+        new_run = copy.deepcopy(self.base_pyro)
+        new_run.file_name = self.file_name
+        new_run.run_directory = self.base_directory / name
+        new_run.run_parameters = copy.deepcopy(parameters)
+        return name, new_run
 
     def write(self, file_name=None, base_directory=None, template_file=None):
         """

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -19,6 +19,16 @@ class PyroScan:
     { param : [values], }
     """
 
+    JSON_ATTRS = [
+        "value_fmt",
+        "value_separator",
+        "parameter_separator",
+        "parameter_dict",
+        "file_name",
+        "base_directory",
+        "p_prime_type",
+    ]
+
     def __init__(
         self,
         pyro,
@@ -79,24 +89,10 @@ class PyroScan:
             with open(pyroscan_json) as f:
                 self.pyroscan_json = json.load(f)
 
-            self.value_fmt = self.pyroscan_json["value_fmt"]
-            self.value_separator = self.pyroscan_json["value_separator"]
-            self.parameter_separator = self.pyroscan_json["parameter_separator"]
-            self.parameter_dict = self.pyroscan_json["parameter_dict"]
-            self.file_name = self.pyroscan_json["file_name"]
-            self.base_directory = self.pyroscan_json["base_directory"]
-            self.p_prime_type = self.pyroscan_json["p_prime_type"]
-
+            for key, value in self.pyroscan_json.items():
+                setattr(self, key, value)
         else:
-            self.pyroscan_json = {
-                "value_fmt": self.value_fmt,
-                "value_separator": self.value_separator,
-                "parameter_separator": self.parameter_separator,
-                "parameter_dict": self.parameter_dict,
-                "file_name": self.file_name,
-                "base_directory": self.base_directory,
-                "p_prime_type": self.p_prime_type,
-            }
+            self.pyroscan_json = {attr: getattr(self, attr) for attr in self.JSON_ATTRS}
 
         # Get len of values for each parameter
         self.value_size = [len(value) for value in self.parameter_dict.values()]

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -424,4 +424,8 @@ class NumpyEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, pathlib.Path):
             return str(obj)
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
         return json.JSONEncoder.default(self, obj)

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -27,6 +27,7 @@ class PyroScan:
         "file_name",
         "base_directory",
         "p_prime_type",
+        "parameter_map",
     ]
 
     def __init__(
@@ -110,6 +111,7 @@ class PyroScan:
             pyro_dict[single_run_name].run_directory = (
                 self.base_directory / single_run_name
             )
+            pyro_dict[single_run_name].run_parameters = copy.deepcopy(run)
 
         self.pyro_dict = pyro_dict
 
@@ -194,6 +196,7 @@ class PyroScan:
         dict_item = {parameter_key: [parameter_attr, parameter_location]}
 
         self.parameter_map.update(dict_item)
+        self.pyroscan_json["parameter_map"] = self.parameter_map
 
     def load_default_parameter_keys(self):
         """

--- a/pyrokinetics/tests/test_pyroscan.py
+++ b/pyrokinetics/tests/test_pyroscan.py
@@ -1,5 +1,6 @@
 from pyrokinetics.pyroscan import PyroScan
 from pyrokinetics.examples import example_SCENE
+from pyrokinetics import Pyro
 
 from pathlib import Path
 import numpy as np
@@ -42,3 +43,9 @@ def test_compare_read_write_pyroscan(tmp_path):
     ]
     for attrs in comparison_attrs:
         assert_close_or_equal(attrs, initial_pyroscan, new_pyroscan)
+
+
+def test_format_run_name():
+    scan = PyroScan(Pyro(gk_code="GS2"), value_separator="|", parameter_separator="@")
+
+    assert scan.format_single_run_name({"ky": 0.1, "nx": 55}) == "ky|0.10@nx|55.00"

--- a/pyrokinetics/tests/test_pyroscan.py
+++ b/pyrokinetics/tests/test_pyroscan.py
@@ -1,6 +1,7 @@
 from pyrokinetics.pyroscan import PyroScan
 from pyrokinetics.examples import example_SCENE
 
+from pathlib import Path
 import numpy as np
 
 
@@ -8,7 +9,7 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
     left = getattr(left_pyroscan, attr)
     right = getattr(right_pyroscan, attr)
 
-    if isinstance(left, (str, list, type(None), dict)):
+    if isinstance(left, (str, list, type(None), dict, Path)):
         assert left == right
     else:
         assert np.allclose(left, right), f"{left} != {right}"

--- a/pyrokinetics/tests/test_pyroscan.py
+++ b/pyrokinetics/tests/test_pyroscan.py
@@ -49,3 +49,20 @@ def test_format_run_name():
     scan = PyroScan(Pyro(gk_code="GS2"), value_separator="|", parameter_separator="@")
 
     assert scan.format_single_run_name({"ky": 0.1, "nx": 55}) == "ky|0.10@nx|55.00"
+
+
+def test_create_single_run():
+    scan = PyroScan(
+        Pyro(gk_code="GS2"),
+        base_directory="some_dir",
+        value_separator="|",
+        parameter_separator="@",
+    )
+
+    run_parameters = {"ky": 0.1, "nx": 55}
+    name, new_run = scan.create_single_run(run_parameters)
+
+    assert name == scan.format_single_run_name(run_parameters)
+    assert new_run.file_name == "input.in"
+    assert new_run.run_directory == Path(f"./some_dir/{name}").absolute()
+    assert new_run.run_parameters == run_parameters


### PR DESCRIPTION
- Save/restore `parameter_map` dict to/from JSON file
- Pull out a method for formatting the individual run directory names

Saving the `parameter_map` is essential in order to know what parameters the scan was over. Latter method enables iterating over the output files in a scan afterwards.