### PR TITLE
Enable reading more kinds of GS2 simulations

### DIFF
--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -217,7 +217,8 @@ class GKInputGS2(GKInput):
             "nky": 1,
             "nkx": 1,
             "ky": self.data["kt_grids_single_parameters"]["aky"] / sqrt2,
-            "kx": self.data["kt_grids_single_parameters"].get("akx", ky * shat * theta0) / sqrt2,
+            "kx": self.data["kt_grids_single_parameters"].get("akx", ky * shat * theta0)
+            / sqrt2,
             "theta0": self.data["kt_grids_single_parameters"].get("theta0", 0.0),
         }
 

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -217,7 +217,7 @@ class GKInputGS2(GKInput):
             "nky": 1,
             "nkx": 1,
             "ky": self.data["kt_grids_single_parameters"]["aky"] / sqrt2,
-            "kx": 0.0,
+            "kx": self.data["kt_grids_single_parameters"].get("akx", ky * shat * theta0) / sqrt2
             "theta0": self.data["kt_grids_single_parameters"].get("theta0", 0.0),
         }
 

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -212,6 +212,99 @@ class GKInputGS2(GKInput):
         local_species.normalise()
         return local_species
 
+    def _read_single_grid(self):
+        return {
+            "nky": 1,
+            "nkx": 1,
+            "ky": self.data["kt_grids_single_parameters"]["aky"] / sqrt2,
+            "kx": 0.0,
+            "theta0": self.data["kt_grids_single_parameters"].get("theta0", 0.0),
+        }
+
+    def _read_range_grid(self):
+        range_options = self.data["kt_grids_range_parameters"]
+        nky = range_options.get("naky", 1)
+
+        ky_min = range_options.get("aky_min", "0.0")
+        ky_max = range_options.get("aky_max", "0.0")
+
+        spacing_option = range_options.get("kyspacing_option", "linear")
+        if spacing_option == "default":
+            spacing_option = "linear"
+
+        ky_space = np.linspace if spacing_option == "linear" else np.logspace
+
+        ky = ky_space(ky_min, ky_max, nky) / sqrt2
+
+        return {
+            "nky": nky,
+            "nkx": 1,
+            "ky": ky,
+            "kx": np.array([0.0]),
+            "theta0": 0.0,
+        }
+
+    def _read_box_grid(self):
+        box = self.data["kt_grids_box_parameters"]
+        keys = box.keys()
+
+        grid_data = {}
+
+        # Set up ky grid
+        if "ny" in keys:
+            grid_data["nky"] = int((box["ny"] - 1) / 3 + 1)
+        elif "n0" in keys:
+            grid_data["nky"] = box["n0"]
+        elif "nky" in keys:
+            grid_data["nky"] = box["naky"]
+        else:
+            raise RuntimeError(f"ky grid details not found in {keys}")
+
+        if "y0" in keys:
+            if box["y0"] < 0.0:
+                grid_data["ky"] = -box["y0"] / sqrt2
+            else:
+                grid_data["ky"] = 1 / box["y0"] / sqrt2
+        else:
+            raise RuntimeError(f"Min ky details not found in {keys}")
+
+        if "nx" in keys:
+            grid_data["nkx"] = int((2 * box["nx"] - 1) / 3 + 1)
+        elif "ntheta0" in keys():
+            grid_data["nkx"] = int((2 * box["ntheta0"] - 1) / 3 + 1)
+        else:
+            raise RuntimeError("kx grid details not found in {keys}")
+
+        shat_params = self.pyro_gs2_miller["shat"]
+        shat = self.data[shat_params[0]][shat_params[1]]
+        if abs(shat) > 1e-6:
+            grid_data["kx"] = grid_data["ky"] * shat * 2 * pi / box["jtwist"]
+        else:
+            grid_data["kx"] = 2 * pi / (box["x0"] * sqrt2)
+
+        return grid_data
+
+    def _read_grid(self):
+        """Read the perpendicular wavenumber grid"""
+
+        grid_option = self.data["kt_grids_knobs"].get("grid_option", "single")
+
+        GRID_READERS = {
+            "default": self._read_single_grid,
+            "single": self._read_single_grid,
+            "range": self._read_range_grid,
+            "box": self._read_box_grid,
+            "nonlinear": self._read_box_grid,
+        }
+
+        try:
+            return GRID_READERS[grid_option]()
+        except KeyError:
+            valid_options = ", ".join(f"'{option}'" for option in GRID_READERS)
+            raise ValueError(
+                f"Unknown GS2 'kt_grids_knobs::grid_option', '{grid_option}'. Expected one of {valid_options}"
+            )
+
     def get_numerics(self) -> Numerics:
         """Gather numerical info (grid spacing, time steps, etc)"""
 
@@ -227,63 +320,9 @@ class GKInputGS2(GKInput):
         numerics_data["delta_time"] = delta_time
         numerics_data["max_time"] = self.data["knobs"].get("nstep", 50000) * delta_time
 
-        # Fourier space grid
-        # Linear simulation
-        if self.is_linear():
-            numerics_data["nky"] = 1
-            numerics_data["nkx"] = 1
-            numerics_data["ky"] = self.data["kt_grids_single_parameters"]["aky"] / sqrt2
-            numerics_data["kx"] = 0.0
-            numerics_data["theta0"] = self.data["kt_grids_single_parameters"].get(
-                "theta0", 0.0
-            )
-            numerics_data["nonlinear"] = False
-        # Nonlinear/multiple modes in box
-        # kt_grids_knobs.grid_option == "box"
-        else:
-            box = self.data["kt_grids_box_parameters"]
-            keys = box.keys()
+        numerics_data["nonlinear"] = self.is_nonlinear()
 
-            # Set up ky grid
-            if "ny" in keys:
-                numerics_data["nky"] = int((box["ny"] - 1) / 3 + 1)
-            elif "n0" in keys:
-                numerics_data["nky"] = box["n0"]
-            elif "nky" in keys:
-                numerics_data["nky"] = box["naky"]
-            else:
-                raise RuntimeError(f"ky grid details not found in {keys}")
-
-            if "y0" in keys:
-                if box["y0"] < 0.0:
-                    numerics_data["ky"] = -box["y0"] / sqrt2
-                else:
-                    numerics_data["ky"] = 1 / box["y0"] / sqrt2
-            else:
-                raise RuntimeError(f"Min ky details not found in {keys}")
-
-            if "nx" in keys:
-                numerics_data["nkx"] = int((2 * box["nx"] - 1) / 3 + 1)
-            elif "ntheta0" in keys():
-                numerics_data["nkx"] = int((2 * box["ntheta0"] - 1) / 3 + 1)
-            else:
-                raise RuntimeError("kx grid details not found in {keys}")
-
-            shat_params = self.pyro_gs2_miller["shat"]
-            shat = self.data[shat_params[0]][shat_params[1]]
-            if abs(shat) > 1e-6:
-                numerics_data["kx"] = (
-                    numerics_data["ky"] * shat * 2 * pi / box["jtwist"]
-                )
-            else:
-                numerics_data["kx"] = 2 * pi / (box["x0"] * sqrt2)
-
-            try:
-                numerics_data["nonlinear"] = (
-                    self.data["nonlinear_terms_knobs"]["nonlinear_mode"] == "on"
-                )
-            except KeyError:
-                numerics_data["nonlinear"] = False
+        numerics_data.update(self._read_grid())
 
         # Theta grid
         numerics_data["ntheta"] = self.data["theta_grid_parameters"]["ntheta"]

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -217,7 +217,7 @@ class GKInputGS2(GKInput):
             "nky": 1,
             "nkx": 1,
             "ky": self.data["kt_grids_single_parameters"]["aky"] / sqrt2,
-            "kx": self.data["kt_grids_single_parameters"].get("akx", ky * shat * theta0) / sqrt2
+            "kx": self.data["kt_grids_single_parameters"].get("akx", ky * shat * theta0) / sqrt2,
             "theta0": self.data["kt_grids_single_parameters"].get("theta0", 0.0),
         }
 

--- a/pyrokinetics/gk_code/GKOutputReader.py
+++ b/pyrokinetics/gk_code/GKOutputReader.py
@@ -3,6 +3,7 @@ import xarray as xr
 from abc import abstractmethod
 from typing import Optional, Tuple, Any
 from pathlib import Path
+import warnings
 
 from .GKInput import GKInput
 from ..typing import PathLike
@@ -232,6 +233,10 @@ class GKOutputReader(Reader):
 
         This should be called after _set_fields, and is only valid for linear runs.
         """
+        if "fields" not in data:
+            warnings.warn("'fields' not set in data, unable to compute eigenfunctions")
+            return data
+
         eigenfunctions = data["fields"]
 
         square_fields = np.abs(data["fields"]) ** 2

--- a/pyrokinetics/gk_code/GKOutputReaderGS2.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGS2.py
@@ -4,6 +4,7 @@ import logging
 from itertools import product
 from typing import Tuple, Optional, Any
 from pathlib import Path
+import warnings
 
 from .GKOutputReader import GKOutputReader
 from .GKInputGS2 import GKInputGS2
@@ -140,6 +141,7 @@ class GKOutputReaderGS2(GKOutputReader):
                 "nfield": len(fields),
                 "nspecies": len(species),
                 "linear": gk_input.is_linear(),
+                "time_divisor": time_divisor
             },
         )
 
@@ -249,4 +251,21 @@ class GKOutputReaderGS2(GKOutputReader):
             fluxes[:, imoment, ifield, :, :] = flux
 
         data["fluxes"] = (coords, fluxes)
+        return data
+
+    @staticmethod
+    def _set_eigenvalues(
+        data: xr.Dataset, raw_data: Optional[Any] = None, gk_input: Optional[Any] = None
+    ) -> xr.Dataset:
+        if "fields" in data:
+            return GKOutputReader._set_eigenvalues(data, raw_data, gk_input)
+
+        warnings.warn("'fields' not set in data, falling back to 'omega_average' -- 'eigenvalues' will not be set!")
+
+        frequency = raw_data.omega_average.isel(ri=0).data / data.time_divisor
+        growth_rate = raw_data.omega_average.isel(ri=1).data / data.time_divisor
+
+        data["mode_frequency"] = (("time", "ky", "kx"), frequency)
+        data["growth_rate"] = (("time", "ky", "kx"), growth_rate)
+
         return data

--- a/pyrokinetics/gk_code/GKOutputReaderGS2.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGS2.py
@@ -141,7 +141,7 @@ class GKOutputReaderGS2(GKOutputReader):
                 "nfield": len(fields),
                 "nspecies": len(species),
                 "linear": gk_input.is_linear(),
-                "time_divisor": time_divisor
+                "time_divisor": time_divisor,
             },
         )
 
@@ -260,7 +260,9 @@ class GKOutputReaderGS2(GKOutputReader):
         if "fields" in data:
             return GKOutputReader._set_eigenvalues(data, raw_data, gk_input)
 
-        warnings.warn("'fields' not set in data, falling back to 'omega_average' -- 'eigenvalues' will not be set!")
+        warnings.warn(
+            "'fields' not set in data, falling back to 'omega_average' -- 'eigenvalues' will not be set!"
+        )
 
         frequency = raw_data.omega_average.isel(ri=0).data / data.time_divisor
         growth_rate = raw_data.omega_average.isel(ri=1).data / data.time_divisor


### PR DESCRIPTION
- enables "range" grids, as well as "box" for linear simulations
- enables reading `omega_average` if the time-dependent fields aren't present

Closes #94 

The normalisation for the growth rate and frequency probably want checking by an expert!

This let me read and do some basic analysis on more kinds of GS2 runs, but it almost certainly has some rough edges, and will need some work to generalise a bit more.