### PR TITLE
Contributions to 'Feature/p file reader'

### DIFF
--- a/pyrokinetics/examples/example_JETTO.py
+++ b/pyrokinetics/examples/example_JETTO.py
@@ -12,12 +12,10 @@ def main(base_path: Union[os.PathLike, str] = "."):
     kinetics_file = template_dir / "jetto.cdf"
 
     # Load up pyro object
-    pyro = Pyro()
-
-    pyro.load_global_eq(eq_file=eq_file, eq_type="GEQDSK")
-
-    pyro.load_global_kinetics(
-        kinetics_file=kinetics_file, kinetics_type="JETTO", time=550
+    pyro = Pyro(
+        eq_file=eq_file,
+        kinetics_file=kinetics_file,
+        kinetics_kwargs={"time": 550},
     )
 
     # Generate local parameters at psi_n=0.5

--- a/pyrokinetics/kinetics/Kinetics.py
+++ b/pyrokinetics/kinetics/Kinetics.py
@@ -50,32 +50,19 @@ class Kinetics:
         self,
         kinetics_file: PathLike,
         kinetics_type: Optional[str] = None,
-        eq_file: Optional[PathLike] = None,
         **kwargs,
     ):
         self.kinetics_file = Path(kinetics_file)
 
         if kinetics_type is not None:
-            if kinetics_type == "pFile":  # if pFile.
-                reader = kinetics_readers[kinetics_type]
-                self.kinetics_type = kinetics_type
-                self.eq_file = Path(eq_file)
-            else:
-                reader = kinetics_readers[kinetics_type]
-                self.kinetics_type = kinetics_type
+            reader = kinetics_readers[kinetics_type]
+            self.kinetics_type = kinetics_type
         else:
             # Infer kinetics type from file
             reader = kinetics_readers[kinetics_file]
             self.kinetics_type = reader.file_type
 
-        if kinetics_type == "pFile":
-            self.species_data = CleverDict(
-                reader(kinetics_file, eq_file, **kwargs)
-            )  # Use reader __call__
-        else:
-            self.species_data = CleverDict(
-                reader(kinetics_file, **kwargs)
-            )  # Use reader __call__
+        self.species_data = CleverDict(reader(kinetics_file, **kwargs))
 
     @property
     def supported_kinetics_types(self):
@@ -85,21 +72,11 @@ class Kinetics:
     def kinetics_type(self):
         return self._kinetics_type
 
-    @property
-    def eq_file(self):
-        return self._eq_file
-
     @kinetics_type.setter
     def kinetics_type(self, value):
         if value not in self.supported_kinetics_types:
             raise ValueError(f"Kinetics type {value} is not currently supported.")
         self._kinetics_type = value
-
-    @eq_file.setter
-    def eq_file(self, value):
-        if value is None:
-            raise ValueError(f"eq_file is None.")
-        self._eq_file = value
 
     @property
     def nspec(self):

--- a/pyrokinetics/kinetics/KineticsReaderpFile.py
+++ b/pyrokinetics/kinetics/KineticsReaderpFile.py
@@ -64,7 +64,7 @@ class KineticsReaderpFile(KineticsReader):
     def read(
         self,
         filename: PathLike,
-        eq_file: Optional[PathLike] = None,
+        eq_file: PathLike = None,
         time_index: int = -1,
         time: Optional[float] = None,
     ) -> Dict[str, Species]:
@@ -75,8 +75,6 @@ class KineticsReaderpFile(KineticsReader):
         pFile, and assumed to be called geqdsk.
         """
         # eq_file must be provided
-        # Note: The 'Optional[T]' type hint just means the arg can be of type T or it
-        # can be 'None' -- it doesn't mean the user can skip providing it!
         if eq_file is None:
             raise ValueError(
                 dedent(

--- a/pyrokinetics/pyro.py
+++ b/pyrokinetics/pyro.py
@@ -36,6 +36,8 @@ class Pyro:
         Type of equilibrium file. When set, this will skip file type inference. Possible
         values are GEQDSK or TRANSP. If set to None, the file type is inferred
         automatically.
+    eq_kwargs : Optional[Dict[str, Any]] = None
+        Keyword arguments to be used when building an Equilibrium object
     kinetics_file : PathLike, default ``None``
         Filename for outputs from a global kinetics code, such as SCENE, JETTO,
         TRANSP, or pFile. When passed, this will set the 'kinetics' attribute. This can be used to
@@ -44,6 +46,8 @@ class Pyro:
         Type of kinetics file. When set, this will skip file type inference. Possible
         values are SCENE, JETTO, TRANSP, or pFile. If set to None, the file type is inferred
         automatically.
+    kinetics_kwargs : Optional[Dict[str, Any]] = None
+        Keyword arguments to be used when building a Kinetics object.
     gk_file : PathLike, default ``None``
         Filename for a gyrokinetics input file (GS2, GENE, CGYRO). When passed, the
         attributes 'local_geometry', 'local_species', and 'numerics' are set.
@@ -71,8 +75,10 @@ class Pyro:
         self,
         eq_file: Optional[PathLike] = None,
         eq_type: Optional[str] = None,
+        eq_kwargs: Optional[Dict[str, Any]] = None,
         kinetics_file: Optional[PathLike] = None,
         kinetics_type: Optional[str] = None,
+        kinetics_kwargs: Optional[Dict[str, Any]] = None,
         gk_file: Optional[PathLike] = None,
         gk_output_file: Optional[PathLike] = None,
         gk_code: Optional[str] = None,
@@ -152,14 +158,18 @@ class Pyro:
             self.read_gk_output_file(self.gk_output_file, gk_code)
 
         # Load global equilibrium file if it exists
+        if eq_kwargs is None:
+            eq_kwargs = {}
+
         if eq_file is not None:
-            self.load_global_eq(eq_file, eq_type)
+            self.load_global_eq(eq_file, eq_type, **eq_kwargs)
 
         # Load global kinetics file if it exists
-        if kinetics_type == "pFile":
-            self.load_global_kinetics(kinetics_file, kinetics_type, eq_file)
-        elif kinetics_file is not None:
-            self.load_global_kinetics(kinetics_file, kinetics_type)
+        if kinetics_kwargs is None:
+            kinetics_kwargs = {}
+
+        if kinetics_file is not None:
+            self.load_global_kinetics(kinetics_file, kinetics_type, **kinetics_kwargs)
 
         self._check_beta_consistency()
 
@@ -1288,7 +1298,6 @@ class Pyro:
         self,
         kinetics_file: PathLike,
         kinetics_type: Optional[str] = None,
-        eq_file: Optional[PathLike] = None,
         **kwargs,
     ) -> None:
         """
@@ -1316,16 +1325,19 @@ class Pyro:
             Kinetics.
         """
         self.kinetics_file = kinetics_file  # property setter, converts to Path
-
-        if kinetics_type is not None:
-            if kinetics_type == "pFile":
+        try:
+            self.kinetics = Kinetics(self.kinetics_file, kinetics_type, **kwargs)
+        except ValueError as exc:
+            # Some kinetics readers need an eq_file to work properly.
+            if "eq_file" in str(exc) and self.eq_file is not None:
                 self.kinetics = Kinetics(
-                    self.kinetics_file, kinetics_type, eq_file, **kwargs
+                    self.kinetics_file,
+                    kinetics_type,
+                    eq_file=self.eq_file,
+                    **kwargs,
                 )
             else:
-                self.kinetics = Kinetics(self.kinetics_file, kinetics_type, **kwargs)
-        else:
-            self.kinetics = Kinetics(self.kinetics_file, kinetics_type, **kwargs)
+                raise exc
 
     @property
     def kinetics_type(self) -> Union[str, None]:

--- a/pyrokinetics/readers.py
+++ b/pyrokinetics/readers.py
@@ -1,69 +1,83 @@
-"""readers.py
-
-Defines utilities for creating the various 'reader' objects used throughout
-Pyrokinetics.
-"""
-
 from pathlib import Path
-from typing import Optional, Union, Type, Any
+from typing import Type, Any
 from .typing import PathLike
 from abc import ABC, abstractmethod
 from .factory import Factory
 
 
 class Reader(ABC):
-    @abstractmethod
-    def read(
-        self,
-        filename: PathLike,
-        second_filename: Optional[PathLike] = None,
-        *args,
-        **kwargs,
-    ) -> Any:
-        """
-        Read and process a file
+    """
+    An abstract base class for classes that can read data from disk and create a
+    Pyrokinetics object. ``Reader`` classes should define both a ``read`` method and a
+    ``verify`` method.
 
-        second_filename used for pFile reader where we need to pass the eq_file path.
+    - ``read`` simply reads a file and returns a Pyrokinetics object.
+    - ``verify`` checks whether a file is of a particular type. It should raise an
+      exception if it isn't, or do nothing otherwise. This is used for automatic
+      filetype inference.
+    """
+
+    @abstractmethod
+    def read(self, filename: PathLike, **kwargs) -> Any:
+        """
+        Read and process an arbitrary number of files.
+
+        Parameters
+        ----------
+        filename: PathLike
+            The file to be read.
+        **kwargs
+            Keyword arguments to be used by the reader. This may be used to pass in
+            options to the reader, and may also be used to pass in auxiliary file names.
+
+        Returns
+        -------
+        Any
+            Derived classes may return any type of data from this function.
+
+        Notes
+        -----
+        Rather than accepting ``**kwargs``, it is recommended that derived classes
+        should specify their keywords explicitly.
         """
         pass
 
-    def verify(
-        self, filename: PathLike, second_filename: Optional[PathLike] = None
-    ) -> None:
-        """Perform a series of checks on the file to ensure it is valid
-
-        Does not return anything, but should raise exceptions if something goes
-        wrong.
-
-        By default, simply read the file. This should be avoided in cases where
-        reading and processing the whole file takes a long time. Ideally, this
-        function should make only a few quick metadata checks, and leave the
-        actual processing to `read`. It is therefore recommended to shadow this
-        function in subclasses.
-
-        second_filename used for pFile reader where we need to pass the eq_file path.
+    def verify(self, filename: PathLike) -> None:
         """
-        if second_filename is not None:
-            self.read(filename, second_filename)
-        else:
-            self.read(filename)
+        Perform a series of checks on the file to ensure it is valid. Does not return
+        anything, but should raise exceptions if something goes wrong.
 
-    def __call__(
-        self,
-        filename: PathLike,
-        second_filename: Optional[PathLike] = None,
-        *args,
-        **kwargs,
-    ) -> Any:
-        if second_filename is not None:
-            return self.read(filename, second_filename, *args, **kwargs)
-        else:
-            return self.read(filename, *args, **kwargs)
+        The default implementation simply reads the file, performs the usual processing,
+        and discards the results. This is rarely the best way to verify a file type,
+        so this should be overridden is most cases. In particular, the default
+        implementation should not be used if:
+
+        - Reading and processing the whole file is computationally expensive.
+        - The read function depends upon keyword arguments.
+        - The read function can read multiple related file types and further information
+          is needed to differentiate between them. For example, multiple gyrokinetics
+          codes use Fortran namelists as input files, so a specialised verify method
+          is needed to check the names stored within to determine which code the input
+          file belongs to.
+
+        Parameters
+        ----------
+        filename: PathLike
+            The file to be read.
+        """
+        self.read(filename)
+
+    def __call__(self, filename: PathLike, **kwargs) -> Any:
+        """
+        Forwards calls to ``read``.
+        """
+        return self.read(filename, **kwargs)
 
 
 def create_reader_factory(BaseReader=Reader, name: str = None):
-    """Generates Factory which inherits UserDict and redefines the __getitem__
-    and __setitem__ methods. The registered types should subclass BaseReader, which
+    """
+    Generates Factory which inherits UserDict and redefines the __getitem__ and
+    __setitem__ methods. The registered types should subclass BaseReader, which
     defaults to Reader.
 
     Factories behave similarly to dictionaries, and define a mapping between
@@ -91,7 +105,7 @@ def create_reader_factory(BaseReader=Reader, name: str = None):
         def __init__(self):
             super().__init__(BaseReader)
 
-        def get_type(self, key: str) -> Union[Type[BaseReader], None]:
+        def get_type(self, key: str) -> Type[BaseReader]:
             # First, assume the given key is name registered to the factory
             # Note that the values of self.data are class types. A new instance is
             # created for each call to __getitem__
@@ -108,7 +122,7 @@ def create_reader_factory(BaseReader=Reader, name: str = None):
                         f"nor is {key} the name of a valid input file."
                     ) from key_error
 
-        def _infer_file_type(self, filename: PathLike) -> Union[str, None]:
+        def _infer_file_type(self, filename: PathLike) -> str:
             # Check to see if it's a valid filename
             filename = Path(filename)
             if not filename.exists():

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -610,6 +610,7 @@ def test_unique_names_bad_character():
     assert two.name == "test2cdf0000"
     assert three.name == "test_20000"
 
+
 def test_eq_kwargs():
     # Note: This test will fail if the GEQDSK psi_n_lcfs system is failing
     # Instantiate pyro object normally
@@ -621,6 +622,7 @@ def test_eq_kwargs():
     )
     # Check that the kwargs have been passed on correctly
     assert np.isclose(0.9 * pyro_1.eq.psi_lcfs, pyro_2.eq.psi_lcfs)
+
 
 def test_kinetics_kwargs():
     # Instantiate pyro object normally

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -625,7 +625,7 @@ def test_eq_kwargs():
 def test_kinetics_kwargs():
     # Instantiate pyro object normally
     pyro_1 = Pyro(kinetics_file=kinetics_templates["JETTO"])
-    # Instantiate pyro object with special options passed via eq_kwargs
+    # Instantiate pyro object with special options passed via kinetics_kwargs
     pyro_2 = Pyro(
         kinetics_file=kinetics_templates["JETTO"],
         kinetics_kwargs={"time_index": 3},

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -610,6 +610,32 @@ def test_unique_names_bad_character():
     assert two.name == "test2cdf0000"
     assert three.name == "test_20000"
 
+def test_eq_kwargs():
+    # Note: This test will fail if the GEQDSK psi_n_lcfs system is failing
+    # Instantiate pyro object normally
+    pyro_1 = Pyro(eq_file=eq_templates["GEQDSK"])
+    # Instantiate pyro object with special options passed via eq_kwargs
+    pyro_2 = Pyro(
+        eq_file=eq_templates["GEQDSK"],
+        eq_kwargs={"psi_n_lcfs": 0.9},
+    )
+    # Check that the kwargs have been passed on correctly
+    assert np.isclose(0.9 * pyro_1.eq.psi_lcfs, pyro_2.eq.psi_lcfs)
+
+def test_kinetics_kwargs():
+    # Instantiate pyro object normally
+    pyro_1 = Pyro(kinetics_file=kinetics_templates["JETTO"])
+    # Instantiate pyro object with special options passed via eq_kwargs
+    pyro_2 = Pyro(
+        kinetics_file=kinetics_templates["JETTO"],
+        kinetics_kwargs={"time_index": 3},
+    )
+    # Check that the kwargs have been passed on correctly
+    # (unsure what the resulting values should be, only that they should be different)
+    density_1 = pyro_1.kinetics.species_data["electron"].dens(0.5)
+    density_2 = pyro_2.kinetics.species_data["electron"].dens(0.5)
+    assert density_1 != density_2
+
 
 # The following monkeypatch fixtures modify the global 'factory'/'reader' objects
 # gk_inputs, gk_output_readers, local_geometries, Equilibrium._readers, and


### PR DESCRIPTION
Contributions to PR https://github.com/pyro-kinetics/pyrokinetics/pull/179

pFile reader requires an additional G-EQDSK file to determine its $\rho$ grid, so a `second_filename` arg was added to the `Reader` class. As this class is very generic and should be applicable throughout the project, I think it'd be better to keep it simple and make use of the `**kwargs` passed to the `read` function to handle any special cases. This PR reverts the changes to `Kinetics` and `Reader`, and instead passes `eq_file` via standard `**kwargs`. Further changes:

- Updated pFile reader ``verify`` method, automatic file type inference now working:
```python
>>> # No need for kinetics_type:
>>> import pyrokinetics as pk
>>> pyro = pk.Pyro(kinetics_file=pk.kinetics_templates["pFile"], eq_file=pk.eq_templates["GEQDSK"])
```
- ``Pyro`` now takes optional dicts `eq_kwargs` and `kinetics_kwargs` to its constructor, so complicated builds that previously required separate calls to `load_global_eq` and `load_global_kinetics` can now be done in one step.
- If ``Pyro`` has an ``eq_file`` and the user tries to load a pFile kinetics, it will detect if the error is simply a missing ``eq_file`` arg and correct it automatically.
- Updated Reader docs, removed unused `*args` and fixed some type hints