### PR TITLE
'supported types' lists now properties, not class-level vars

### DIFF
--- a/pyrokinetics/equilibrium/Equilibrium.py
+++ b/pyrokinetics/equilibrium/Equilibrium.py
@@ -61,9 +61,6 @@ class Equilibrium:
         all readers, so only include this if necessary.
     """
 
-    # Define class level info
-    supported_equilibrium_types = [*equilibrium_readers]
-
     def __init__(
         self,
         eq_file: PathLike,
@@ -84,6 +81,10 @@ class Equilibrium:
         # Store results in a dict. This data is accessible via __getattr__,
         # so eq.R gives the same result as eq._data["R"]
         self._data = reader(eq_file, **kwargs)
+
+    @property
+    def supported_equilibrium_types(self):
+        return [*equilibrium_readers]
 
     @property
     def eq_type(self):

--- a/pyrokinetics/kinetics/Kinetics.py
+++ b/pyrokinetics/kinetics/Kinetics.py
@@ -44,9 +44,6 @@ class Kinetics:
         all readers, so only include this if necessary.
     """
 
-    # Define class level info
-    supported_kinetics_types = [*kinetics_readers]
-
     def __init__(
         self,
         kinetics_file: PathLike,
@@ -64,6 +61,10 @@ class Kinetics:
             self.kinetics_type = reader.file_type
 
         self.species_data = CleverDict(reader(kinetics_file, **kwargs))
+
+    @property
+    def supported_kinetics_types(self):
+        return [*kinetics_readers]
 
     @property
     def kinetics_type(self):

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -11,8 +11,8 @@ from .gk_code import GKInput, gk_inputs, gk_output_readers
 from .local_geometry import LocalGeometry, LocalGeometryMiller, local_geometries
 from .local_species import LocalSpecies
 from .numerics import Numerics
-from .equilibrium import Equilibrium
-from .kinetics import Kinetics
+from .equilibrium import Equilibrium, equilibrium_readers
+from .kinetics import Kinetics, kinetics_readers
 from .typing import PathLike
 from .templates import gk_templates
 
@@ -58,13 +58,6 @@ class Pyro:
     gk_type : str, default ``None``
         Deprecated, synonym for gk_code. gk_code takes precedence.
     """
-
-    # Define class level info
-    supported_gk_inputs = [*gk_inputs]
-    supported_gk_output_readers = [*gk_output_readers]
-    supported_local_geometries = [*local_geometries]
-    supported_equilibrium_types = [*Equilibrium.supported_equilibrium_types]
-    supported_kinetics_types = [*Kinetics.supported_kinetics_types]
 
     def __init__(
         self,
@@ -146,6 +139,79 @@ class Pyro:
         # Load global kinetics file if it exists
         if kinetics_file is not None:
             self.load_global_kinetics(kinetics_file, kinetics_type)
+
+    # ============================================================
+    # Properties for determining supported features
+
+    @property
+    def supported_gk_inputs(self) -> List[str]:
+        """
+        Returns a list of supported GKInput classes, expressed as strings. The user
+        can add new GKInput classes by 'registering' them with
+        pyrokinetics.gk_code.gk_inputs.
+
+        Returns
+        -------
+        List[str]
+            List of supported GKInput classes, expressed as strings.
+        """
+        return [*gk_inputs]
+
+    @property
+    def supported_gk_output_readers(self) -> List[str]:
+        """
+        Returns a list of supported GKOutputReader classes, expressed as strings. The
+        user can add new GKOutputReader classes by 'registering' them with
+        pyrokinetics.gk_code.gk_output_readers.
+
+        Returns
+        -------
+        List[str]
+            List of supported GKOutputReader classes, expressed as strings.
+        """
+        return [*gk_output_readers]
+
+    @property
+    def supported_local_geometries(self) -> List[str]:
+        """
+        Returns a list of supported LocalGeometry classes, expressed as strings. The
+        user can add new LocalGeometry classes by 'registering' them with
+        pyrokinetics.local_geometry.local_geometries.
+
+        Returns
+        -------
+        List[str]
+            List of supported LocalGeometry classes, expressed as strings.
+        """
+        return [*local_geometries]
+
+    @property
+    def supported_equilibrium_types(self) -> List[str]:
+        """
+        Returns a list of supported Equilibrium types, expressed as strings (e.g.
+        GEQDSK, TRANSP). The user can add new EquilibriumReader classes by 'registering'
+        them with pyrokinetics.equilibrium.equilibrium_readers.
+
+        Returns
+        -------
+        List[str]
+            Supported Equilibrium types, expressed as strings.
+        """
+        return [*equilibrium_readers]
+
+    @property
+    def supported_kinetics_types(self) -> List[str]:
+        """
+        Returns a list of supported Kinetics types, expressed as strings (e.g. JETTO,
+        SCENE, TRANSP). The user can add new KineticsReader classes by 'registering'
+        them with pyrokinetics.kinetics.kinetics_readers.
+
+        Returns
+        -------
+        List[str]
+            List of supported Kinetics types, expressed as strings.
+        """
+        return [*kinetics_readers]
 
     # ============================================================
     # Functions and  properties for handling gyrokinetics contexts


### PR DESCRIPTION
We earlier implemented a plugin architecture for `GKInput`/`Equilibrium`/`Kinetics` etc, but on testing, I found it didn't work as intended for user-created plugins:

```python
import pyrokinetics as pk

# User creates a new GKInput class 
class MyGKInput( pk.gk_code.GKInput):
    # ... implement all the required methods here ...

# Register with gk_inputs factory
pk.gk_code.gk_inputs["MyGKInput"] = MyGKInput

# Try to read a file
pyro = pk.Pyro(gk_file="my_gkinput_file.txt")
``` 
The last step fails, as `Pyro.supported_gk_inputs` is defined at the class level, and is therefore instantiated back during the original `import`. It can't recognise the new plugin created by the user.

I've changed these class-level lists to be implemented as properties instead, meaning a new list is created from the factory classes each time the user accesses `pyro.supported_gk_inputs`, `pyro.supported_equilibrium_types`, etc. A simpler but less flexible fix could be to instead move the class-level lists inside the `__init__` function -- let me know if you'd prefer this.