### PR TITLE
Fix for f90nml v1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 include_package_data = True
 install_requires =
     numpy >= 1.20.3
-    f90nml >= 1.3, != 1.4
+    f90nml >= 1.3, != 1.4.0
     scipy >= 1.6.3
     netCDF4 >= 1.5.6
     path >= 15.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 include_package_data = True
 install_requires =
     numpy >= 1.20.3
-    f90nml >= 1.3
+    f90nml >= 1.3, != 1.4
     scipy >= 1.6.3
     netCDF4 >= 1.5.6
     path >= 15.1.2


### PR DESCRIPTION
f90nml v1.4 changed how it would support repeated keys in Fortran namelists, which are used by GENE to represent multiple species. Rather than collecting them into a list by default, the user is required to explicitly declare them as 'cogroups'. When converting to and from dict, repeated namelist keys are listed as separate entries with keys '_grp_entry_0', '_grp_entry_1', etc. The preferred way to deal with cogroups is to build a `f90nml.Namelist` object first and then explicitly add cogroups, but as GKCode converts to dict after reading, we instead must prepend `'_grp_'` and append a number to the species key. 

v1.4 appears to have bugs, but 1.4.1 and 1.4.2 behave as expected. 1.4 has been excluded in setup.cfg.