### PR TITLE
Bugfix/remove template beta

### DIFF
--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -143,7 +143,9 @@ class LocalSpecies(CleverDict):
             species = self[name]
             # Total pressure
             pressure += species["temp"] * species["dens"]
-            a_lp += species["temp"] * species["dens"] * (species["a_lt"] + species["a_ln"])
+            a_lp += (
+                species["temp"] * species["dens"] * (species["a_lt"] + species["a_ln"])
+            )
 
         self["pressure"] = pressure
 

--- a/pyrokinetics/local_species.py
+++ b/pyrokinetics/local_species.py
@@ -143,7 +143,7 @@ class LocalSpecies(CleverDict):
             species = self[name]
             # Total pressure
             pressure += species["temp"] * species["dens"]
-            a_lp += pressure * (species["a_lt"] + species["a_ln"])
+            a_lp += species["temp"] * species["dens"] * (species["a_lt"] + species["a_ln"])
 
         self["pressure"] = pressure
 

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -38,7 +38,7 @@ class Numerics(CleverDict):
             "bpar": False,
             "max_time": 500.0,
             "delta_time": 0.001,
-            "beta": 0.0,
+            "beta": None,
         }
 
         super().__init__(data_dict)

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -1315,7 +1315,7 @@ class Pyro:
         # Bail early if there's nothing to check. They'll only both be
         # non-zero if we have all three of a GK sim, geometry, and
         # kinetics. In any other situation, we can't check, so don't bother
-        if beta == 0.0 or self.norms.beta == 0.0:
+        if beta == 0.0 or self.norms.beta == 0.0 or beta is None:
             return
 
         # No units, so scalar, for example because the user has changed

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -410,6 +410,10 @@ class Pyro:
         # numerics will now refer to different objects.
         self.read_gk_file(template_file, gk_code=gk_code, no_process=no_process)
 
+        # Need to remove beta from template file otherwise won't be set
+        if self.numerics:
+            self.numerics.beta = None
+
         # Copy across the previous numerics, local_geometry and local_species, if they
         # were found. Note that the context has now been switched, so
         # self.local_geometry now refers to a new object.


### PR DESCRIPTION
Currently when loading in a template, the `numerics` are set from the template including `beta`. This `beta then carries through the whole calculation and would override the actual `beta` as shown here

https://github.com/pyro-kinetics/pyrokinetics/blob/0cd4b168e85ba152de93dbd80367d43ab6fa3412/pyrokinetics/gk_code/GKInputCGYRO.py#L342-L343

This forces `beta` back to a `None`, meaning it will get set appropriately.

@ZedThree do you think there is a better place for this? As far as I can tell, `beta` is the only term in `numerics` which would be impacted physical parameters so we won't have to do this anywhere else

