### PR TITLE
Minor fixes and tests for missing/default keys in GS2 inputs

### DIFF
--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -304,12 +304,14 @@ class GKInputGS2(GKInput):
         }
 
         try:
-            return GRID_READERS[grid_option]()
+            reader = GRID_READERS[grid_option]
         except KeyError:
             valid_options = ", ".join(f"'{option}'" for option in GRID_READERS)
             raise ValueError(
                 f"Unknown GS2 'kt_grids_knobs::grid_option', '{grid_option}'. Expected one of {valid_options}"
             )
+
+        return reader()
 
     def get_numerics(self) -> Numerics:
         """Gather numerical info (grid spacing, time steps, etc)"""

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -284,7 +284,9 @@ class GKInputGS2(GKInput):
         shat_params = self.pyro_gs2_miller["shat"]
         shat = self.data[shat_params[0]][shat_params[1]]
         if abs(shat) > 1e-6:
-            grid_data["kx"] = grid_data["ky"] * shat * 2 * pi / box["jtwist"]
+            jtwist_default = max(int(2 * pi * shat + 0.5), 1)
+            jtwist = box.get("jtwist", jtwist_default)
+            grid_data["kx"] = grid_data["ky"] * shat * 2 * pi / jtwist
         else:
             grid_data["kx"] = 2 * pi / (box["x0"] * sqrt2)
 

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -348,7 +348,7 @@ class GKInputGS2(GKInput):
             numerics_data["nenergy"] = self.data["le_grids_knobs"]["negrid"]
 
         # Currently using number of un-trapped pitch angles
-        numerics_data["npitch"] = self.data["le_grids_knobs"]["ngauss"] * 2
+        numerics_data["npitch"] = self.data["le_grids_knobs"].get("ngauss", 5) * 2
 
         return Numerics(numerics_data)
 

--- a/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
+++ b/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
@@ -24,9 +24,7 @@ def gs2():
     return GKInputGS2(template_file)
 
 
-def modified_gs2_input(
-    filename: str, replacements: Dict[str, Optional[Dict[str, Optional[str]]]]
-):
+def modified_gs2_input(replacements: Dict[str, Optional[Dict[str, Optional[str]]]]):
     """Return a GS2 input file based on the template file, but with
     updated keys/namelists from replacements. Keys that are `None` will be deleted
     """
@@ -49,10 +47,7 @@ def modified_gs2_input(
             else:
                 input_file[namelist][key] = value
 
-    with open(filename, "w") as f:
-        f90nml.write(input_file, f)
-
-    return GKInputGS2(filename)
+    return GKInputGS2.from_str(str(input_file))
 
 
 def test_read(gs2):
@@ -151,7 +146,7 @@ def test_gs2_linear_box(tmp_path):
         "kt_grids_knobs": {"grid_option": "box"},
         "kt_grids_box_parameters": {"ny": 12, "y0": 2, "nx": 8, "jtwist": 8},
     }
-    gs2 = modified_gs2_input(tmp_path / "gs2_box.in", replacements)
+    gs2 = modified_gs2_input(replacements)
 
     numerics = gs2.get_numerics()
     assert numerics.nkx == 6
@@ -165,7 +160,7 @@ def test_gs2_linear_box_no_jtwist(tmp_path):
         "kt_grids_knobs": {"grid_option": "box"},
         "kt_grids_box_parameters": {"ny": 12, "y0": 2, "nx": 8},
     }
-    gs2 = modified_gs2_input(tmp_path / "gs2_box.in", replacements)
+    gs2 = modified_gs2_input(replacements)
 
     numerics = gs2.get_numerics()
     assert numerics.nkx == 6
@@ -182,7 +177,7 @@ def test_gs2_linear_range(tmp_path):
         "kt_grids_knobs": {"grid_option": "range"},
         "kt_grids_range_parameters": {"naky": 12, "aky_min": 2, "aky_max": 8},
     }
-    gs2 = modified_gs2_input(tmp_path / "gs2_range.in", replacements)
+    gs2 = modified_gs2_input(replacements)
 
     numerics = gs2.get_numerics()
     assert numerics.nkx == 1
@@ -193,7 +188,7 @@ def test_gs2_linear_range(tmp_path):
 
 def test_gs2_linear_missing_ngauss(tmp_path):
     replacements = {"le_grids_knobs": {"ngauss": None}}
-    gs2 = modified_gs2_input(tmp_path / "gs2_missing_ngauss.in", replacements)
+    gs2 = modified_gs2_input(replacements)
     numerics = gs2.get_numerics()
 
     assert numerics.npitch == 10
@@ -201,7 +196,7 @@ def test_gs2_linear_missing_ngauss(tmp_path):
 
 def test_gs2_linear_nesubsuper(tmp_path):
     replacements = {"le_grids_knobs": {"nesub": 11, "nesuper": 15, "negrid": None}}
-    gs2 = modified_gs2_input(tmp_path / "gs2_nesubsuper.in", replacements)
+    gs2 = modified_gs2_input(replacements)
     numerics = gs2.get_numerics()
 
     assert numerics.nenergy == 26
@@ -213,7 +208,7 @@ def test_gs2_invalid_nonlinear(tmp_path):
         "kt_grids_knobs": {"grid_option": "box"},
     }
     with pytest.raises(RuntimeError):
-        modified_gs2_input(tmp_path / "gs2_invalid_nonlinear.in", replacements)
+        modified_gs2_input(replacements)
 
 
 def test_gs2_valid_nonlinear_with_wstart_units(tmp_path):
@@ -223,5 +218,5 @@ def test_gs2_valid_nonlinear_with_wstart_units(tmp_path):
         "knobs": {"wstar_units": False},
     }
 
-    gs2 = modified_gs2_input(tmp_path / "gs2_invalid_nonlinear.in", replacements)
+    gs2 = modified_gs2_input(replacements)
     assert gs2.is_nonlinear()

--- a/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
+++ b/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
@@ -153,6 +153,27 @@ def test_gs2_linear_box(tmp_path):
     assert np.isclose(numerics.kx, np.pi * np.sqrt(2) / 4)
 
 
+def test_gs2_linear_box_no_jtwist(tmp_path):
+    replacements = {
+        "kt_grids_knobs": {"grid_option": "box"},
+        "kt_grids_box_parameters": {
+            "ny": 12,
+            "y0": 2,
+            "nx": 8,
+        },
+    }
+    gs2 = modified_gs2_input(replacements, tmp_path / "gs2_box.in")
+
+    numerics = gs2.get_numerics()
+    assert numerics.nkx == 6
+    assert numerics.nky == 4
+    assert np.isclose(numerics.ky, np.sqrt(2) / 4)
+    shat = 4
+    jtwist = 2 * np.pi * shat
+    expected_kx = numerics.ky * jtwist / int(jtwist)
+    assert np.isclose(numerics.kx, expected_kx)
+
+
 def test_gs2_linear_range(tmp_path):
     replacements = {
         "kt_grids_knobs": {"grid_option": "range"},

--- a/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
+++ b/pyrokinetics/tests/gk_code/test_gk_input_gs2.py
@@ -205,3 +205,23 @@ def test_gs2_linear_nesubsuper(tmp_path):
     numerics = gs2.get_numerics()
 
     assert numerics.nenergy == 26
+
+
+def test_gs2_invalid_nonlinear(tmp_path):
+    replacements = {
+        "nonlinear_terms_knobs": {"nonlinear_mode": "on"},
+        "kt_grids_knobs": {"grid_option": "box"},
+    }
+    with pytest.raises(RuntimeError):
+        modified_gs2_input(tmp_path / "gs2_invalid_nonlinear.in", replacements)
+
+
+def test_gs2_valid_nonlinear_with_wstart_units(tmp_path):
+    replacements = {
+        "nonlinear_terms_knobs": {"nonlinear_mode": "on"},
+        "kt_grids_knobs": {"grid_option": "box"},
+        "knobs": {"wstar_units": False},
+    }
+
+    gs2 = modified_gs2_input(tmp_path / "gs2_invalid_nonlinear.in", replacements)
+    assert gs2.is_nonlinear()


### PR DESCRIPTION
`jtwist` and `ngauss` might not be present, but will have default values.

Adds a bunch of tests for various variations of GS2 input files.

The test helper function `modified_gs2_input` enables deleting keys/namelists from an existing input file by setting them to `None` in the dict of replacements -- this could be useful for `GKInput.add_flags`? It might get a bit complicated with how it interacts with keys that will get set from other objects via `GKInput.set`. Maybe we should remove `add_flags` and instead add a `code_specific_parameters` input to `set`? Then it wouldn't be possible to modify things in a potentially inconsistent way