### PR TITLE
Zeff bugfix

### DIFF
--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -272,7 +272,7 @@ class GKInputGENE(GKInput):
             ).m * nu_ee.units
 
         local_species.zeff = (
-            self.data["geometry"].get("zeff", 1.0) * ureg.elementary_charge
+            self.data["general"].get("zeff", 1.0) * ureg.elementary_charge
         )
 
         return local_species
@@ -426,7 +426,7 @@ class GKInputGENE(GKInput):
             single_species["omt"] = local_species[name].a_lt
             single_species["omn"] = local_species[name].a_ln
 
-        self.data["geometry"]["zeff"] = local_species.zeff
+        self.data["general"]["zeff"] = local_species.zeff
 
         beta_ref = local_norm.gene.beta if local_norm else 0.0
         self.data["general"]["beta"] = (

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -242,9 +242,17 @@ class GKInputGS2(GKInput):
 
         local_species.normalise()
 
-        local_species.zeff = (
-            self.data["knobs"].get("zeff", 1.0) * ureg.elementary_charge
-        )
+
+        if "zeff" in self.data["knobs"]:
+            local_species.zeff = (
+                self.data["knobs"]["zeff"] * ureg.elementary_charge
+            )
+        elif "zeff" in self.data["parameters"]:
+            local_species.zeff = (
+                self.data["parameters"]["zeff"] * ureg.elementary_charge
+            )
+        else:
+            local_species.zeff = 1.0 * ureg.elementary_charge
 
         return local_species
 

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -242,11 +242,8 @@ class GKInputGS2(GKInput):
 
         local_species.normalise()
 
-
         if "zeff" in self.data["knobs"]:
-            local_species.zeff = (
-                self.data["knobs"]["zeff"] * ureg.elementary_charge
-            )
+            local_species.zeff = self.data["knobs"]["zeff"] * ureg.elementary_charge
         elif "zeff" in self.data["parameters"]:
             local_species.zeff = (
                 self.data["parameters"]["zeff"] * ureg.elementary_charge


### PR DESCRIPTION
- Check for `zeff` in both `GS2` namelists (knobs & parameters); precedence to knobs
- Write to `GENE.general` 