### PR TITLE
Bugfix/nspecies gene

### DIFF
--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -422,7 +422,7 @@ class GKInputGENE(GKInput):
             for key, val in self.pyro_gene_species.items():
                 single_species[val] = local_species[name][key]
 
-            #TODO Allow for major radius to be used as normalising length
+            # TODO Allow for major radius to be used as normalising length
             single_species["omt"] = local_species[name].a_lt
             single_species["omn"] = local_species[name].a_ln
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -392,36 +392,39 @@ class GKInputGENE(GKInput):
         self.data["box"]["n_spec"] = local_species.nspec
 
         for iSp, name in enumerate(local_species.names):
+            try:
+                single_species = self.data["species"][iSp]
+            except IndexError:
+                if f90nml.__version__ < "1.4":
+                    self.data["species"].append(copy.copy(self.data["species"][0]))
+                    single_species = self.data["species"][iSp]
+                else:
+                    # FIXME f90nml v1.4+ uses 'Cogroups' for Namelist groups sharing
+                    # a common key. As of version 1.4.2, Cogroup derives from
+                    # 'list', but does not implement all methods, so confusingly it
+                    # allows calls to 'append', but then doesn't do anything!
+                    # Currently working around this in a horribly inefficient
+                    # manner, by deconstructing the entire Namelist to a dict, using
+                    # secret cogroup names directly, and rebundling the Namelist.
+                    # There must be a better way!
+                    d = self.data.todict()
+                    copied = copy.deepcopy(d["_grp_species_0"])
+                    copied["name"] = None
+                    d[f"_grp_species_{iSp}"] = copied
+                    self.data = f90nml.Namelist(d)
+                    single_species = self.data["species"][iSp]
+
             if name == "electron":
-                self.data["species"][iSp]["name"] = "electron"
+                single_species["name"] = "electron"
             else:
-                try:
-                    self.data["species"][iSp]["name"] = "ion"
-                except IndexError:
-                    if f90nml.__version__ < "1.4":
-                        self.data["species"].append(copy.copy(self.data["species"][0]))
-                        self.data["species"][iSp]["name"] = "ion"
-                    else:
-                        # FIXME f90nml v1.4+ uses 'Cogroups' for Namelist groups sharing
-                        # a common key. As of version 1.4.2, Cogroup derives from
-                        # 'list', but does not implement all methods, so confusingly it
-                        # allows calls to 'append', but then doesn't do anything!
-                        # Currently working around this in a horribly inefficient
-                        # manner, by deconstructing the entire Namelist to a dict, using
-                        # secret cogroup names directly, and rebundling the Namelist.
-                        # There must be a better way!
-                        d = self.data.todict()
-                        copied = copy.deepcopy(d["_grp_species_0"])
-                        copied["name"] = "ion"
-                        d[f"_grp_species_{iSp}"] = copied
-                        self.data = f90nml.Namelist(d)
+                single_species["name"] = "ion"
 
             for key, val in self.pyro_gene_species.items():
-                self.data["species"][iSp][val] = local_species[name][key]
+                single_species[val] = local_species[name][key]
 
-            # Can these just be in the pyro_gene_species mapping?
-            self.data["species"][iSp]["omt"] = local_species[name].a_lt
-            self.data["species"][iSp]["omn"] = local_species[name].a_ln
+            #TODO Allow for major radius to be used as normalising length
+            single_species["omt"] = local_species[name].a_lt
+            single_species["omn"] = local_species[name].a_ln
 
         self.data["geometry"]["zeff"] = local_species.zeff
 

--- a/tests/gk_code/test_gk_input_gene.py
+++ b/tests/gk_code/test_gk_input_gene.py
@@ -3,6 +3,7 @@ from pyrokinetics import template_dir
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
+from pyrokinetics.examples import example_JETTO
 
 from pathlib import Path
 import numpy as np
@@ -123,3 +124,15 @@ def test_write(tmp_path, gene):
     assert local_species.nspec == new_local_species.nspec
     new_numerics = gene_reader.get_numerics()
     assert numerics.delta_time == new_numerics.delta_time
+
+
+def test_species_order(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+
+    # Reverse species order so electron is last
+    pyro.local_species.names = pyro.local_species.names[::-1]
+    pyro.gk_code = "GENE"
+
+    pyro.write_gk_file(file_name=tmp_path / "input.in")
+
+    assert Path(tmp_path / "input.in").exists()


### PR DESCRIPTION
When writing a GENE file, a template namelist is used with only 2 species. For simulations with more species, we would need to create a new namelist for each species. Currently we are only creating a new namelists for ion species, so if the electron species is the 3rd or higher in order, then a new namelist wouldn't be created and an `IndexError` would occur

Here we move the check for the namelist earlier