### PR TITLE
Fixed GENE error when paths contain numbers

### DIFF
--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -78,8 +78,9 @@ class GKOutputReaderGENE(GKOutputReader):
         # If the input file is of the form name_####, get the numbered part and
         # search for 'parameters_####' in the run directory. If not, simply return
         # the directory.
+        filename = Path(filename)
         num_part_regex = re.compile(r"(\d{4})")
-        num_part_match = num_part_regex.search(str(filename))
+        num_part_match = num_part_regex.search(filename.name)
         if num_part_match is None:
             return Path(filename).parent
         else:

--- a/pyrokinetics/tests/gk_code/test_gk_output_reader_gene.py
+++ b/pyrokinetics/tests/gk_code/test_gk_output_reader_gene.py
@@ -84,6 +84,7 @@ def test_verify_not_gene_file(reader, not_gene_file):
         Path("dir/to/parameters_0003"),
         Path("dir/to/nrg_0017"),
         Path("dir/to/input_file"),
+        Path("dir_0001/to_5102/parameters_0005"),
     ],
 )
 def test_infer_path_from_input_file_gene(input_path):
@@ -92,9 +93,9 @@ def test_infer_path_from_input_file_gene(input_path):
     # Otherwise, get the dir
     last_4_chars = str(input_path)[-4:]
     if last_4_chars.isdigit():
-        assert output_path == Path(f"dir/to/parameters_{last_4_chars}")
+        assert output_path == input_path.parent / f"parameters_{last_4_chars}"
     else:
-        assert output_path == Path("dir/to/")
+        assert output_path == input_path.parent
 
 
 # Golden answer tests


### PR DESCRIPTION
Bug fix for a minor error. If the working directory path contains strings of at least four digits (e.g. dates), the methods used to find GENE files would use the first 4 digits in the path rather than the actual file paths.

e.g.

```python
infer_path_from_input_file("data_20220101/nrg_0003")
# returns "data_20220101/parameters_2022"
# expected "data_20220101/parameters_0003"
```

The methods used to find GENE files may need another look at some point, but I don't think it's a high priority right now. I added a test to ensure errors of this nature don't pop up again later.