### PR TITLE
Fix incorrect collisionality for ions when Z!=1

### DIFF
--- a/pyrokinetics/examples/example_JETTO.py
+++ b/pyrokinetics/examples/example_JETTO.py
@@ -16,7 +16,9 @@ def main(base_path: Union[os.PathLike, str] = "."):
 
     pyro.load_global_eq(eq_file=eq_file, eq_type="GEQDSK", psi_n_lcfs=1.0)
 
-    pyro.load_global_kinetics(kinetics_file=kinetics_file, kinetics_type="JETTO", time=550)
+    pyro.load_global_kinetics(
+        kinetics_file=kinetics_file, kinetics_type="JETTO", time=550
+    )
 
     # Generate local parameters at psi_n=0.5
     pyro.load_local(psi_n=0.5, local_geometry="Miller")

--- a/pyrokinetics/examples/example_JETTO.py
+++ b/pyrokinetics/examples/example_JETTO.py
@@ -1,32 +1,46 @@
 from pyrokinetics import Pyro, template_dir
+import os
+import pathlib
+from typing import Union
 
-# Equilibrium file
-eq_file = template_dir / "test.geqdsk"
 
-# Kinetics data file
-kinetics_file = template_dir / "jetto.cdf"
+def main(base_path: Union[os.PathLike, str] = "."):
+    # Equilibrium file
+    eq_file = template_dir / "test.geqdsk"
 
-# Load up pyro object
-pyro = Pyro()
+    # Kinetics data file
+    kinetics_file = template_dir / "jetto.cdf"
 
-pyro.load_global_eq(eq_file=eq_file, eq_type="GEQDSK", psi_n_lcfs=1.0)
+    # Load up pyro object
+    pyro = Pyro()
 
-pyro.load_global_kinetics(kinetics_file=kinetics_file, kinetics_type="JETTO", time=550)
+    pyro.load_global_eq(eq_file=eq_file, eq_type="GEQDSK", psi_n_lcfs=1.0)
 
-# Generate local parameters at psi_n=0.5
-pyro.load_local(psi_n=0.5, local_geometry="Miller")
+    pyro.load_global_kinetics(kinetics_file=kinetics_file, kinetics_type="JETTO", time=550)
 
-# Change GK code to GS2
-pyro.gk_code = "GS2"
+    # Generate local parameters at psi_n=0.5
+    pyro.load_local(psi_n=0.5, local_geometry="Miller")
 
-# GS2 template input file
-template_file = template_dir / "input.gs2"
+    # Select code as CGYRO
+    pyro.gk_code = "CGYRO"
 
-# Write single input file using my own template
-pyro.write_gk_file(file_name="test_jetto.gs2", template_file=template_file)
+    base_path = pathlib.Path(base_path)
 
-# Select code as CGYRO
-pyro.gk_code = "CGYRO"
+    # Write CGYRO input file using default template
+    pyro.write_gk_file(file_name=base_path / "test_jetto.cgyro")
 
-# Write CGYRO input file using default template
-pyro.write_gk_file(file_name="test_jetto.cgyro")
+    # Write single GS2 input file, specifying the code type
+    # in the call.
+    pyro.write_gk_file(file_name=base_path / "test_jetto.gs2", gk_code="GS2")
+
+    # Write single GENE input file, specifying the code type
+    # in the call.
+    pyro.write_gk_file(file_name=base_path / "test_jetto.gene", gk_code="GENE")
+
+    pyro.write_gk_file(file_name=base_path / "test_jetto.tglf", gk_code="TGLF")
+
+    return pyro
+
+
+if __name__ == "__main__":
+    main()

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -297,10 +297,11 @@ class GKInputCGYRO(GKInput):
             nion = local_species[key]["dens"]
             tion = local_species[key]["temp"]
             mion = local_species[key]["mass"]
+            zion = local_species[key]["z"]
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (nion / tion**1.5 / mion**0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
                 / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -239,10 +239,11 @@ class GKInputGENE(GKInput):
             nion = local_species[key]["dens"]
             tion = local_species[key]["temp"]
             mion = local_species[key]["mass"]
+            zion = local_species[key]["z"]
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (nion / tion**1.5 / mion**0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
                 / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -151,7 +151,7 @@ class GKInputTGLF(GKInput):
         miller = LocalGeometryMiller.from_gk_data(miller_data)
 
         beta = self.data["betae"]
-        miller.B0 = 1 / (beta ** 0.5) / miller.bunit_over_b0 if beta != 0 else None
+        miller.B0 = 1 / (beta**0.5) / miller.bunit_over_b0 if beta != 0 else None
 
         # FIXME: This actually needs to be scaled (or overwritten?) by
         # local_species.a_lp and self.data["BETA_STAR_SCALE"]. So we
@@ -160,7 +160,7 @@ class GKInputTGLF(GKInput):
             self.data["p_prime_loc"]
             * miller_data["rho"]
             / miller_data["q"]
-            * miller.bunit_over_b0 ** 2
+            * miller.bunit_over_b0**2
             * (8 * np.pi)
         )
 
@@ -222,8 +222,8 @@ class GKInputTGLF(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         local_species.normalise()
@@ -288,7 +288,7 @@ class GKInputTGLF(GKInput):
             self.data[value] = local_geometry[key]
 
         self.data["s_delta_loc"] = local_geometry.s_delta * np.sqrt(
-            1 - local_geometry.delta ** 2
+            1 - local_geometry.delta**2
         )
         self.data["q_prime_loc"] = (
             local_geometry.shat * (local_geometry.q / local_geometry.rho) ** 2
@@ -313,7 +313,7 @@ class GKInputTGLF(GKInput):
             local_geometry.beta_prime
             * local_geometry.q
             / local_geometry.rho
-            / local_geometry.bunit_over_b0 ** 2
+            / local_geometry.bunit_over_b0**2
             / (8 * np.pi)
         )
 

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -151,7 +151,7 @@ class GKInputTGLF(GKInput):
         miller = LocalGeometryMiller.from_gk_data(miller_data)
 
         beta = self.data["betae"]
-        miller.B0 = 1 / (beta**0.5) / miller.bunit_over_b0 if beta != 0 else None
+        miller.B0 = 1 / (beta ** 0.5) / miller.bunit_over_b0 if beta != 0 else None
 
         # FIXME: This actually needs to be scaled (or overwritten?) by
         # local_species.a_lp and self.data["BETA_STAR_SCALE"]. So we
@@ -160,7 +160,7 @@ class GKInputTGLF(GKInput):
             self.data["p_prime_loc"]
             * miller_data["rho"]
             / miller_data["q"]
-            * miller.bunit_over_b0**2
+            * miller.bunit_over_b0 ** 2
             * (8 * np.pi)
         )
 
@@ -222,8 +222,8 @@ class GKInputTGLF(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion**4 * nion / tion**1.5 / mion**0.5)
-                / (ne / te**1.5 / me**0.5)
+                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
+                / (ne / te ** 1.5 / me ** 0.5)
             ).m * nu_ee.units
 
         local_species.normalise()
@@ -288,7 +288,7 @@ class GKInputTGLF(GKInput):
             self.data[value] = local_geometry[key]
 
         self.data["s_delta_loc"] = local_geometry.s_delta * np.sqrt(
-            1 - local_geometry.delta**2
+            1 - local_geometry.delta ** 2
         )
         self.data["q_prime_loc"] = (
             local_geometry.shat * (local_geometry.q / local_geometry.rho) ** 2
@@ -313,7 +313,7 @@ class GKInputTGLF(GKInput):
             local_geometry.beta_prime
             * local_geometry.q
             / local_geometry.rho
-            / local_geometry.bunit_over_b0**2
+            / local_geometry.bunit_over_b0 ** 2
             / (8 * np.pi)
         )
 

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -218,10 +218,11 @@ class GKInputTGLF(GKInput):
             nion = local_species[key]["dens"]
             tion = local_species[key]["temp"]
             mion = local_species[key]["mass"]
+            zion = local_species[key]["z"]
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (nion / tion**1.5 / mion**0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
                 / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -228,7 +228,7 @@ class GKInputTGLF(GKInput):
 
         local_species.normalise()
 
-        local_species.zeff = self.data.get("ZEFF", 1.0) * ureg.elementary_charge
+        local_species.zeff = self.data.get("zeff", 1.0) * ureg.elementary_charge
 
         return local_species
 


### PR DESCRIPTION
When setting the collisionality of different ion species from CGYRO/GENE/TGLF, a factor of `Z**4` was missing.

This only impacts results where CGYRO/GENE/TGLF is converted to GS2.  Loading from profile data or a GS2 input file loads in the collisionality correctly. 

Converting between CGYRO/GENE/TGLF would also be fine as this gets the electron collision freq correct and that is what is needed.