### PR TITLE
Set squareness to zero when not specifeid in CGYRO input

### DIFF
--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -71,7 +71,7 @@ class GKInputCGYRO(GKInput):
         "q": 2.0,
         "kappa": 1.0,
         "s_kappa": 0.0,
-        "shat":1.0,
+        "shat": 1.0,
         "shift": 0.0,
     }
 
@@ -199,11 +199,13 @@ class GKInputCGYRO(GKInput):
         """
         miller_data = default_miller_inputs()
 
-        for (key, val), val_default in zip(self.pyro_cgyro_miller.items(), self.pyro_cgyro_miller_defaults.values()):
+        for (key, val), val_default in zip(
+            self.pyro_cgyro_miller.items(), self.pyro_cgyro_miller_defaults.values()
+        ):
             miller_data[key] = self.data.get(val, val_default)
 
-        miller_data["s_delta"] = self.data["S_DELTA"] / np.sqrt(
-            1 - self.data["DELTA"] ** 2
+        miller_data["s_delta"] = self.data.get("S_DELTA", 0.0) / np.sqrt(
+            1 - self.data.get("DELTA", 0.0) ** 2
         )
 
         # must construct using from_gk_data as we cannot determine bunit_over_b0 here
@@ -213,7 +215,7 @@ class GKInputCGYRO(GKInput):
         # FIXME Should not be modifying miller after creation
         beta = self.data["BETAE_UNIT"]
         if beta != 0:
-            miller.B0 = 1 / (miller.bunit_over_b0 * beta**0.5)
+            miller.B0 = 1 / (miller.bunit_over_b0 * beta ** 0.5)
         else:
             miller.B0 = None
 
@@ -222,7 +224,7 @@ class GKInputCGYRO(GKInput):
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
         if miller.B0 is not None:
-            miller.beta_prime = -local_species.a_lp * beta_prime_scale / miller.B0**2
+            miller.beta_prime = -local_species.a_lp * beta_prime_scale / miller.B0 ** 2
         else:
             miller.beta_prime = 0.0
 
@@ -234,7 +236,9 @@ class GKInputCGYRO(GKInput):
         """
         fourier_data = default_fourier_cgyro_inputs()
 
-        for (key, val), val_default in zip(self.pyro_cgyro_fourier.items(), self.pyro_cgyro_miller_defaults.values()):
+        for (key, val), val_default in zip(
+            self.pyro_cgyro_fourier.items(), self.pyro_cgyro_miller_defaults.values()
+        ):
             fourier_data[key] = self.data.get(val, val_default)
 
         # Add CGYRO mappings here
@@ -248,7 +252,7 @@ class GKInputCGYRO(GKInput):
         # FIXME B0 = None can cause problems when writing
         beta = self.data["BETAE_UNIT"]
         if beta != 0:
-            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta**0.5)
+            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta ** 0.5)
         else:
             fourier.B0 = None
 
@@ -258,7 +262,7 @@ class GKInputCGYRO(GKInput):
 
         if fourier.B0 is not None:
             fourier.beta_prime = (
-                -local_species.a_lp * beta_prime_scale / fourier.B0**2
+                -local_species.a_lp * beta_prime_scale / fourier.B0 ** 2
             )
         else:
             fourier.beta_prime = 0.0
@@ -324,8 +328,8 @@ class GKInputCGYRO(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion**4 * nion / tion**1.5 / mion**0.5)
-                / (ne / te**1.5 / me**0.5)
+                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
+                / (ne / te ** 1.5 / me ** 0.5)
             ).m * nu_ee.units
 
         if self.data.get("Z_EFF_METHOD", 2) == 2:
@@ -413,7 +417,7 @@ class GKInputCGYRO(GKInput):
                 self.data[val] = local_geometry[key]
 
             self.data["S_DELTA"] = local_geometry.s_delta * np.sqrt(
-                1 - local_geometry.delta**2
+                1 - local_geometry.delta ** 2
             )
 
         elif eq_type == "Fourier":
@@ -442,7 +446,7 @@ class GKInputCGYRO(GKInput):
         # Calculate beta_prime_scale
         if beta != 0.0:
             beta_prime_scale = -local_geometry.beta_prime / (
-                local_species.a_lp * beta * local_geometry.bunit_over_b0**2
+                local_species.a_lp * beta * local_geometry.bunit_over_b0 ** 2
             )
         else:
             beta_prime_scale = 1.0

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -71,7 +71,7 @@ class GKInputCGYRO(GKInput):
         "q": 2.0,
         "kappa": 1.0,
         "s_kappa": 0.0,
-        "shat":1.0,
+        "shat": 1.0,
         "shift": 0.0,
     }
 
@@ -199,7 +199,9 @@ class GKInputCGYRO(GKInput):
         """
         miller_data = default_miller_inputs()
 
-        for (key, val), val_default in zip(self.pyro_cgyro_miller.items(), self.pyro_cgyro_miller_defaults.values()):
+        for (key, val), val_default in zip(
+            self.pyro_cgyro_miller.items(), self.pyro_cgyro_miller_defaults.values()
+        ):
             miller_data[key] = self.data.get(val, val_default)
 
         miller_data["s_delta"] = self.data["S_DELTA"] / np.sqrt(
@@ -234,7 +236,9 @@ class GKInputCGYRO(GKInput):
         """
         fourier_data = default_fourier_cgyro_inputs()
 
-        for (key, val), val_default in zip(self.pyro_cgyro_fourier.items(), self.pyro_cgyro_miller_defaults.values()):
+        for (key, val), val_default in zip(
+            self.pyro_cgyro_fourier.items(), self.pyro_cgyro_miller_defaults.values()
+        ):
             fourier_data[key] = self.data.get(val, val_default)
 
         # Add CGYRO mappings here

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -215,7 +215,7 @@ class GKInputCGYRO(GKInput):
         # FIXME Should not be modifying miller after creation
         beta = self.data["BETAE_UNIT"]
         if beta != 0:
-            miller.B0 = 1 / (miller.bunit_over_b0 * beta ** 0.5)
+            miller.B0 = 1 / (miller.bunit_over_b0 * beta**0.5)
         else:
             miller.B0 = None
 
@@ -224,7 +224,7 @@ class GKInputCGYRO(GKInput):
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
         if miller.B0 is not None:
-            miller.beta_prime = -local_species.a_lp * beta_prime_scale / miller.B0 ** 2
+            miller.beta_prime = -local_species.a_lp * beta_prime_scale / miller.B0**2
         else:
             miller.beta_prime = 0.0
 
@@ -252,7 +252,7 @@ class GKInputCGYRO(GKInput):
         # FIXME B0 = None can cause problems when writing
         beta = self.data["BETAE_UNIT"]
         if beta != 0:
-            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta ** 0.5)
+            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta**0.5)
         else:
             fourier.B0 = None
 
@@ -262,7 +262,7 @@ class GKInputCGYRO(GKInput):
 
         if fourier.B0 is not None:
             fourier.beta_prime = (
-                -local_species.a_lp * beta_prime_scale / fourier.B0 ** 2
+                -local_species.a_lp * beta_prime_scale / fourier.B0**2
             )
         else:
             fourier.beta_prime = 0.0
@@ -328,8 +328,8 @@ class GKInputCGYRO(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         if self.data.get("Z_EFF_METHOD", 2) == 2:
@@ -417,7 +417,7 @@ class GKInputCGYRO(GKInput):
                 self.data[val] = local_geometry[key]
 
             self.data["S_DELTA"] = local_geometry.s_delta * np.sqrt(
-                1 - local_geometry.delta ** 2
+                1 - local_geometry.delta**2
             )
 
         elif eq_type == "Fourier":
@@ -446,7 +446,7 @@ class GKInputCGYRO(GKInput):
         # Calculate beta_prime_scale
         if beta != 0.0:
             beta_prime_scale = -local_geometry.beta_prime / (
-                local_species.a_lp * beta * local_geometry.bunit_over_b0 ** 2
+                local_species.a_lp * beta * local_geometry.bunit_over_b0**2
             )
         else:
             beta_prime_scale = 1.0

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -42,6 +42,19 @@ class GKInputCGYRO(GKInput):
         "shift": "SHIFT",
     }
 
+    pyro_cgyro_miller_defaults = {
+        "rho": 0.5,
+        "Rmaj": 3.0,
+        "q": 2.0,
+        "kappa": 1.0,
+        "s_kappa": 0.0,
+        "delta": 0.0,
+        "zeta": 0.0,
+        "s_zeta": 0.0,
+        "shat": 1.0,
+        "shift": 0.0,
+    }
+
     pyro_cgyro_fourier = {
         "rho": "RMIN",
         "Rmaj": "RMAJ",
@@ -50,6 +63,16 @@ class GKInputCGYRO(GKInput):
         "s_kappa": "S_KAPPA",
         "shat": "S",
         "shift": "SHIFT",
+    }
+
+    pyro_cgyro_fourier_defaults = {
+        "rho": 0.5,
+        "Rmaj": 3.0,
+        "q": 2.0,
+        "kappa": 1.0,
+        "s_kappa": 0.0,
+        "shat":1.0,
+        "shift": 0.0,
     }
 
     @staticmethod
@@ -176,8 +199,8 @@ class GKInputCGYRO(GKInput):
         """
         miller_data = default_miller_inputs()
 
-        for key, val in self.pyro_cgyro_miller.items():
-            miller_data[key] = self.data.get(val, 0)
+        for (key, val), val_default in zip(self.pyro_cgyro_miller.items(), self.pyro_cgyro_miller_defaults.values()):
+            miller_data[key] = self.data.get(val, val_default)
 
         miller_data["s_delta"] = self.data["S_DELTA"] / np.sqrt(
             1 - self.data["DELTA"] ** 2
@@ -211,8 +234,8 @@ class GKInputCGYRO(GKInput):
         """
         fourier_data = default_fourier_cgyro_inputs()
 
-        for key, val in self.pyro_cgyro_fourier.items():
-            fourier_data[key] = self.data[val]
+        for (key, val), val_default in zip(self.pyro_cgyro_fourier.items(), self.pyro_cgyro_miller_defaults.values()):
+            fourier_data[key] = self.data.get(val, val_default)
 
         # Add CGYRO mappings here
 

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -177,7 +177,7 @@ class GKInputCGYRO(GKInput):
         miller_data = default_miller_inputs()
 
         for key, val in self.pyro_cgyro_miller.items():
-            miller_data[key] = self.data[val]
+            miller_data[key] = self.data.get(val, 0)
 
         miller_data["s_delta"] = self.data["S_DELTA"] / np.sqrt(
             1 - self.data["DELTA"] ** 2

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -165,7 +165,7 @@ class GKInputGENE(GKInput):
 
         if miller.B0 is not None:
             miller.beta_prime = -self.data["geometry"].get("amhd", 0.0) / (
-                miller.q ** 2 * miller.Rmaj
+                miller.q**2 * miller.Rmaj
             )
 
         return miller
@@ -266,8 +266,8 @@ class GKInputGENE(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         local_species.zeff = (
@@ -356,7 +356,7 @@ class GKInputGENE(GKInput):
             self.data[gene_param][gene_key] = local_geometry[pyro_key]
 
         self.data["geometry"]["amhd"] = (
-            -(local_geometry.q ** 2) * local_geometry.Rmaj * local_geometry.beta_prime
+            -(local_geometry.q**2) * local_geometry.Rmaj * local_geometry.beta_prime
         )
         self.data["geometry"]["trpeps"] = local_geometry.rho / local_geometry.Rmaj
         self.data["geometry"]["minor_r"] = 1.0

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -145,7 +145,7 @@ class GKInputGENE(GKInput):
         ):
             miller_data[pyro_key] = self.data[gene_param].get(gene_key, gene_default)
 
-        #TODO Need to handle case where minor_r not defined
+        # TODO Need to handle case where minor_r not defined
         miller_data["Rmaj"] = self.data["geometry"].get("major_r", 1.0) / self.data[
             "geometry"
         ].get("minor_r", 1.0)

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -40,9 +40,26 @@ class GKInputGENE(GKInput):
         "shift": ["geometry", "drr"],
     }
 
+    pyro_gene_miller_default = {
+        "q": None,
+        "kappa": 1.0,
+        "s_kappa": 0.0,
+        "delta": 0.0,
+        "s_delta": 0.0,
+        "zeta": 0.0,
+        "s_zeta": 0.0,
+        "shat": 0.0,
+        "shift": 0.0,
+    }
+
     pyro_gene_circular = {
         "q": ["geometry", "q0"],
         "shat": ["geometry", "shat"],
+    }
+
+    pyro_gene_circular_default = {
+        "q": None,
+        "shat": 0.0,
     }
 
     pyro_gene_species = {
@@ -123,13 +140,17 @@ class GKInputGENE(GKInput):
         """
         miller_data = default_miller_inputs()
 
-        for pyro_key, (gene_param, gene_key) in self.pyro_gene_miller.items():
-            miller_data[pyro_key] = self.data[gene_param][gene_key]
+        for (pyro_key, (gene_param, gene_key)), gene_default in zip(
+            self.pyro_gene_miller.items(), self.pyro_gene_miller_default.values()
+        ):
+            miller_data[pyro_key] = self.data[gene_param].get(gene_key, gene_default)
 
-        miller_data["Rmaj"] = self.data["geometry"]["major_r"] / self.data[
+        miller_data["Rmaj"] = self.data["geometry"].get("major_r", 1.0) / self.data[
             "geometry"
         ].get("minor_r", 1.0)
-        miller_data["rho"] = self.data["geometry"]["trpeps"] * miller_data["Rmaj"]
+        miller_data["rho"] = (
+            self.data["geometry"].get("trpeps", 0.0) * miller_data["Rmaj"]
+        )
 
         # must construct using from_gk_data as we cannot determine bunit_over_b0 here
         miller = LocalGeometryMiller.from_gk_data(miller_data)
@@ -143,8 +164,8 @@ class GKInputGENE(GKInput):
             miller.B0 = None
 
         if miller.B0 is not None:
-            miller.beta_prime = -self.data["geometry"]["amhd"] / (
-                miller.q**2 * miller.Rmaj
+            miller.beta_prime = -self.data["geometry"].get("amhd", 0.0) / (
+                miller.q ** 2 * miller.Rmaj
             )
 
         return miller
@@ -160,10 +181,12 @@ class GKInputGENE(GKInput):
             circular_data[pyro_key] = self.data[gene_param][gene_key]
         circular_data["local_geometry"] = "Miller"
 
-        circular_data["Rmaj"] = self.data["geometry"]["major_r"] / self.data[
+        circular_data["Rmaj"] = self.data["geometry"].get("major_r", 1.0) / self.data[
             "geometry"
         ].get("minor_r", 1.0)
-        circular_data["rho"] = self.data["geometry"]["trpeps"] * circular_data["Rmaj"]
+        circular_data["rho"] = (
+            self.data["geometry"].get("trpeps", 0.0) * circular_data["Rmaj"]
+        )
 
         circular = LocalGeometryMiller.from_gk_data(circular_data)
 
@@ -243,8 +266,8 @@ class GKInputGENE(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion**4 * nion / tion**1.5 / mion**0.5)
-                / (ne / te**1.5 / me**0.5)
+                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
+                / (ne / te ** 1.5 / me ** 0.5)
             ).m * nu_ee.units
 
         local_species.zeff = (
@@ -333,7 +356,7 @@ class GKInputGENE(GKInput):
             self.data[gene_param][gene_key] = local_geometry[pyro_key]
 
         self.data["geometry"]["amhd"] = (
-            -(local_geometry.q**2) * local_geometry.Rmaj * local_geometry.beta_prime
+            -(local_geometry.q ** 2) * local_geometry.Rmaj * local_geometry.beta_prime
         )
         self.data["geometry"]["trpeps"] = local_geometry.rho / local_geometry.Rmaj
         self.data["geometry"]["minor_r"] = 1.0

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -145,6 +145,7 @@ class GKInputGENE(GKInput):
         ):
             miller_data[pyro_key] = self.data[gene_param].get(gene_key, gene_default)
 
+        #TODO Need to handle case where minor_r not defined
         miller_data["Rmaj"] = self.data["geometry"].get("major_r", 1.0) / self.data[
             "geometry"
         ].get("minor_r", 1.0)

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -37,6 +37,16 @@ class GKInputGS2(GKInput):
         "beta_prime": ["theta_grid_eik_knobs", "beta_prime_input"],
     }
 
+    pyro_gs2_miller_defaults = {
+        "rho": 0.5,
+        "Rmaj": 3.0,
+        "q": 1.5,
+        "kappa": 1.0,
+        "shat": 0.0,
+        "shift": 0.0,
+        "beta_prime": 0.0,
+    }
+
     pyro_gs2_species = {
         "mass": "mass",
         "z": "z",
@@ -160,16 +170,22 @@ class GKInputGS2(GKInput):
 
         miller_data = default_miller_inputs()
 
-        for pyro_key, (gs2_param, gs2_key) in self.pyro_gs2_miller.items():
-            miller_data[pyro_key] = self.data[gs2_param][gs2_key]
+        for (pyro_key, (gs2_param, gs2_key)), gs2_default in zip(
+            self.pyro_gs2_miller.items(), self.pyro_gs2_miller_defaults.values()
+        ):
+            miller_data[pyro_key] = self.data[gs2_param].get(gs2_key, gs2_default)
 
         rho = miller_data["rho"]
         kappa = miller_data["kappa"]
-        miller_data["delta"] = np.sin(self.data["theta_grid_parameters"]["tri"])
-        miller_data["s_kappa"] = (
-            self.data["theta_grid_parameters"]["akappri"] * rho / kappa
+        miller_data["delta"] = np.sin(
+            self.data["theta_grid_parameters"].get("tri", 0.0)
         )
-        miller_data["s_delta"] = self.data["theta_grid_parameters"]["tripri"] * rho
+        miller_data["s_kappa"] = (
+            self.data["theta_grid_parameters"].get("akappri", 0.0) * rho / kappa
+        )
+        miller_data["s_delta"] = (
+            self.data["theta_grid_parameters"].get("tripri", 0.0) * rho
+        )
 
         # Get beta and beta_prime normalised to R_major(in case R_geo != R_major)
         r_geo = self.data["theta_grid_parameters"].get("r_geo", miller_data["Rmaj"])

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -166,7 +166,7 @@ class GKInputTGLF(GKInput):
         miller = LocalGeometryMiller.from_gk_data(miller_data)
 
         beta = self.data.get("betae", 0.0)
-        miller.B0 = 1 / (beta ** 0.5) / miller.bunit_over_b0 if beta != 0 else None
+        miller.B0 = 1 / (beta**0.5) / miller.bunit_over_b0 if beta != 0 else None
 
         # FIXME: This actually needs to be scaled (or overwritten?) by
         # local_species.a_lp and self.data["BETA_STAR_SCALE"]. So we
@@ -175,7 +175,7 @@ class GKInputTGLF(GKInput):
             self.data.get("q_prime_loc", 16.0)
             * miller_data["rho"]
             / miller_data["q"]
-            * miller.bunit_over_b0 ** 2
+            * miller.bunit_over_b0**2
             * (8 * np.pi)
         )
 
@@ -237,8 +237,8 @@ class GKInputTGLF(GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         local_species.normalise()
@@ -303,7 +303,7 @@ class GKInputTGLF(GKInput):
             self.data[value] = local_geometry[key]
 
         self.data["s_delta_loc"] = local_geometry.s_delta * np.sqrt(
-            1 - local_geometry.delta ** 2
+            1 - local_geometry.delta**2
         )
         self.data["q_prime_loc"] = (
             local_geometry.shat * (local_geometry.q / local_geometry.rho) ** 2
@@ -328,7 +328,7 @@ class GKInputTGLF(GKInput):
             local_geometry.beta_prime
             * local_geometry.q
             / local_geometry.rho
-            / local_geometry.bunit_over_b0 ** 2
+            / local_geometry.bunit_over_b0**2
             / (8 * np.pi)
         )
 


### PR DESCRIPTION
The squareness is not always specified in CGYRO input file, especially if generated with a previous version of `pyrokinetics`. In this case, the squareness should be set to zero. 