### PR TITLE
Bugfix/gene rho fix

### DIFF
--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -144,7 +144,7 @@ class GKInputGENE(GKInput):
 
         for pyro_key, (gene_param, gene_key) in self.pyro_gene_circular.items():
             circular_data[pyro_key] = self.data[gene_param][gene_key]
-        circular_data["local_geometry"] = "Circular"
+        circular_data["local_geometry"] = "Miller"
 
         circular_data["Rmaj"] = (
             self.data["geometry"]["major_r"] / self.data["geometry"]["minor_r"]

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -36,7 +36,6 @@ class GKInputGENE(GKInput):
     }
 
     pyro_gene_circular = {
-        "Rmaj": ["geometry", "major_r"],
         "q": ["geometry", "q0"],
         "shat": ["geometry", "shat"],
     }
@@ -146,6 +145,11 @@ class GKInputGENE(GKInput):
         for pyro_key, (gene_param, gene_key) in self.pyro_gene_circular.items():
             circular_data[pyro_key] = self.data[gene_param][gene_key]
         circular_data["local_geometry"] = "Circular"
+
+        circular_data["Rmaj"] = (
+            self.data["geometry"]["major_r"] / self.data["geometry"]["minor_r"]
+        )
+        circular_data["rho"] = self.data["geometry"]["trpeps"] * circular_data["Rmaj"]
 
         circular = LocalGeometryMiller.from_gk_data(circular_data)
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -46,8 +46,6 @@ class GKInputGENE(GKInput):
         "z": "charge",
         "dens": "dens",
         "temp": "temp",
-        "a_lt": "omt",
-        "a_ln": "omn",
     }
 
     def read(self, filename: PathLike) -> Dict[str, Any]:
@@ -177,6 +175,8 @@ class GKInputGENE(GKInput):
             for pyro_key, gene_key in self.pyro_gene_species.items():
                 species_data[pyro_key] = gene_data[gene_key]
 
+            species_data["a_lt"] = gene_data["omt"] * self.data["geometry"]["minor_r"]
+            species_data["a_ln"] = gene_data["omn"] * self.data["geometry"]["minor_r"]
             species_data["vel"] = 0.0
             species_data["a_lv"] = 0.0
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -131,7 +131,7 @@ class GKInputGENE(GKInput):
 
         if miller.B0 is not None:
             miller.beta_prime = -self.data["geometry"]["amhd"] / (
-                miller.q ** 2 * miller.Rmaj
+                miller.q**2 * miller.Rmaj
             )
 
         return miller
@@ -219,8 +219,8 @@ class GKInputGENE(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             )
 
         return local_species
@@ -302,7 +302,7 @@ class GKInputGENE(GKInput):
             self.data[gene_param][gene_key] = local_geometry[pyro_key]
 
         self.data["geometry"]["amhd"] = (
-            -(local_geometry.q ** 2) * local_geometry.Rmaj * local_geometry.beta_prime
+            -(local_geometry.q**2) * local_geometry.Rmaj * local_geometry.beta_prime
         )
         self.data["geometry"]["trpeps"] = local_geometry.rho / local_geometry.Rmaj
         self.data["geometry"]["minor_r"] = 1.0
@@ -350,10 +350,10 @@ class GKInputGENE(GKInput):
             if local_species.nref is not None:
                 pref = local_species.nref * local_species.tref * electron_charge
                 bref = local_geometry.B0
-                beta = pref / bref ** 2 * 8 * pi * 1e-7
+                beta = pref / bref**2 * 8 * pi * 1e-7
             # Calculate from reference  at centre of flux surface
             else:
-                beta = 1 / local_geometry.B0 ** 2
+                beta = 1 / local_geometry.B0**2
 
         self.data["general"]["beta"] = beta
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -339,6 +339,9 @@ class GKInputGENE(GKInput):
             for key, val in self.pyro_gene_species.items():
                 self.data["species"][iSp][val] = local_species[name][key]
 
+            self.data["species"][iSp]["omt"] = local_species[name].a_lt
+            self.data["species"][iSp]["omn"] = local_species[name].a_ln
+
         # Calculate beta. If B0 is not defined, it takes the following
         # default value
         beta = 0.0

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -429,12 +429,12 @@ class GKInputGS2(GKInput):
             # FIXME local_geometry.B0 may be set to None
             bref = local_geometry.B0
 
-            beta = pref / bref ** 2 * 8 * pi * 1e-7
+            beta = pref / bref**2 * 8 * pi * 1e-7
 
         # Calculate from reference  at centre of flux surface
         else:
             if local_geometry.B0 is not None:
-                beta = 1 / local_geometry.B0 ** 2
+                beta = 1 / local_geometry.B0**2
             else:
                 beta = 0.0
 


### PR DESCRIPTION
Fixes incorrect `rho` in #106 

Also handles cases when `Lref!=aminor` when reading in `omn` and `omt`

