### PR TITLE
Switched out freegs._geqdsk for freeqdsk.geqdsk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "numpy >= 1.20.3",
+    "matplotlib >= 3.6",
     "f90nml >= 1.4.2",
     "scipy >= 1.9.3",
     "netCDF4 >= 1.5.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "matplotlib >= 3.6",
     "f90nml >= 1.4.2",
     "scipy >= 1.9.3",
+    "h5py >= 2.10",
     "netCDF4 >= 1.5.6",
     "path >= 15.1.2",
     "wheel >= 0.36",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ classifiers = [
 
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >= 1.20.3, < 1.24",
+    "numpy >= 1.20.3",
     "f90nml >= 1.4.2",
     "scipy >= 1.9.3",
     "netCDF4 >= 1.5.6",
     "path >= 15.1.2",
     "wheel >= 0.36",
-    "freegs >= 0.6",
+    "freeqdsk == 0.1.*",
     "cleverdict >= 1.9.1",
     "xarray >= 0.10",
     "pint ~= 0.20.1",

--- a/pyrokinetics/equilibrium/geqdsk.py
+++ b/pyrokinetics/equilibrium/geqdsk.py
@@ -7,7 +7,7 @@ from ..typing import PathLike
 from ..units import ureg as units
 
 import numpy as np
-from freegs import _geqdsk
+from freeqdsk import geqdsk
 
 
 @equilibrium_reader("GEQDSK")
@@ -48,7 +48,7 @@ class EquilibriumReaderGEQDSK(Reader):
 
         # Get geqdsk data in a dict
         with redirect_stdout(None), open(filename) as f:
-            data = _geqdsk.read(f)
+            data = geqdsk.read(f)
 
         # Get RZ grids
         # G-EQDSK uses linearly spaced grids, which we must build ourselves.
@@ -150,9 +150,9 @@ class EquilibriumReaderGEQDSK(Reader):
 
     def verify(self, filename: PathLike) -> None:
         """Quickly verify that we're looking at a GEQDSK file without processing"""
-        # Try opening the GEQDSK file using freegs._geqdsk
+        # Try opening the GEQDSK file using freeqdsk.geqdsk
         with redirect_stdout(None), open(filename) as f:
-            data = _geqdsk.read(f)
+            data = geqdsk.read(f)
         # Check that the correct variables exist
         var_names = ["nx", "ny", "simagx", "sibdry", "rmagx", "zmagx"]
         if not np.all(np.isin(var_names, list(data.keys()))):


### PR DESCRIPTION
We just released [FreeQDSK 0.1](https://pypi.org/project/freeqdsk/), so this PR opts to use that to read GEQDSK files instead of FreeGS. It's the same functions from FreeGS spun off into a small utility library, so nothing in Pyrokinetics needs to be fundamentally changed to accommodate this. An immediate advantage of this is that it allows us to use the latest NumPy release (1.24), which is incompatible with the latest FreeGS release on PyPI (0.6). In the long term, it'll also be easier to develop FreeQDSK if we want to add new features.