### PR TITLE
Set Jinja version limit in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ sphinx==3.5.4
 myst_parser==0.14.0
 cleverdict>=1.9.1
 xarray>=0.10
+jinja2 < 3.1.0
 # Not required for Python>=3.8, but included because conda does not support
 # conditional expressions in --file arguments.
 # This file should only be used by developers, so the odd extra package is not


### PR DESCRIPTION
Set `jinja2 < 3.1` in `requirements.txt` due to import error when setting up readthedocs

https://readthedocs.org/projects/pyrokinetics/builds/19084114/

Issue outlined here

https://github.com/readthedocs/readthedocs.org/issues/9038

Do we need both `requirements.txt` and the `setup.cfg`