### PR TITLE
Relax matplotlib contraint to >=3.3.4 (for OMFIT compatibility)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "numpy >= 1.20.3",
-    "matplotlib >= 3.6",
+    "matplotlib >= 3.3.4",
     "f90nml >= 1.4.2",
     "scipy >= 1.9.3",
     "h5py >= 2.10",


### PR DESCRIPTION
OMFIT requires matplotlib up to 3.3.4 and I see no reason for us to _need_ matplotlib>3.6 so this will let us be compatible with them.

I think the amount of work to get OMFIT compatible with the latest versions of matplotlib would probably be significant so this seems easier for now