### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ $ pip install -e .[tests]
 $ pytest --cov .
 ```
 
+## Basic Usage
+
+The simplest action in Pyrokinetics is to convert a gyrokinetics input file for code
+'X' into an equivalent input file for code 'Y'. The easiest way to achieve this is to
+use a `Pyro` object, which manages the various other classes in the API. For example,
+to convert a GS2 input file to a CGYRO input file:
+
+```python
+>>> from pyrokinetics import Pyro
+>>> pyro = Pyro(gk_file="my_gs2_file.in") # file type is automatically inferred
+>>> pyro.write_gk_file("input.cgyro", gk_code="CGYRO")
+```
+
+There are many other features in Pyrokinetics, such as methods for building gyrokinetics
+input files using global plasma equilibria and/or kinetics profiles. There are also
+methods for analysing and comparing the results from gyrokinetics code runs. Please
+[read the docs](https://pyrokinetics.readthedocs.io/en/latest/#) for more information.
+
 ## Command Line Interface
 
 After installing, simple pyrokinetics operations can be performed on the command line

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ $ pip install -e .[tests]
 $ pytest --cov .
 ```
 
+## Command Line Interface
+
+After installing, simple pyrokinetics operations can be performed on the command line
+using either of the following methods:
+
+```bash
+$ python3 -m pyrokinetics {args...}
+$ pyro {args...}
+```
+
+For example, to convert a GS2 input file to CGYRO:
+
+```bash
+$ pyro convert CGYRO "my_gs2_file.in" -o "input.cgyro"
+```
+
+You can get help on how to use the command line interface or any of its subcommands
+by providing `-h` or `--help`:
+
+```bash
+$ pyro --help
+$ pyro convert --help
+```
+
 ## Code structure 
 
 Pyro object comprised of 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,26 @@ If you are developing pyrokinetics:
   $ pip install -e .[docs,tests]
 
 
+Command Line Interface
+----------------------
+
+After installing, simple pyrokinetics operations can be performed on the command line
+using either of the following methods::
+
+    $ python3 -m pyrokinetics {args...}
+    $ pyro {args...}
+
+For example, to convert a GS2 input file to CGYRO::
+
+    $ pyro convert CGYRO "my_gs2_file.in" -o "input.cgyro"
+
+You can get help on how to use the command line interface or any of its subcommands
+by providing ``-h`` or ``--help``::
+
+    $ pyro --help
+    $ pyro convert --help
+
+
 Structure
 ---------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ Source = "https://github.com/pyro-kinetics/pyrokinetics"
 Tracker = "https://github.com/pyro-kinetics/pyrokinetics/issues"
 Documentation = "https://pyrokinetics.readthedocs.io/en/latest/"
 
+[project.scripts]
+pyro = "pyrokinetics.cli:entrypoint"
 
 [build-system]
 requires = [

--- a/pyrokinetics/__main__.py
+++ b/pyrokinetics/__main__.py
@@ -1,0 +1,3 @@
+from .cli import entrypoint
+
+entrypoint()

--- a/pyrokinetics/cli/__init__.py
+++ b/pyrokinetics/cli/__init__.py
@@ -1,0 +1,1 @@
+from .entrypoint import entrypoint

--- a/pyrokinetics/cli/convert.py
+++ b/pyrokinetics/cli/convert.py
@@ -11,7 +11,12 @@ def add_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         "target",
         type=str,
-        help="The target gyrokinetics code, e.g. 'GS2', 'CGYRO'.",
+        help=dedent(
+            f"""\
+            The target gyrokinetics code. Options include
+            {', '.join(Pyro().supported_gk_inputs)}.
+            """
+        ),
     )
 
     parser.add_argument(
@@ -32,8 +37,8 @@ def add_arguments(parser: ArgumentParser) -> None:
         type=str,
         help=dedent(
             """\
-            The type of flux surface geometry to convert to. Options include 'Miller' or
-            'Fourier'.
+            The type of flux surface geometry to convert to. Options currently include
+            Miller (all), MillerTurnbull (GENE) and MXH (CGYRO, TGLF).
             """
         ),
     )
@@ -44,10 +49,11 @@ def add_arguments(parser: ArgumentParser) -> None:
         "-e",
         type=Path,
         help=dedent(
-            """\
+            f"""\
             Path to a plasma equilibrium file, which is used to overwrite the flux
             surface in 'input_file'. Users should also provide 'psi' to select which
-            flux surface to use from the equilibrium.
+            flux surface to use from the equilibrium. The supported equilibrium types
+            are {', '.join(Pyro().supported_equilibrium_types)}.
             """
         ),
     )
@@ -64,10 +70,11 @@ def add_arguments(parser: ArgumentParser) -> None:
         "-k",
         type=Path,
         help=dedent(
-            """\
+            f"""\
             Path to a plasma kinetics file, which is used to overwrite the local species
             data in 'input_file'. Users should also provide 'psi' and 'a_minor' to
-            select which flux surface to use, or provide 'psi' and 'equilibrium'.
+            select which flux surface to use, or provide 'psi' and 'equilibrium'. The
+            supported kinetcs types are {', '.join(Pyro().supported_kinetics_types)}.
             """
         ),
     )

--- a/pyrokinetics/cli/convert.py
+++ b/pyrokinetics/cli/convert.py
@@ -1,0 +1,146 @@
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from textwrap import dedent
+
+from pyrokinetics import Pyro
+
+description = "Convert a gyrokinetics input file to a different code."
+
+
+def add_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "target",
+        type=str,
+        help="The target gyrokinetics code, e.g. 'GS2', 'CGYRO'.",
+    )
+
+    parser.add_argument(
+        "input_file",
+        type=Path,
+        help="The gyrokinetics config file you wish to convert.",
+    )
+
+    parser.add_argument(
+        "--input_type",
+        type=str,
+        help="The code type of the input file. If not provided, this will be inferred.",
+    )
+
+    parser.add_argument(
+        "--equilibrium",
+        "--eq",
+        "-e",
+        type=Path,
+        help=dedent(
+            """\
+            Path to a plasma equilibrium file, which is used to overwrite the flux
+            surface in 'input_file'. Users should also provide 'psi' to select which
+            flux surface to use from the equilibrium.
+            """
+        ),
+    )
+
+    parser.add_argument(
+        "--equilibrium_type",
+        "--eq_type",
+        type=str,
+        help="The type of equilibrium file. If not provided, this is inferred.",
+    )
+
+    parser.add_argument(
+        "--kinetics",
+        "-k",
+        type=Path,
+        help=dedent(
+            """\
+            Path to a plasma kinetics file, which is used to overwrite the local species
+            data in 'input_file'. Users should also provide 'psi' and 'a_minor' to
+            select which flux surface to use, or provide 'psi' and 'equilibrium'.
+            """
+        ),
+    )
+
+    parser.add_argument(
+        "--kinetics_type",
+        "--k_type",
+        type=str,
+        help="The type of kinetics file. If not provided, this is inferred.",
+    )
+
+    parser.add_argument(
+        "--psi",
+        "-p",
+        type=float,
+        help=dedent(
+            """\
+            The normalised poloidal flux function, used to index which flux surface to
+            draw equilibrium/kinetics data from. Should be in the range [0,1], with 0
+            being the magnetic axis, and 1 being the last closed flux surface.
+            """
+        ),
+    )
+
+    parser.add_argument(
+        "--a_minor",
+        "-a",
+        type=float,
+        help=dedent(
+            """\
+            The width of the last closed flux surface, in meters. Used to select a flux
+            surface when providing kinetics data but no equilibrium. Otherwise, this
+            argument is ignored.
+            """
+        ),
+    )
+
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Name of the new gyrokinetics config file.",
+    )
+
+    parser.add_argument(
+        "--template",
+        "-t",
+        type=Path,
+        help="Template file to use for the new gyrokinetics config file.",
+    )
+
+
+def main(args: Namespace) -> None:
+    # Handle illegal combinations of optional args
+    if args.equilibrium is not None and args.psi is None:
+        raise ValueError("If providing an equilibrium file, must also provide psi")
+
+    if args.kinetics is not None and args.psi is None:
+        raise ValueError("If providing a kinetics file, must also provide psi")
+
+    if args.kinetics is not None and args.equilibrium is None and args.a_minor is None:
+        raise ValueError(
+            "If providing a kinetics file without an equilibrium, "
+            "must also provide a_minor"
+        )
+
+    # Create a pyro object with just gk info
+    pyro = Pyro(gk_file=args.input_file, gk_code=args.input_type)
+
+    # Modify local geometry
+    if args.equilibrium is not None:
+        pyro.load_global_eq(eq_file=args.equilibrium, eq_type=args.equilibrium_type)
+        pyro.load_local_geometry(psi_n=args.psi)
+
+    # Modify local species
+    if args.kinetics is not None:
+        pyro.load_global_kinetics(
+            kinetics_file=args.kinetics,
+            kinetics_type=args.kinetics_type,
+        )
+        pyro.load_local_species(
+            psi_n=args.psi,
+            a_minor=(args.a_minor if args.equilibrium is None else None),
+        )
+
+    # Convert and write
+    filename = f"input.{args.target}".lower() if args.output is None else args.output
+    pyro.write_gk_file(filename, gk_code=args.target, template_file=args.template)

--- a/pyrokinetics/cli/convert.py
+++ b/pyrokinetics/cli/convert.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from textwrap import dedent
 
 from pyrokinetics import Pyro
-from pyrokinetics.local_geometry import LocalGeometryMiller, LocalGeometryFourierCGYRO
 
 description = "Convert a gyrokinetics input file to a different code."
 

--- a/pyrokinetics/cli/convert.py
+++ b/pyrokinetics/cli/convert.py
@@ -156,30 +156,7 @@ def main(args: Namespace) -> None:
 
     # Convert local geometry type
     if args.geometry is not None:
-        # TODO Current PR introduces MillerTurnbull for GENE, sets MXH as the CGYRO
-        # Miller variant, etc. This will need to be updated.
-        # TODO GENE fourier not yet in use.
-
-        # Map between input geometry types and the target key within
-        # local_geometry.local_geometries
-        geometries = {
-            "GS2": {"Miller": "Miller"},
-            "GENE": {"Miller": "Miller"},
-            "CGYRO": {"Miller": "Miller", "Fourier": "FourierCGYRO"},
-            "TGLF": {"Miller": "Miller"},
-        }
-        try:
-            geometry = geometries[args.target.upper()][args.geometry]
-        except KeyError:
-            raise ValueError(
-                dedent(
-                    f"""\
-                    There is no geometry {args.geometry} associated with the target
-                    {args.target}
-                    """
-                )
-            )
-        pyro.switch_local_geometry(local_geometry=geometry)
+        pyro.switch_local_geometry(local_geometry=args.geometry)
 
     # Convert and write
     filename = f"input.{args.target}".lower() if args.output is None else args.output

--- a/pyrokinetics/cli/entrypoint.py
+++ b/pyrokinetics/cli/entrypoint.py
@@ -1,0 +1,53 @@
+from argparse import ArgumentParser
+from textwrap import dedent
+
+from .convert import (
+    add_arguments as convert_add_arguments,
+    description as convert_description,
+    main as convert_main,
+)
+
+
+def entrypoint() -> None:
+    """
+    The entrypoint for the Command Line Interface (CLI). Uses ``argparse`` to handle
+    command line arguments, and makes use of subparsers to delegate tasks across
+    multiple functions.
+    """
+
+    # Set up ArgumentParser and subparsers
+    parser = ArgumentParser(
+        prog="Pyrokinetics",
+        description="A tool to run and analyse gyrokinetics simulations.",
+    )
+    subparsers = parser.add_subparsers(
+        description=dedent(
+            """\
+            Please provide one of the following subcommands as a positional argument.
+            For information on how each subcommand works, try providing '--help' after
+            the subcommand.
+            """
+        ),
+        dest="subcommand",
+    )
+
+    # Add a subparser for each subcommand. These should provide a short description
+    # string, and two functions:
+    # - add_arguments(parser): Add arguments to their own subparser. Takes the subparser
+    #   as its only argument.
+    # - main(args): Run the subroutine. Takes an argparse Namespace object as the only
+    #   argument, and must unpack the Namespace itself.
+    # The parser should then set it's default 'main' arg to the corresponding main
+    # function, and the add_arguments function should set up the required arguments.
+    convert_parser = subparsers.add_parser("convert", help=convert_description)
+    convert_parser.set_defaults(main=convert_main)
+    convert_add_arguments(convert_parser)
+
+    args = parser.parse_args()
+
+    # If user provided no subcommand, print help text
+    if args.subcommand is None:
+        parser.print_help()
+        parser.exit()
+
+    args.main(args)

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,0 +1,113 @@
+import sys
+from difflib import unified_diff
+from pathlib import Path
+
+import pytest
+
+import pyrokinetics as pk
+from pyrokinetics.cli import entrypoint
+
+
+_geometries = {
+    "GS2" : "Miller",
+    "CGYRO": "MXH",
+    "TGLF": "MXH",
+    "GENE": "MillerTurnbull",
+}
+
+_long_opts = {
+    "a": "a_minor",
+    "e": "equilibrium",
+    "g": "geometry",
+    "k": "kinetics",
+    "p": "psi",
+    "o": "output",
+}
+
+def opt(name: str, long: bool):
+    return f"--{_long_opts[name]}" if long else f"-{name}"
+
+eq_type = "GEQDSK"
+eq_file = pk.eq_templates[eq_type]
+k_type = "JETTO"
+k_file = pk.kinetics_templates[k_type]
+
+@pytest.mark.parametrize(
+    "gk_input,gk_output,eq,kinetics,switch_geometry,long_opts,explicit_types",
+    [
+        ("GENE", "GS2", None, None, False, False, False),
+        ("GS2", "GENE", eq_file, k_file, True, False, False),
+        ("GS2", "CGYRO", None, None, True, False, True),
+        ("CGYRO", "GENE", None, k_file, False, True, False),
+        ("CGYRO", "GS2", eq_file, None, True, True, True),
+        ("CGYRO", "TGLF", None, None, False, False, False),
+        ("TGLF", "GS2", eq_file, k_file, False, False, False),
+    ]
+)
+def test_convert(gk_input, gk_output, eq, kinetics, switch_geometry, long_opts, explicit_types, tmp_path):
+    # TODO Tests only a small subset of all possible combinations. The whole matrix
+    #      can take up to 10 minutes!
+    # TODO Not testing template options
+    # TODO Not testing with TGLF while switching geomtry to MXH, as this functionality
+    #      seems to be bugged at the time of writing.
+    # Create directory to work in
+    d = tmp_path / "test_convert"
+    d.mkdir(exist_ok=True)
+    
+    # Get input file and output file names
+    file_in = pk.gk_templates[gk_input]
+    file_out = d / f"result.{gk_output.lower()}"
+    file_out_cli = d / f"result_cli.{gk_output.lower()}"
+
+    # Get input types, if needed
+    if explicit_types:
+        gk_type = gk_input
+        eq_type = "GEQDSK"
+        k_type = "JETTO"
+    else:
+        gk_type = None
+        eq_type = None
+        k_type = None
+
+    # Perform conversion using Python API
+    pyro = pk.Pyro(gk_file=file_in, gk_code=gk_type, eq_file=eq, eq_type=eq_type, kinetics_file=kinetics, kinetics_type=k_type)
+    if eq is not None:
+        pyro.load_local_geometry(psi_n=0.9)
+    if kinetics is not None:
+        pyro.load_local_species(psi_n=0.9, a_minor=3.0 if eq is None else None)
+    if switch_geometry:
+        geometry = _geometries[gk_output]
+        pyro.switch_local_geometry(geometry)
+    pyro.write_gk_file(file_out, gk_code=gk_output)
+
+    # Perform conversion using cli tool
+    with pytest.MonkeyPatch.context() as m:
+        argv = ["pyro", "convert", gk_output, str(file_in)]
+        argv.extend([opt("o", long_opts), str(file_out_cli)])
+        if explicit_types:
+            argv.extend(["--input_type", str(gk_input)])
+        if eq is not None:
+            argv.extend([opt("e", long_opts), str(eq)])
+            argv.extend([opt("p", long_opts), str(0.9)])
+            if explicit_types:
+                argv.extend(["--eq_type", "GEQDSK"])
+        if kinetics is not None:
+            argv.extend([opt("k", long_opts), str(kinetics)])
+            if explicit_types:
+                argv.extend(["--kinetics_type", "JETTO"])
+            if eq is None:
+                argv.extend([opt("p", long_opts), str(0.9)])
+                argv.extend([opt("a", long_opts), str(3.0)])
+        if switch_geometry:
+            argv.extend([opt("g", long_opts), geometry])
+        m.setattr(sys, "argv", argv)
+        entrypoint()
+
+    # Expect the files match
+    # Is this condition too strict? Not sure how else to test without writing
+    # individual tests for each combination of gk in, gk out, eq, kinetics, and geometry
+    with open(file_out_cli) as f_results, open(file_out) as f_expected:
+        results = f_results.readlines()
+        expected = f_expected.readlines()
+    diff = [*unified_diff(results, expected)]
+    assert not diff

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,18 +1,14 @@
 import sys
 from difflib import unified_diff
+from itertools import product
+from pathlib import Path
+from typing import Optional
 
 import pytest
 
 import pyrokinetics as pk
 from pyrokinetics.cli import entrypoint
 
-
-_geometries = {
-    "GS2": "Miller",
-    "CGYRO": "MXH",
-    "TGLF": "MXH",
-    "GENE": "MillerTurnbull",
-}
 
 _long_opts = {
     "a": "a_minor",
@@ -28,49 +24,20 @@ def opt(name: str, long: bool):
     return f"--{_long_opts[name]}" if long else f"-{name}"
 
 
-eq_type = "GEQDSK"
-eq_file = pk.eq_templates[eq_type]
-k_type = "JETTO"
-k_file = pk.kinetics_templates[k_type]
-
-
-@pytest.mark.parametrize(
-    "gk_input,gk_output,eq,kinetics,switch_geometry,long_opts,explicit_types",
-    [
-        ("GENE", "GS2", None, None, False, False, False),
-        ("GS2", "GENE", eq_file, k_file, True, False, False),
-        ("GS2", "CGYRO", None, None, True, False, True),
-        ("CGYRO", "GENE", None, k_file, False, True, False),
-        ("CGYRO", "GS2", eq_file, None, True, True, True),
-        ("CGYRO", "TGLF", None, None, False, False, False),
-        ("TGLF", "GS2", eq_file, k_file, False, False, False),
-    ],
-)
-def test_convert(
-    gk_input,
-    gk_output,
-    eq,
-    kinetics,
-    switch_geometry,
-    long_opts,
-    explicit_types,
-    tmp_path,
-):
-    # TODO Tests only a small subset of all possible combinations. The whole matrix
-    #      can take up to 10 minutes!
-    # TODO Not testing template options
-    # TODO Not testing with TGLF while switching geomtry to MXH, as this functionality
-    #      seems to be bugged at the time of writing.
-    # Create directory to work in
-    d = tmp_path / "test_convert"
-    d.mkdir(exist_ok=True)
-
-    # Get input file and output file names
+def convert_with_python(
+    gk_input: str,
+    gk_output: str,
+    output_dir: Path,
+    eq_file: Optional[Path] = None,
+    kinetics_file: Optional[Path] = None,
+    local_geometry: Optional[str] = None,
+    explicit_types: bool = False,
+    base_case: bool = False,
+) -> Path:
+    """
+    Performs conversion via Pyro object within Python
+    """
     file_in = pk.gk_templates[gk_input]
-    file_out = d / f"result.{gk_output.lower()}"
-    file_out_cli = d / f"result_cli.{gk_output.lower()}"
-
-    # Get input types, if needed
     if explicit_types:
         gk_type = gk_input
         eq_type = "GEQDSK"
@@ -84,48 +51,204 @@ def test_convert(
     pyro = pk.Pyro(
         gk_file=file_in,
         gk_code=gk_type,
-        eq_file=eq,
+        eq_file=eq_file,
         eq_type=eq_type,
-        kinetics_file=kinetics,
+        kinetics_file=kinetics_file,
         kinetics_type=k_type,
     )
-    if eq is not None:
+    if eq_file is not None:
         pyro.load_local_geometry(psi_n=0.9)
-    if kinetics is not None:
-        pyro.load_local_species(psi_n=0.9, a_minor=3.0 if eq is None else None)
-    if switch_geometry:
-        geometry = _geometries[gk_output]
-        pyro.switch_local_geometry(geometry)
-    pyro.write_gk_file(file_out, gk_code=gk_output)
+    if kinetics_file is not None:
+        pyro.load_local_species(psi_n=0.9, a_minor=3.0 if eq_file is None else None)
+    if local_geometry is not None:
+        pyro.switch_local_geometry(local_geometry)
 
-    # Perform conversion using cli tool
+    if base_case:
+        file_out = output_dir / f"result_base.{gk_output.lower()}"
+    else:
+        file_out = output_dir / f"result.{gk_output.lower()}"
+    pyro.write_gk_file(file_out, gk_code=gk_output)
+    return file_out
+
+
+def convert_with_cli(
+    gk_input: str,
+    gk_output: str,
+    output_dir: Path,
+    eq_file: Optional[Path] = None,
+    kinetics_file: Optional[Path] = None,
+    local_geometry: Optional[str] = None,
+    long_opts: bool = False,
+    explicit_types: bool = False,
+) -> Path:
+    """
+    Performs conversion via CLI convert tool
+    """
+    file_in = pk.gk_templates[gk_input]
+    file_out = output_dir / f"result_cli.{gk_output.lower()}"
     with pytest.MonkeyPatch.context() as m:
         argv = ["pyro", "convert", gk_output, str(file_in)]
-        argv.extend([opt("o", long_opts), str(file_out_cli)])
+        argv.extend([opt("o", long_opts), str(file_out)])
         if explicit_types:
             argv.extend(["--input_type", str(gk_input)])
-        if eq is not None:
-            argv.extend([opt("e", long_opts), str(eq)])
+        if eq_file is not None:
+            argv.extend([opt("e", long_opts), str(eq_file)])
             argv.extend([opt("p", long_opts), str(0.9)])
             if explicit_types:
                 argv.extend(["--eq_type", "GEQDSK"])
-        if kinetics is not None:
-            argv.extend([opt("k", long_opts), str(kinetics)])
+        if kinetics_file is not None:
+            argv.extend([opt("k", long_opts), str(kinetics_file)])
             if explicit_types:
                 argv.extend(["--kinetics_type", "JETTO"])
-            if eq is None:
+            if eq_file is None:
                 argv.extend([opt("p", long_opts), str(0.9)])
                 argv.extend([opt("a", long_opts), str(3.0)])
-        if switch_geometry:
-            argv.extend([opt("g", long_opts), geometry])
+        if local_geometry is not None:
+            argv.extend([opt("g", long_opts), local_geometry])
         m.setattr(sys, "argv", argv)
         entrypoint()
+    return file_out
 
-    # Expect the files match
+
+def files_match(result: Path, expected: Path, base_case: Optional[Path] = None):
+    # Assert the files match
     # Is this condition too strict? Not sure how else to test without writing
-    # individual tests for each combination of gk in, gk out, eq, kinetics, and geometry
-    with open(file_out_cli) as f_results, open(file_out) as f_expected:
-        results = f_results.readlines()
-        expected = f_expected.readlines()
-    diff = [*unified_diff(results, expected)]
+    # individual tests for each combination of gk_input and gk_output
+    with open(result) as f_result, open(expected) as f_expected:
+        result_lines = f_result.readlines()
+        expected_lines = f_expected.readlines()
+    diff = [*unified_diff(result_lines, expected_lines)]
     assert not diff
+
+    if base_case is not None:
+        # Assert the files don't match the base case.
+        # This should be used when testing with optional features, to ensure they
+        # are having an affect on the results
+        with open(base_case) as f_base:
+            base_lines = f_base.readlines()
+        base_diff = [*unified_diff(result_lines, base_lines)]
+        assert base_diff
+
+
+@pytest.mark.parametrize(
+    "gk_input,gk_output",
+    product(
+        pk.Pyro().supported_gk_inputs,
+        pk.Pyro().supported_gk_inputs,
+    ),
+)
+def test_convert(gk_input, gk_output, tmp_path):
+    # Create directory to work in
+    d = tmp_path / "test_convert"
+    d.mkdir(exist_ok=True)
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python(gk_input, gk_output, output_dir=d)
+    file_out_cli = convert_with_cli(gk_input, gk_output, output_dir=d)
+    files_match(file_out, file_out_cli)
+
+
+@pytest.mark.parametrize("eq", ["GEQDSK", "TRANSP"])
+def test_convert_with_eq(eq, tmp_path):
+    # Create directory to work in
+    d = tmp_path / "test_convert_with_eq"
+    d.mkdir(exist_ok=True)
+
+    eq_file = pk.eq_templates[eq]
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python("GS2", "CGYRO", output_dir=d, eq_file=eq_file)
+    file_out_cli = convert_with_cli("GS2", "CGYRO", output_dir=d, eq_file=eq_file)
+    file_out_base = convert_with_python("GS2", "CGYRO", output_dir=d, base_case=True)
+    files_match(file_out, file_out_cli, base_case=file_out_base)
+
+
+@pytest.mark.parametrize(
+    "kinetics,long_opts",
+    product(
+        ("JETTO", "SCENE", "TRANSP"),
+        (True, False),
+    ),
+)
+def test_convert_with_kinetics(kinetics, long_opts, tmp_path):
+    # Note: this tests over long_opts as it's the only test where a_minor is used
+    # Create directory to work in
+    d = tmp_path / "test_convert_with_kinetics"
+    d.mkdir(exist_ok=True)
+
+    kinetics_file = pk.kinetics_templates[kinetics]
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python(
+        "GS2", "CGYRO", output_dir=d, kinetics_file=kinetics_file
+    )
+    file_out_cli = convert_with_cli(
+        "GS2", "CGYRO", output_dir=d, kinetics_file=kinetics_file, long_opts=long_opts
+    )
+    file_out_base = convert_with_python("GS2", "CGYRO", output_dir=d, base_case=True)
+    files_match(file_out, file_out_cli, base_case=file_out_base)
+
+
+@pytest.mark.parametrize("kinetics", ["JETTO", "SCENE", "TRANSP"])
+def test_convert_with_kinetics_and_eq(kinetics, tmp_path):
+    # Create directory to work in
+    d = tmp_path / "test_convert_with_kinetics_and_eq"
+    d.mkdir(exist_ok=True)
+
+    eq_file = pk.eq_templates["GEQDSK"]
+    kinetics_file = pk.kinetics_templates[kinetics]
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python(
+        "GS2", "CGYRO", output_dir=d, eq_file=eq_file, kinetics_file=kinetics_file
+    )
+    file_out_cli = convert_with_cli(
+        "GS2", "CGYRO", output_dir=d, eq_file=eq_file, kinetics_file=kinetics_file
+    )
+    file_out_base = convert_with_python("GS2", "CGYRO", output_dir=d, base_case=True)
+    files_match(file_out, file_out_cli, base_case=file_out_base)
+
+
+def test_convert_with_geometry(tmp_path):
+    # Create directory to work in
+    d = tmp_path / "test_convert_with_geometry"
+    d.mkdir(exist_ok=True)
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python("GS2", "CGYRO", output_dir=d, local_geometry="MXH")
+    file_out_cli = convert_with_cli("GS2", "CGYRO", output_dir=d, local_geometry="MXH")
+    file_out_base = convert_with_python("GS2", "CGYRO", output_dir=d, base_case=True)
+    files_match(file_out, file_out_cli, base_case=file_out_base)
+
+
+@pytest.mark.parametrize("long_opts", (True, False))
+def test_convert_all_opts(long_opts, tmp_path):
+    # Create directory to work in
+    d = tmp_path / "test_convert_all_opts"
+    d.mkdir(exist_ok=True)
+
+    eq_file = pk.eq_templates["GEQDSK"]
+    kinetics_file = pk.kinetics_templates["JETTO"]
+
+    # Perform conversions, assert files match
+    file_out = convert_with_python(
+        "GS2",
+        "CGYRO",
+        output_dir=d,
+        eq_file=eq_file,
+        kinetics_file=kinetics_file,
+        local_geometry="MXH",
+        explicit_types=True,
+    )
+    file_out_cli = convert_with_cli(
+        "GS2",
+        "CGYRO",
+        output_dir=d,
+        eq_file=eq_file,
+        kinetics_file=kinetics_file,
+        local_geometry="MXH",
+        long_opts=True,
+        explicit_types=True,
+    )
+    file_out_base = convert_with_python("GS2", "CGYRO", output_dir=d, base_case=True)
+    files_match(file_out, file_out_cli, base_case=file_out_base)

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -35,7 +35,7 @@ def convert_with_python(
     base_case: bool = False,
 ) -> Path:
     """
-    Performs conversion via Pyro object within Python
+    Performs conversion via Pyro object within Python.
     """
     file_in = pk.gk_templates[gk_input]
     if explicit_types:
@@ -82,7 +82,7 @@ def convert_with_cli(
     explicit_types: bool = False,
 ) -> Path:
     """
-    Performs conversion via CLI convert tool
+    Performs conversion via CLI convert tool.
     """
     file_in = pk.gk_templates[gk_input]
     file_out = output_dir / f"result_cli.{gk_output.lower()}"

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,6 +1,5 @@
 import sys
 from difflib import unified_diff
-from pathlib import Path
 
 import pytest
 
@@ -9,7 +8,7 @@ from pyrokinetics.cli import entrypoint
 
 
 _geometries = {
-    "GS2" : "Miller",
+    "GS2": "Miller",
     "CGYRO": "MXH",
     "TGLF": "MXH",
     "GENE": "MillerTurnbull",
@@ -24,13 +23,16 @@ _long_opts = {
     "o": "output",
 }
 
+
 def opt(name: str, long: bool):
     return f"--{_long_opts[name]}" if long else f"-{name}"
+
 
 eq_type = "GEQDSK"
 eq_file = pk.eq_templates[eq_type]
 k_type = "JETTO"
 k_file = pk.kinetics_templates[k_type]
+
 
 @pytest.mark.parametrize(
     "gk_input,gk_output,eq,kinetics,switch_geometry,long_opts,explicit_types",
@@ -42,9 +44,18 @@ k_file = pk.kinetics_templates[k_type]
         ("CGYRO", "GS2", eq_file, None, True, True, True),
         ("CGYRO", "TGLF", None, None, False, False, False),
         ("TGLF", "GS2", eq_file, k_file, False, False, False),
-    ]
+    ],
 )
-def test_convert(gk_input, gk_output, eq, kinetics, switch_geometry, long_opts, explicit_types, tmp_path):
+def test_convert(
+    gk_input,
+    gk_output,
+    eq,
+    kinetics,
+    switch_geometry,
+    long_opts,
+    explicit_types,
+    tmp_path,
+):
     # TODO Tests only a small subset of all possible combinations. The whole matrix
     #      can take up to 10 minutes!
     # TODO Not testing template options
@@ -53,7 +64,7 @@ def test_convert(gk_input, gk_output, eq, kinetics, switch_geometry, long_opts, 
     # Create directory to work in
     d = tmp_path / "test_convert"
     d.mkdir(exist_ok=True)
-    
+
     # Get input file and output file names
     file_in = pk.gk_templates[gk_input]
     file_out = d / f"result.{gk_output.lower()}"
@@ -70,7 +81,14 @@ def test_convert(gk_input, gk_output, eq, kinetics, switch_geometry, long_opts, 
         k_type = None
 
     # Perform conversion using Python API
-    pyro = pk.Pyro(gk_file=file_in, gk_code=gk_type, eq_file=eq, eq_type=eq_type, kinetics_file=kinetics, kinetics_type=k_type)
+    pyro = pk.Pyro(
+        gk_file=file_in,
+        gk_code=gk_type,
+        eq_file=eq,
+        eq_type=eq_type,
+        kinetics_file=kinetics,
+        kinetics_type=k_type,
+    )
     if eq is not None:
         pyro.load_local_geometry(psi_n=0.9)
     if kinetics is not None:


### PR DESCRIPTION
In a recent chat, it was mentioned that a Command Line Interface (CLI) for basic operations would be helpful, and that it would serve as a useful first step towards a GUI. I've added a system using [`argparse`](https://docs.python.org/3/library/argparse.html) that allows users to convert GK input files on the command line, and they can optionally pull in equilibrium/kinetics/template data too.

As Pyrokinetics is capable of doing a bunch of different things, I designed this to be extendable using 'subparsers'. Currently, it only has one subcommand `convert`, but I could foresee it having subcommands such as `run`, `scan`, `compare`, `analyse`, etc in future.

Let me know if there's anything here you'd like me to change.

## Usage

You can run the CLI via two methods:

- `$ python3 -m pyrokinetics`, which uses the file `__main__.py`.
- `$ pyro`, which uses script entrypoints in `pyproject.toml` to call `pyrokinetics.cli.entrypoint:entrypoint` directly.

Both point to the same entrypoint function, so there's no practical difference in usage. If you only call `$ pyro`, it'll print a help message:

```
usage: Pyrokinetics [-h] {convert} ...

A tool to run and analyse gyrokinetics simulations.

optional arguments:
  -h, --help  show this help message and exit

subcommands:
  Please provide one of the following subcommands as a positional argument. For information on how each subcommand works, try providing '--help' after the subcommand.

  {convert}
    convert   Convert a gyrokinetics input file to a different code.
```

You can also get this by calling `$ pyro --help` or `$ pyro -h`. The `convert` subcommand also provides help text if you call `$ pyro convert --help`:

```
usage: Pyrokinetics convert [-h] [--input_type INPUT_TYPE] [--equilibrium EQUILIBRIUM] [--equilibrium_type EQUILIBRIUM_TYPE] [--kinetics KINETICS] [--kinetics_type KINETICS_TYPE] [--psi PSI] [--a_minor A_MINOR] [--output OUTPUT] [--template TEMPLATE] target input_file

positional arguments:
  target                The target gyrokinetics code, e.g. 'GS2', 'CGYRO'.
  input_file            The gyrokinetics config file you wish to convert.

optional arguments:
  -h, --help            show this help message and exit
  --input_type INPUT_TYPE
                        The code type of the input file. If not provided, this will be inferred.
  --equilibrium EQUILIBRIUM, --eq EQUILIBRIUM, -e EQUILIBRIUM
                        Path to a plasma equilibrium file, which is used to overwrite the flux surface in 'input_file'. Users should also provide 'psi' to select which flux surface to use from the equilibrium.
  --equilibrium_type EQUILIBRIUM_TYPE, --eq_type EQUILIBRIUM_TYPE
                        The type of equilibrium file. If not provided, this is inferred.
  --kinetics KINETICS, -k KINETICS
                        Path to a plasma kinetics file, which is used to overwrite the local species data in 'input_file'. Users should also provide 'psi' and 'a_minor' to select which flux surface to use, or provide 'psi' and 'equilibrium'.
  --kinetics_type KINETICS_TYPE, --k_type KINETICS_TYPE
                        The type of kinetics file. If not provided, this is inferred.
  --psi PSI, -p PSI     The normalised poloidal flux function, used to index which flux surface to draw equilibrium/kinetics data from. Should be in the range [0,1], with 0 being the magnetic axis, and 1 being the last closed flux surface.
  --a_minor A_MINOR, -a A_MINOR
                        The width of the last closed flux surface, in meters. Used to select a flux surface when providing kinetics data but no equilibrium. Otherwise, this argument is ignored.
  --output OUTPUT, -o OUTPUT
                        Name of the new gyrokinetics config file.
  --template TEMPLATE, -t TEMPLATE
                        Template file to use for the new gyrokinetics config file.
```

The following will convert a GS2 file to CGYRO:

```
$ pyro convert CGYRO my_gs2_file.in --output input.cgyro
```

You can also bring in equilibrium/kinetics stuff, but the command line gets a bit crowded if you do:

```
$ pyro convert CGYRO my_gs2_file.in --equilibrium my_eq.geqdsk --kinetics my_kinetics.cdf --psi=0.95 --output input.cgyro
```

Most optional arguments also have shortened aliases:

```
$ pyro convert CGYRO my_gs2_file.in -e my_eq.geqdsk -k my_kinetics.cdf -p=0.95 -o input.cgyro
```

## Issues

- Haven't written tests yet, and CLI stuff is quite difficult to test anyway. @ZedThree would you recommend just testing the `main()` function I've written and leaving the other pieces untested? Or should I test the whole thing using `subprocess`?
- Currently don't have a way to specify the preferred `LocalGeometry` type, but as that whole system is in flux I think it'll be fine to keep this restricted to Miller for now.