### PR TITLE
Feature/nearest z jetto

### DIFF
--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -94,7 +94,11 @@ class KineticsReaderJETTO(KineticsReader):
             ]
 
             for i_imp, impurity_z in enumerate(impurity_keys):
-                impurity_charge = int(kinetics_data[impurity_z][-1, 0].data)
+                try:
+                    impurity_charge = int(kinetics_data[impurity_z][-1, 0].data)
+                except ValueError:
+                    impurity_charge = round(kinetics_data[impurity_z][-1, 0].data)
+
                 impurity_mass = (
                     self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
                 )

--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -100,7 +100,7 @@ class KineticsReaderJETTO(KineticsReader):
                             self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
                     )
 
-                except ValueError:
+                except KeyError:
                     impurity_charge = round(kinetics_data[impurity_z][-1, 0].data)
                     impurity_mass = (
                             self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass

--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -96,12 +96,15 @@ class KineticsReaderJETTO(KineticsReader):
             for i_imp, impurity_z in enumerate(impurity_keys):
                 try:
                     impurity_charge = int(kinetics_data[impurity_z][-1, 0].data)
+                    impurity_mass = (
+                            self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
+                    )
+
                 except ValueError:
                     impurity_charge = round(kinetics_data[impurity_z][-1, 0].data)
-
-                impurity_mass = (
-                    self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
-                )
+                    impurity_mass = (
+                            self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
+                    )
 
                 possible_species.append(
                     {

--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -97,13 +97,13 @@ class KineticsReaderJETTO(KineticsReader):
                 try:
                     impurity_charge = int(kinetics_data[impurity_z][-1, 0].data)
                     impurity_mass = (
-                            self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
+                        self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
                     )
 
                 except ValueError:
                     impurity_charge = round(kinetics_data[impurity_z][-1, 0].data)
                     impurity_mass = (
-                            self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
+                        self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
                     )
 
                 possible_species.append(

--- a/pyrokinetics/kinetics/KineticsReaderJETTO.py
+++ b/pyrokinetics/kinetics/KineticsReaderJETTO.py
@@ -101,7 +101,7 @@ class KineticsReaderJETTO(KineticsReader):
                     )
 
                 except KeyError:
-                    impurity_charge = round(kinetics_data[impurity_z][-1, 0].data)
+                    impurity_charge = np.rint(kinetics_data[impurity_z][-1, 0].data)
                     impurity_mass = (
                         self.impurity_charge_to_mass[impurity_charge] * hydrogen_mass
                     )


### PR DESCRIPTION
Some codes (JETTO) can have no integer charges for a species as they may lump together different ionised species. This will handle a cases where charge is not in the list but close to. Not great practice in general but some codes could spit out a charge like 1.9999 which would fail here even though it shouldn't.

Maybe we should add a check to see if it is "close" to these numbers.