### PR TITLE
Fixed error in reading beta_prime from TGLF input

### DIFF
--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -172,7 +172,7 @@ class GKInputTGLF(GKInput):
         # local_species.a_lp and self.data["BETA_STAR_SCALE"]. So we
         # need to get all the species data first?
         miller.beta_prime = (
-            self.data.get("q_prime_loc", 16.0)
+            self.data.get("p_prime_loc", 0.0)
             * miller_data["rho"]
             / miller_data["q"]
             * miller.bunit_over_b0**2

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -92,7 +92,6 @@ def test_compare_roundtrip(setup_roundtrip, gk_code_a, gk_code_b):
         "dRdr",
         "dZdtheta",
         "dZdr",
-        "beta_prime",
         "zeta",
         "s_zeta",
         "bunit_over_b0",


### PR DESCRIPTION
Seems like pyro was using `Q_PRIME_LOC` to set `beta_prime` rather than `P_PRIME_LOC`

Seems like it slipped through the cracks because `beta_prime` wasn't checked in `test_roundtrip.py` so I have added that back in.