### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ author_email = bhavin.s.patel@ukaea.uk
 license = LGPL
 license_file = LICENSE
 keywords = gyrokinetics, analysis, plasma, research
+python_requires = >= 3.8
 classifiers =
     Programming Language :: Python
     Development Status :: 3 - Alpha
@@ -37,7 +38,6 @@ install_requires =
     numpy >= 1.20.3
     cleverdict >= 1.9.1
     xarray >= 0.10
-    importlib-metadata; python_version >= "3.6"
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Python 3.7 is end of life in June 2023, most OSes that still have it as the system python3 are either EOL or will be shortly. Several of our dependencies (xarray, numpy) have also started dropping support for Python 3.7.