### PR TITLE
Refactor Numerics

### DIFF
--- a/pyrokinetics/__init__.py
+++ b/pyrokinetics/__init__.py
@@ -23,19 +23,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with Pyrokinetics.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from .metadata import __version__
 from .pyro import Pyro
 from .pyroscan import PyroScan
-
-try:
-    from importlib.metadata import version, PackageNotFoundError
-except ModuleNotFoundError:
-    from importlib_metadata import version, PackageNotFoundError
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    from setuptools_scm import get_version
-
-    __version__ = get_version(root="..", relative_to=__file__)
 
 # Location of bundled templates
 from .templates import template_dir, gk_templates, eq_templates, kinetics_templates
@@ -49,6 +39,9 @@ from .equilibrium import (
     supported_equilibrium_types,
 )
 
+# Numerics
+from .numerics import Numerics
+
 __all__ = [
     "__version__",
     "Pyro",
@@ -59,4 +52,5 @@ __all__ = [
     "read_equilibrium",
     "equilibrium_reader",
     "supported_equilibrium_types",
+    "Numerics",
 ]

--- a/pyrokinetics/dataset_wrapper.py
+++ b/pyrokinetics/dataset_wrapper.py
@@ -80,7 +80,7 @@ class DatasetWrapper:
         )
 
         # Add metadata to attrs dict
-        obj_name = self.__class__.__name__ # name of derived class, not DatasetWrapper
+        obj_name = self.__class__.__name__  # name of derived class, not DatasetWrapper
         meta_dict = metadata(title, obj_name, netcdf4_version=nc.__version__)
         for key, val in meta_dict.items():
             new_attrs[key] = val
@@ -216,7 +216,7 @@ class DatasetWrapper:
                 else:
                     title = str(overwrite_title)
                 new_metadata = metadata(
-                        title, cls.__name__, netcdf4_version=nc.__version__
+                    title, cls.__name__, netcdf4_version=nc.__version__
                 )
                 for key, val in new_metadata.items():
                     dataset.attrs[key] = val

--- a/pyrokinetics/dataset_wrapper.py
+++ b/pyrokinetics/dataset_wrapper.py
@@ -80,11 +80,8 @@ class DatasetWrapper:
         )
 
         # Add metadata to attrs dict
-        meta_dict = metadata(
-            title=title,
-            object_type=self.__class__.__name__,
-            netcdf4_version=nc.__version__,
-        )
+        obj_name = self.__class__.__name__ # name of derived class, not DatasetWrapper
+        meta_dict = metadata(title, obj_name, netcdf4_version=nc.__version__)
         for key, val in meta_dict.items():
             new_attrs[key] = val
 
@@ -218,7 +215,9 @@ class DatasetWrapper:
                     title = cls.__name__
                 else:
                     title = str(overwrite_title)
-                new_metadata = metadata(title=title, netcdf4_version=nc.__version__)
+                new_metadata = metadata(
+                        title, cls.__name__, netcdf4_version=nc.__version__
+                )
                 for key, val in new_metadata.items():
                     dataset.attrs[key] = val
             instance.data = dataset

--- a/pyrokinetics/dataset_wrapper.py
+++ b/pyrokinetics/dataset_wrapper.py
@@ -1,17 +1,16 @@
-import uuid
-from datetime import datetime
-from typing import Dict, Any, Optional, Mapping
-from pathlib import Path
 from ast import literal_eval
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, Any, Optional, Mapping
 
-from ._version import __version__
+from .metadata import metadata
 from .typing import PathLike
 from .units import ureg
 
-import xarray as xr
+import netCDF4 as nc
 import pint  # noqa
 import pint_xarray  # noqa
-import netCDF4 as nc
+import xarray as xr
 
 
 class DatasetWrapper:
@@ -49,11 +48,6 @@ class DatasetWrapper:
         Redirects to the dataset attrs
     """
 
-    # Define UUID and session start as a class-level variables.
-    # Determined at the first import, and should be fixed during each session.
-    __uuid = uuid.uuid4()
-    __session_start = datetime.now()
-
     def __init__(
         self,
         data_vars: Optional[Dict[str, Any]] = None,
@@ -85,8 +79,13 @@ class DatasetWrapper:
             {k: str(v) for k, v in self._attr_units.items()}
         )
 
-        # Set metadata
-        for key, val in self._metadata(title).items():
+        # Add metadata to attrs dict
+        meta_dict = metadata(
+            title=title,
+            object_type=self.__class__.__name__,
+            netcdf4_version=nc.__version__,
+        )
+        for key, val in meta_dict.items():
             new_attrs[key] = val
 
         # Set underlying dataset
@@ -124,19 +123,6 @@ class DatasetWrapper:
     def dims(self) -> Mapping[str, int]:
         """Redirects to underlying Xarray Dataset dims."""
         return self.data.dims
-
-    @classmethod
-    def _metadata(cls, title: str) -> Dict[str, str]:
-        return {
-            "title": str(title),
-            "software_name": "Pyrokinetics",
-            "software_version": __version__,
-            "object_type": cls.__name__,
-            "session_started": str(cls.__session_start),
-            "session_uuid": str(cls.__uuid),
-            "date_created": str(datetime.now()),
-            "netcdf4_version": nc.__version__,
-        }
 
     def __getitem__(self, key: str) -> Any:
         """Redirect indexing to self.data"""
@@ -210,15 +196,30 @@ class DatasetWrapper:
             Instance of a derived class with self.data initialised. Derived classes
             which need to do more than this should override this method with their
             own implementation.
+
+        Raises
+        ------
+        RuntimeError
+            If the netcdf is for the wrong type of object.
         """
         instance = cls.__new__(cls)
         with xr.open_dataset(Path(path), *args, **kwargs) as dataset:
+            if dataset.attrs.get("object_type", cls.__name__) != cls.__name__:
+                raise RuntimeError(
+                    dedent(
+                        f"""\
+                        netcdf of type {dataset.attrs["object_type"]} cannot be used
+                        to create objects of type {cls.__name__}.
+                        """
+                    )
+                )
             if overwrite_metadata:
                 if overwrite_title is None:
                     title = cls.__name__
                 else:
                     title = str(overwrite_title)
-                for key, val in cls._metadata(title).items():
+                new_metadata = metadata(title=title, netcdf4_version=nc.__version__)
+                for key, val in new_metadata.items():
                     dataset.attrs[key] = val
             instance.data = dataset
         # Set up attr_units

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -438,7 +438,7 @@ class GKInputCGYRO(GKInput):
 
         numerics_data["beta"] = self.data["BETAE_UNIT"] * ureg.beta_ref_ee_Bunit
 
-        return Numerics(numerics_data)
+        return Numerics(**numerics_data)
 
     def set(
         self,

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -398,7 +398,7 @@ class GKInputGENE(GKInput):
 
         numerics_data["beta"] = self.data["general"]["beta"] * ureg.beta_ref_ee_B0
 
-        return Numerics(numerics_data)
+        return Numerics(**numerics_data)
 
     def set(
         self,

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -390,7 +390,7 @@ class GKInputGS2(GKInput):
         beta = self.data["parameters"]["beta"] * (Rmaj / r_geo) ** 2
         numerics_data["beta"] = beta * ureg.beta_ref_ee_B0
 
-        return Numerics(numerics_data)
+        return Numerics(**numerics_data)
 
     def set(
         self,

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -335,7 +335,7 @@ class GKInputTGLF(GKInput):
         numerics_data["nonlinear"] = self.is_nonlinear()
         numerics_data["beta"] = self.data["betae"] * ureg.beta_ref_ee_Bunit
 
-        return Numerics(numerics_data)
+        return Numerics(**numerics_data)
 
     def set(
         self,

--- a/pyrokinetics/metadata.py
+++ b/pyrokinetics/metadata.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import datetime
+from typing import Dict
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    from importlib_metadata import version, PackageNotFoundError
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    try:
+        from setuptools_scm import get_version
+
+        __version__ = get_version(root="..", relative_to=__file__)
+    except ImportError:
+        __version__ = "0.0.1"
+
+
+# Define UUID and session start as module-level variables.
+# Determined at the first import, and should be fixed during each session.
+
+__uuid = uuid.uuid4()
+__session_start = datetime.now()
+
+
+def metadata(**kwargs: str) -> Dict[str, str]:
+    """
+    Return a dict of metadata uniquely describing this Pyrokinetics session. Should be
+    written to Pyrokinetics output files to establish their provenance.
+
+    Parameters
+    ----------
+    **kwargs: str
+        Extra keywords to add to the returned dict.
+    """
+    return {
+        "software_name": "Pyrokinetics",
+        "software_version": __version__,
+        "session_started": str(__session_start),
+        "session_uuid": str(__uuid),
+        "date_created": str(datetime.now()),
+        **kwargs,
+    }

--- a/pyrokinetics/metadata.py
+++ b/pyrokinetics/metadata.py
@@ -7,7 +7,7 @@ try:
 except ModuleNotFoundError:
     from importlib_metadata import version, PackageNotFoundError
 try:
-    __version__ = version(__name__)
+    __version__ = version("pyrokinetics")
 except PackageNotFoundError:
     try:
         from setuptools_scm import get_version
@@ -20,25 +20,35 @@ except PackageNotFoundError:
 # Define UUID and session start as module-level variables.
 # Determined at the first import, and should be fixed during each session.
 
-__uuid = uuid.uuid4()
+__session_uuid = uuid.uuid4()
 __session_start = datetime.now()
 
 
-def metadata(**kwargs: str) -> Dict[str, str]:
+def metadata(title: str, obj: str, **kwargs: str) -> Dict[str, str]:
     """
-    Return a dict of metadata uniquely describing this Pyrokinetics session. Should be
-    written to Pyrokinetics output files to establish their provenance.
+    Return a dict of metadata which can be used to uniquely identify Pyrokinetics
+    objects. Should be written to Pyrokinetics output files to establish their
+    provenance.
 
     Parameters
     ----------
+    title: str
+        A title to be assigned to the object. Recommended to use the object name if
+        no other obvious title can be determined.
+    obj: str
+        The type of Pyrokinetics object, expressed as a string. It is recommended to
+        use ``self.__class__.__name__`` in external classes.
     **kwargs: str
         Extra keywords to add to the returned dict.
     """
     return {
+        "title": str(title),
         "software_name": "Pyrokinetics",
         "software_version": __version__,
+        "object_type": str(obj),
+        "object_uuid": str(uuid.uuid4()),
+        "object_created": str(datetime.now()),
+        "session_uuid": str(__session_uuid),
         "session_started": str(__session_start),
-        "session_uuid": str(__uuid),
-        "date_created": str(datetime.now()),
         **kwargs,
     }

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -90,8 +90,14 @@ class Numerics:
 
     def __setitem__(self, key: str, value: Any) -> None:
         if key not in vars(self):
-            raise RuntimeError(f"Numerics does not have a key '{key}'")
+            raise KeyError(f"Numerics does not have a key '{key}'")
         setattr(self, key, value)
+
+    def __setattr__(self, attr: str, value: Any) -> None:
+        # TODO when minimum version is 3.10, can just use dataclass(slots=True)
+        if attr not in (field.name for field in dataclasses.fields(self)):
+            raise AttributeError(f"Numerics does not have an attribute '{attr}'")
+        super().__setattr__(attr, value)
 
     def __str__(self) -> str:
         """'Pretty print' self"""

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -80,7 +80,7 @@ class Numerics:
         if self._metadata is None:
             if title is None:
                 title = self.__class__.__name__
-            self._metadata = metadata(title=title, object_type=self.__class__.__name__)
+            self._metadata = metadata(title, self.__class__.__name__)
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -1,58 +1,151 @@
-from cleverdict import CleverDict
-from copy import deepcopy
+import dataclasses
+import json
+import pprint
+from typing import Any, Dict, Optional
+
+from .metadata import metadata
 
 
-class Numerics(CleverDict):
+@dataclasses.dataclass
+class Numerics:
     """
-    Set up numerical grid
-
+    Stores information describing numerical features common to most gyrokinetics
+    solvers, such as the dimensions of numerical grids, the presence of electromagnetic
+    field components, and time steps. Numerics is not used to store special flags
+    belonging to only one gyrokinetics code.
     """
 
-    def __init__(self, *args, **kwargs):
-        s_args = list(args)
+    #: Number of elements in the :math:`\theta` (poloidal) grid
+    ntheta: int = 32
 
-        if args and not isinstance(args[0], CleverDict) and isinstance(args[0], dict):
-            s_args[0] = sorted(args[0].items())
+    #: Number of :math:`2\pi` segments in the toroidal direction.
+    nperiod: int = 1
 
-        if args:
-            super().__init__(*s_args, **kwargs)
-        else:
-            self.default()
+    #: Number of elements in the energy grid
+    nenergy: int = 8
 
-    def default(self):
-        data_dict = {
-            "ntheta": 32,
-            "theta0": 0.0,
-            "nenergy": 8,
-            "npitch": 8,
-            "nky": 1,
-            "nkx": 1,
-            "kx": 0.0,
-            "ky": 0.1,
-            "nperiod": 1,
-            "nonlinear": False,
-            "phi": True,
-            "apar": False,
-            "bpar": False,
-            "max_time": 500.0,
-            "delta_time": 0.001,
-            "beta": None,
-        }
+    #: Number of elements in the pitch grid
+    npitch: int = 8
 
-        super().__init__(data_dict)
+    #: Number of elements in the velocity-space :math:`k_y` grid
+    nky: int = 1
 
-    def __deepcopy__(self, memodict):
+    #: Number of elements in the velocity-space :math:`k_x` grid
+    nkx: int = 1
+
+    #: Value of :math:`k_y\rho`
+    ky: float = 0.1
+
+    #: Value of :math:`k_x\rho`
+    kx: float = 0.0
+
+    #: Initial time step, in units of ``tref``
+    delta_time: float = 0.001
+
+    #: Time step, in units of ``tref``
+    max_time: float = 500.0
+
+    #: The ballooning angle (the point at which the radial wavenumber is zero)
+    theta0: float = 0.0
+
+    #: Boolean flag denoting whether this run evolves the :math:`\phi` field
+    #: (electric potential).
+    phi: bool = True
+
+    #: Boolean flag denoting whether this run evolves the :math:`A_\parallel` field
+    #: (component of the magnetic vector potential running parallel to the field line)
+    apar: bool = False
+
+    #: Boolean flag denoting whether this run evolves the :math:`B_\parallel` field
+    #: (component of the magnetic flux density running parallel to the field line)
+    bpar: bool = False
+
+    #: Ratio of plasma pressure to magnetic pressure
+    beta: Optional[float] = None
+
+    #: Boolean flag noting whether this run includes non-linear features
+    nonlinear: bool = False
+
+    #: Dict containing metadata about this Pyrokinetics session
+    _metadata: Optional[Dict[str, str]] = None
+
+    #: Title to be written to _metadata.
+    #: Defined as an 'InitVar' meaning this isn't a variable stored by the dataclass,
+    #: but instead is an optional argument to the constructor. It is used in the
+    #: __post_init__ function. If unset, this defaults to the class name.
+    title: dataclasses.InitVar[Optional[str]] = None
+
+    def __post_init__(self, title: Optional[str] = None):
+        """Performs secondary construction after calling __init__"""
+        if self._metadata is None:
+            if title is None:
+                title = self.__class__.__name__
+            self._metadata = metadata(title=title, object_type=self.__class__.__name__)
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        setattr(self, key, value)
+
+    def __str__(self) -> str:
+        """'Pretty print' self"""
+        # TODO when minimum version is 3.10, can remove asdict
+        return pprint.pformat(dataclasses.asdict(self))
+
+    def to_json(self, **kwargs: Any) -> str:
         """
-        Allows for deepcopy of a Numerics object
+        Converts self to json string. Includes metadata describing the current
+        Pyrokinetics session.
 
-        Returns
-        -------
-        Copy of Numerics object
+        Parameters
+        ----------
+        **kwargs: Any
+            Parameters passed on to ``json.dumps``
+
+
+        Examples
+        --------
+        ::
+
+            with open("my_numerics.json", "w") as f:
+                # Use indent=4 for pretty print
+                f.write(my_numerics.to_json(indent=4))
         """
+        return json.dumps(dataclasses.asdict(self), **kwargs)
 
-        new_numerics = Numerics()
+    @classmethod
+    def from_json(
+        cls,
+        json_str: str,
+        overwrite_metadata: bool = False,
+        overwrite_title: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        """
+        Creates a new Numerics from a previously saved Numerics json.
 
-        for key, value in self.items():
-            setattr(new_numerics, key, deepcopy(value, memodict))
+        Parameters
+        ----------
+        json_str: str
+            Json string to read
+        overwrite_metadata: bool, default False
+            Take ownership of the Json data, overwriting attributes such as 'title',
+            'software_name', 'date_created', etc.
+        overwrite_title: Optional[str]
+            If ``overwrite_metadata`` is ``True``, this is used to set the ``title``
+            attribute in ``self._metadata``. If unset, the class name is used.
+        **kwargs: Any
+            Keyword arguments forwarded to ``json.loads``
 
-        return new_numerics
+        Examples
+        --------
+        ::
+
+            with open("my_numerics.json", "r") as f:
+                my_numerics = Numerics.from_json(f.read())
+        """
+        numerics_dict = json.loads(json_str, **kwargs)
+        if overwrite_metadata:
+            numerics_dict.pop("_metadata")
+        return Numerics(**numerics_dict, title=overwrite_title)

--- a/pyrokinetics/numerics.py
+++ b/pyrokinetics/numerics.py
@@ -39,10 +39,10 @@ class Numerics:
     #: Value of :math:`k_x\rho`
     kx: float = 0.0
 
-    #: Initial time step, in units of ``tref``
+    #: Initial time step, in units of ``lref / vref``
     delta_time: float = 0.001
 
-    #: Time step, in units of ``tref``
+    #: Time step, in units of ``lref / vref``
     max_time: float = 500.0
 
     #: The ballooning angle (the point at which the radial wavenumber is zero)
@@ -83,9 +83,14 @@ class Numerics:
             self._metadata = metadata(title, self.__class__.__name__)
 
     def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
     def __setitem__(self, key: str, value: Any) -> None:
+        if key not in vars(self):
+            raise RuntimeError(f"Numerics does not have a key '{key}'")
         setattr(self, key, value)
 
     def __str__(self) -> str:

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -1,0 +1,83 @@
+import dataclasses
+import json
+
+from pyrokinetics import Numerics
+
+import pytest
+
+
+def test_keys():
+    numerics = Numerics()  # use defaults
+    # Test you can set an existing key
+    numerics["ntheta"] = 42
+    assert numerics.ntheta == 42
+    # Test you can't set a key that doesn't exist
+    with pytest.raises(KeyError):
+        numerics["n_theta"] = 42
+
+
+def test_attrs():
+    numerics = Numerics()  # use defaults
+    # Test you can set an existing attr
+    numerics.ntheta = 42
+    assert numerics.ntheta == 42
+    # Test you can't set a key that doesn't exist
+    with pytest.raises(AttributeError):
+        numerics.n_theta = 42
+
+
+def test_write(tmp_path):
+    numerics = Numerics()  # use defaults
+    d = tmp_path / "numerics"
+    d.mkdir(exist_ok=True)
+    filename = d / "test_write.json"
+    with open(filename, "w") as f:
+        f.write(numerics.to_json())
+    # Read as standard json and check values match
+    with open(filename) as f:
+        data = json.load(f)
+    for key, value in data.items():
+        if key == "_metadata":
+            for k2, v2 in data["_metadata"].items():
+                assert v2 == numerics._metadata[k2]
+        else:
+            assert value == numerics[key]
+
+
+def test_roundtrip(tmp_path):
+    numerics = Numerics()  # use defaults
+    d = tmp_path / "numerics"
+    d.mkdir(exist_ok=True)
+    filename = d / "test_roundtrip.json"
+    with open(filename, "w") as f:
+        f.write(numerics.to_json())
+    # Read as a new numerics
+    with open(filename) as f:
+        new_numerics = Numerics.from_json(f.read())
+    assert numerics == new_numerics
+
+
+def test_roundtrip_new_metadata(tmp_path):
+    numerics = Numerics()  # use defaults
+    d = tmp_path / "numerics"
+    d.mkdir(exist_ok=True)
+    filename = d / "test_roundtrip_new_metadata.json"
+    with open(filename, "w") as f:
+        f.write(numerics.to_json())
+    # Read as a new numerics, overwriting metadata
+    with open(filename) as f:
+        new_numerics = Numerics.from_json(
+            f.read(),
+            overwrite_metadata=True,
+            overwrite_title="hello world",
+        )
+    data = dataclasses.asdict(new_numerics)
+    for key, value in data.items():
+        if key == "_metadata":
+            for k2, v2 in data["_metadata"].items():
+                if "software" in k2 or "session" in k2 or "object_type" in k2:
+                    assert v2 == numerics._metadata[k2]
+                else:
+                    assert v2 != numerics._metadata[k2]
+        else:
+            assert value == numerics[key]


### PR DESCRIPTION
Some low-hanging fruit, following the discussion we had a few weeks ago. `Numerics` works by taking a dict to its `__init__` and absorbing everything given to it. If there's a typo in the code for a necessary key (say, `n_theta` instead of `ntheta`), it will quietly add a default value of `ntheta=32` and also store `n_theta=whatever`. We could catch this in testing, but it's easier to just enforce a reduced set of possible inputs in the first place.

This PR refactors `Numerics` as a [dataclass](https://docs.python.org/3/library/dataclasses.html), which gives it a nice `__init__` for free which will catch any stray `kwargs` and raise an error.

## Other features:

- Uses `__getitem__`/`__setitem__` for dict-like access.
- Can be written to/from json.
- Has a 'pretty format' method, works when you call `str(numerics)` or `print(numerics)`.
- Contains metadata that allows you to identify which Pyrokinetics session generated each object.
- Improved docs.

## Issues:

- Docs could use some further improvements. @bpatel2107 If you have time, please could you look over the docstrings/annotations (comments written as `#:`) and correct any mistakes or misunderstandings in there? I used the GS2 docs for reference, but it's likely that I've written something incorrect in there.
- Does it make sense for everything to have a default value?
- Needs a couple of tests for the json bits. I'll get on that tomorrow morning.