### PR TITLE
Handle case when electron is last species

### DIFF
--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -447,22 +447,21 @@ class GKInputGS2(GKInput):
 
         # Set local species bits
         self.data["species_knobs"]["nspec"] = local_species.nspec
+
         for iSp, name in enumerate(local_species.names):
             # add new outer params for each species
             species_key = f"species_parameters_{iSp + 1}"
 
+            if species_key not in self.data:
+                self.data[species_key] = copy(self.data["species_parameters_1"])
+                self.data[f"dist_fn_species_knobs_{iSp + 1}"] = self.data[
+                    f"dist_fn_species_knobs_{iSp}"
+                    ]
+
             if name == "electron":
                 self.data[species_key]["type"] = "electron"
             else:
-                try:
-                    self.data[species_key]["type"] = "ion"
-                except KeyError:
-                    self.data[species_key] = copy(self.data["species_parameters_1"])
-                    self.data[species_key]["type"] = "ion"
-
-                    self.data[f"dist_fn_species_knobs_{iSp + 1}"] = self.data[
-                        f"dist_fn_species_knobs_{iSp}"
-                    ]
+                self.data[species_key]["type"] = "ion"
 
             for key, val in self.pyro_gs2_species.items():
                 self.data[species_key][val] = local_species[name][key]

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -456,7 +456,7 @@ class GKInputGS2(GKInput):
                 self.data[species_key] = copy(self.data["species_parameters_1"])
                 self.data[f"dist_fn_species_knobs_{iSp + 1}"] = self.data[
                     f"dist_fn_species_knobs_{iSp}"
-                    ]
+                ]
 
             if name == "electron":
                 self.data[species_key]["type"] = "electron"


### PR DESCRIPTION
If electron is last species in `LocalSpecies` and there are more species than in the template namelist an error occurs when we try to convert to GS2. A KeyError is raised because the species namelist hasn't been added and this was only checked for ion species, not electron species.

This just checks to see if the species namelist exists and if not creates it for all species.