### PR TITLE
Fix/cgyro sign frequency

### DIFF
--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -356,7 +356,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = eigenvalue_over_time[0, :, :]
+        mode_frequency = - eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -356,7 +356,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = - eigenvalue_over_time[0, :, :]
+        mode_frequency = -eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -247,7 +247,9 @@ class GKOutputReaderCGYRO(GKOutputReader):
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
-            field_data = (field_data[0] + gk_input.data['Z_1'] * 1j * field_data[1]) / data.rho_star
+            field_data = (
+                field_data[0] + gk_input.data["Z_1"] * 1j * field_data[1]
+            ) / data.rho_star
 
             # If nonlinear, we can simply save the fields and continue
             if gk_input.is_nonlinear():
@@ -356,7 +358,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = gk_input.data['Z_1'] * eigenvalue_over_time[0, :, :]
+        mode_frequency = gk_input.data["Z_1"] * eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -247,8 +247,12 @@ class GKOutputReaderCGYRO(GKOutputReader):
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
+            mode_sign = -np.sign(
+                np.sign(gk_input.data.get("Q", 2.0)) * -gk_input.data.get("BTCCW", -1)
+            )
+
             field_data = (
-                field_data[0] + int(np.sign(gk_input.data["Z_1"])) * 1j * field_data[1]
+                field_data[0] + mode_sign * 1j * field_data[1]
             ) / data.rho_star
 
             # If nonlinear, we can simply save the fields and continue
@@ -357,10 +361,12 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "out.cgyro.freq to exist. Could not set data_vars 'growth_rate', "
                 "'mode_frequency' and 'eigenvalue'."
             )
-
-        mode_frequency = (
-            int(np.sign(gk_input.data["Z_1"])) * eigenvalue_over_time[0, :, :]
+        mode_sign = -np.sign(
+            np.sign(gk_input.data.get("Q", 2.0)) * -gk_input.data.get("BTCCW", -1)
         )
+
+        mode_frequency = mode_sign * eigenvalue_over_time[0, :, :]
+
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -248,7 +248,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
             field_data = (
-                field_data[0] + np.sign(gk_input.data["Z_1"]) * 1j * field_data[1]
+                field_data[0] + int(np.sign(gk_input.data["Z_1"])) * 1j * field_data[1]
             ) / data.rho_star
 
             # If nonlinear, we can simply save the fields and continue
@@ -358,7 +358,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = np.sign(gk_input.data["Z_1"]) * eigenvalue_over_time[0, :, :]
+        mode_frequency = int(np.sign(gk_input.data["Z_1"])) * eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -358,7 +358,9 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = int(np.sign(gk_input.data["Z_1"])) * eigenvalue_over_time[0, :, :]
+        mode_frequency = (
+            int(np.sign(gk_input.data["Z_1"])) * eigenvalue_over_time[0, :, :]
+        )
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -245,9 +245,9 @@ class GKOutputReaderCGYRO(GKOutputReader):
             else:
                 shape = (2, data.nkx, data.ntheta, data.nky, data.ntime)
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
-            # Using -1j here to match pyrokinetics frequency convention
+            # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
-            field_data = (field_data[0] - 1j * field_data[1]) / data.rho_star
+            field_data = (field_data[0] + gk_input.data['Z_1'] * 1j * field_data[1]) / data.rho_star
 
             # If nonlinear, we can simply save the fields and continue
             if gk_input.is_nonlinear():
@@ -356,7 +356,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = -eigenvalue_over_time[0, :, :]
+        mode_frequency = gk_input.data['Z_1'] * eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -247,7 +247,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
-            field_data = (field_data[0] + gk_input.data['Z_1'] * 1j * field_data[1]) / data.rho_star
+            field_data = (field_data[0] + np.sign(gk_input.data['Z_1']) * 1j * field_data[1]) / data.rho_star
 
             # If nonlinear, we can simply save the fields and continue
             if gk_input.is_nonlinear():
@@ -356,7 +356,7 @@ class GKOutputReaderCGYRO(GKOutputReader):
                 "'mode_frequency' and 'eigenvalue'."
             )
 
-        mode_frequency = gk_input.data['Z_1'] * eigenvalue_over_time[0, :, :]
+        mode_frequency = np.sign(gk_input.data['Z_1']) * eigenvalue_over_time[0, :, :]
         growth_rate = eigenvalue_over_time[1, :, :]
         eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues


### PR DESCRIPTION
The frequency sign needs to be flipped when read from the output file. Before, this was only done in the fields, if available.