### PR TITLE
Improved get_flux_surface

### DIFF
--- a/pyrokinetics/equilibrium/EquilibriumReaderGEQDSK.py
+++ b/pyrokinetics/equilibrium/EquilibriumReaderGEQDSK.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from typing import Dict, Any
 from ..typing import PathLike
 from .EquilibriumReader import EquilibriumReader
@@ -11,6 +13,18 @@ from scipy.interpolate import (
 from freegs import _geqdsk
 
 
+class SuppressPrint:
+    """Utility class to block freegs IO"""
+
+    def __enter__(self):
+        self.stdout = sys.stdout
+        sys.stdout = open(os.devnull, "w")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self.stdout
+
+
 class EquilibriumReaderGEQDSK(EquilibriumReader):
     def read(
         self,
@@ -20,7 +34,7 @@ class EquilibriumReaderGEQDSK(EquilibriumReader):
         """
         Read in GEQDSK file and populates Equilibrium object
         """
-        with open(filename) as f:
+        with SuppressPrint(), open(filename) as f:
             gdata = _geqdsk.read(f)
 
         nr = gdata["nx"]
@@ -28,8 +42,8 @@ class EquilibriumReaderGEQDSK(EquilibriumReader):
         psi_n = np.linspace(0.0, psi_n_lcfs, nr)
         psi_axis = gdata["simagx"]
         psi_bdry = gdata["sibdry"]
-        R_axis = (gdata["rmagx"],)
-        Z_axis = (gdata["zmagx"],)
+        R_axis = gdata["rmagx"]
+        Z_axis = gdata["zmagx"]
 
         # Set up 1D profiles as interpolated functions
         f_psi = InterpolatedUnivariateSpline(psi_n, gdata["fpol"])
@@ -96,7 +110,7 @@ class EquilibriumReaderGEQDSK(EquilibriumReader):
     def verify(self, filename: PathLike) -> None:
         """Quickly verify that we're looking at a GEQDSK file without processing"""
         # Try opening the GEQDSK file using freegs._geqdsk
-        with open(filename) as f:
+        with SuppressPrint(), open(filename) as f:
             gdata = _geqdsk.read(f)
         # Check that the correct variables exist
         var_names = ["nx", "ny", "simagx", "sibdry", "rmagx", "zmagx"]

--- a/pyrokinetics/equilibrium/get_flux_surface.py
+++ b/pyrokinetics/equilibrium/get_flux_surface.py
@@ -1,58 +1,96 @@
+from typing import Callable
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+from skimage.measure import find_contours
 
 
-def get_flux_surface(R, Z, psi_RZ, psi_axis, psi_bdry, R_axis, Z_axis, psi_n=1.0):
+def get_flux_surface(
+    R: np.ndarray,
+    Z: np.ndarray,
+    psi_RZ: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    psi_axis: float,
+    psi_bdry: float,
+    R_axis: float,
+    Z_axis: float,
+    psi_n: float,
+):
+    """
+    Given linearly-spaced RZ coordinates and a function psi(R,Z), returns the
+    R and Z coordinates of a contour at normalised psi_n. Describes a single magnetic
+    flux surface within a tokamak.
+
+    Parameters
+    ----------
+    R : np.ndarray
+        Linearly spaced and monotonically increasing 1D grid of major radius
+        coordinates, i.e. the radial distance from the central column of a tokamak.
+    Z : np.ndarray
+        Linearly spaced and monotonically increasing 1D grid of z-coordinates describing
+        the distance from the midplane of a tokamak.
+    psi_RZ: Callable[[np.ndarray, np.ndarray], np.ndarray]
+        Function describing (non-normalised) psi, the poloidal magnetic flux function,
+        in the range (R,Z).
+    psi_axis: float
+        The value of psi along the magnetic axis.
+    psi_bdry: float
+        The value of psi at the Last Closed Flux Surface (LCFS)
+    R_axis: float
+        R position of the magnetic axis.
+    Z_axis: float
+        Z position of the magnetic axis.
+    psi_n: float
+        Normalised psi coordinate on which to fit a contour. A value close to 0.0 will
+        be near the magnetic axis, while a value of 1.0 will be on the last closed flux
+        surface.
+
+    Returns
+    -------
+    np.ndarray
+        2D array containing R and Z coordinates of the flux surface contour. Indexing
+        with [0,:] gives a 1D array of R coordinates, while [1,:] gives a 1D array of
+        Z coordinates. The endpoints are repeated, so [:,0] == [:,-1].
+
+    Raises
+    ------
+    ValueError
+        If psi_n is outside the range 0.0 <= psi_n <= 1.0.
+    RuntimeError
+        If no flux surface contours could be found.
+    """
 
     if psi_n > 1.0 or psi_n < 0.0:
-        raise ValueError("You must have 0.0 <= psi_n <= 1.0")
+        raise ValueError(f"psi_n={psi_n}, but we require 0.0 <= psi_n <= 1.0")
 
     # Generate 2D mesh of normalised psi
-    psi_2d = np.transpose(psi_RZ(R, Z))
-
+    # TODO psi_RZ should be a grid, could avoid expensive spline interpolation
+    # TODO Pass in psi_n grid instead of psi? Could avoid two args
+    psi_2d = psi_RZ(R, Z)
     psin_2d = (psi_2d - psi_axis) / (psi_bdry - psi_axis)
 
-    # Returns a list of list of contours for psi_n, resets backend to original value
-    original_backend = mpl.get_backend()
-    mpl.use("Agg")
+    # Get contours, raising error if none are found
+    contours_raw = find_contours(psin_2d, psi_n)
+    if not contours_raw:
+        raise RuntimeError(f"Could not find flux surface contours for psi_n={psi_n}")
 
-    con = plt.contour(R, Z, psin_2d, levels=[psi_n])
+    # Normalise to RZ grid
+    # Normalisation assumes R and Z are linspace grids with a positive spacing.
+    # The raw contours have a range of 0 to len(x)-1, for x in [R,Z].
+    scaling = np.array([(x[-1] - x[0]) / (len(x) - 1) for x in (R, Z)])
+    RZ_min = np.array([R[0], Z[0]])
+    contours = [contour * scaling + RZ_min for contour in contours_raw]
 
-    mpl.use(original_backend)
+    # Find the contour that is, on average, closest to the magnetic axis, as this
+    # procedure may find additional open contours outside the last closed flux surface.
+    if len(contours) > 1:
+        # TODO Determine R_axis and Z_axis here? Could avoid two args
+        RZ_axis = np.array([[R_axis, Z_axis]])
+        mean_dist = [np.mean(np.linalg.norm(c - RZ_axis, axis=1)) for c in contours]
+        contour = contours[np.argmin(mean_dist)]
+    else:
+        contour = contours[0]
 
-    # Check if more than one contour has been found
-    if len(con.collections) > 1:
-        raise ValueError("More than one contour level found in get_flux_surface")
+    # Adjust the contour arrays so that we begin at the OMP (outside midplane)
+    omp_idx = np.argmax(contour[0, :])
+    contour = np.roll(contour, -omp_idx, axis=0)
 
-    paths = con.collections[0].get_paths()
-
-    if psi_n == 1.0:
-        if len(paths) == 0:
-            raise ValueError(
-                "PsiN=1.0 for LCFS isn't well defined. Try lowering psi_n_lcfs"
-            )
-
-    # Find smallest path integral to find closed loop
-    closest_path = np.argmin(
-        [
-            np.mean(
-                np.sqrt(
-                    (path.vertices[:, 0] - R_axis) ** 2
-                    + (path.vertices[:, 1] - Z_axis) ** 2
-                )
-            )
-            for path in paths
-        ]
-    )
-
-    path = paths[closest_path]
-
-    R_con, Z_con = path.vertices[:, 0], path.vertices[:, 1]
-
-    # Start from OMP
-    Z_con = np.flip(np.roll(Z_con, -np.argmax(R_con) - 1))
-    R_con = np.flip(np.roll(R_con, -np.argmax(R_con) - 1))
-
-    mpl.use(original_backend)
-    return R_con, Z_con
+    # Return transpose so we have array of [[Rs...],[Zs...]]
+    return contour.T

--- a/pyrokinetics/tests/local_geometry/test_miller.py
+++ b/pyrokinetics/tests/local_geometry/test_miller.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from pyrokinetics import template_dir
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_geometry.LocalGeometryMiller import (
@@ -150,9 +151,18 @@ def test_load_from_eq():
         "zeta": 0.0,
     }
     for key, value in expected.items():
-        assert np.isclose(
-            miller[key], value
-        ), f"{key} difference: {miller[key] - value}"
+        actual = miller[key]
+        err_string = dedent(
+            f"""\
+            {key}
+            actual: {actual}
+            expected: {value}
+            abs_err: {actual - value}
+            rel_err: {(actual - value) / np.nextafter(value, np.inf)}"
+            """
+        )
+        # Accurate to 0.5%. May need to update golden answer values
+        assert np.isclose(actual, value, rtol=5e-3), err_string
 
     assert np.isclose(min(miller.R), 1.747667428494825)
     assert np.isclose(max(miller.R), 3.8021621078549717)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     cleverdict >= 1.9.1
     xarray >= 0.10
     pint ~= 0.19.1
+    scikit-image ~= 0.19
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Instead of using matplotlib's contour function with a non-graphical backend, uses scikit-image's [`find_contours`](https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.find_contours). This prevents pyrokinetics from interfering with any of the user's matplotlib code, and leads to a significant speed up. On my machine, unit tests have gone from taking around 30s to under 10s!

Almost all unit tests are continuing to pass with no changes needed. The only exception is `test_miller.py::test_load_from_eq`, which still passes if the relative error tolerance is set to 0.5%. Since this is a golden answer test, I'm hoping this isn't a major problem.

Resolves Issue https://github.com/pyro-kinetics/pyrokinetics/issues/60.

(Also found a way to stop some annoying command line IO whenever freegs reads a GEQDSK file.)