### PR TITLE
fix sign for poloidal field fit

### DIFF
--- a/pyrokinetics/local_geometry/LocalGeometry.py
+++ b/pyrokinetics/local_geometry/LocalGeometry.py
@@ -401,7 +401,7 @@ class LocalGeometry(CleverDict):
 
         R = self.R * self.a_minor
 
-        return self.dpsidr / R * self.get_grad_r(theta, params)
+        return np.abs(self.dpsidr) / R * self.get_grad_r(theta, params)
 
     def get_bunit_over_b0(self):
         r"""


### PR DESCRIPTION
Poloidal field fitting was failing due to poloidal field magnitude being calculated as negative, due to sign of dpsidr. Fixed to absolute value