### PR TITLE
Set GENE output time to index and scale by nrg/field istep

### DIFF
--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -31,7 +31,7 @@ class GKOutputReaderGENE(GKOutputReader):
         if filename.is_dir():
             # If given a dir name, looks for dir/parameters_0000
             dirname = filename
-            dat_matches = np.all(
+            dat_matches = np.any(
                 [Path(filename / f"{p}.dat").is_file() for p in prefixes]
             )
             if dat_matches:
@@ -137,12 +137,17 @@ class GKOutputReaderGENE(GKOutputReader):
         # whatever condition is met first between simtimelim and timelim
         species = gk_input.get_local_species().names
         with open(raw_data["nrg"], "r") as f:
-            lasttime = float(f.readlines()[-(len(species) + 1)])
+            full_data = f.readlines()
+            ntime = len(full_data) // (len(species)+1)
+            lasttime = float(full_data[-(len(species) + 1)])
+
+        ntime = int(ntime * nml["in_out"]["istep_nrg"] /  nml["in_out"]["istep_field"])
+
         if lasttime == nml["general"]["simtimelim"]:
             ntime = ntime + 1
 
-        delta_t = nml["info"]["step_time"][0]
-        time = np.linspace(0, delta_t * (ntime - 1), ntime)
+        # Set time to index for now, gets overwritten by field data
+        time = np.linspace(0, ntime - 1, ntime)
 
         nfield = nml["info"]["n_fields"]
         field = cls.fields[:nfield]

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -128,11 +128,6 @@ class GKOutputReaderGENE(GKOutputReader):
         """
         nml = gk_input.data
 
-        ntime = (
-            nml["info"]["steps"][0]
-            // (gk_input.downsize * nml["in_out"]["istep_field"])
-            + 1
-        )
         # The last time step is not always written, but depends on
         # whatever condition is met first between simtimelim and timelim
         species = gk_input.get_local_species().names
@@ -141,7 +136,7 @@ class GKOutputReaderGENE(GKOutputReader):
             ntime = len(full_data) // (len(species) + 1)
             lasttime = float(full_data[-(len(species) + 1)])
 
-        ntime = int(ntime * nml["in_out"]["istep_nrg"] / nml["in_out"]["istep_field"])
+        ntime = int(ntime * nml["in_out"]["istep_nrg"] / nml["in_out"]["istep_field"]) + 1
 
         if lasttime == nml["general"]["simtimelim"]:
             ntime = ntime + 1

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -136,7 +136,9 @@ class GKOutputReaderGENE(GKOutputReader):
             ntime = len(full_data) // (len(species) + 1)
             lasttime = float(full_data[-(len(species) + 1)])
 
-        ntime = int(ntime * nml["in_out"]["istep_nrg"] / nml["in_out"]["istep_field"]) + 1
+        ntime = (
+            int(ntime * nml["in_out"]["istep_nrg"] / nml["in_out"]["istep_field"]) + 1
+        )
 
         if lasttime == nml["general"]["simtimelim"]:
             ntime = ntime + 1

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -138,10 +138,10 @@ class GKOutputReaderGENE(GKOutputReader):
         species = gk_input.get_local_species().names
         with open(raw_data["nrg"], "r") as f:
             full_data = f.readlines()
-            ntime = len(full_data) // (len(species)+1)
+            ntime = len(full_data) // (len(species) + 1)
             lasttime = float(full_data[-(len(species) + 1)])
 
-        ntime = int(ntime * nml["in_out"]["istep_nrg"] /  nml["in_out"]["istep_field"])
+        ntime = int(ntime * nml["in_out"]["istep_nrg"] / nml["in_out"]["istep_field"])
 
         if lasttime == nml["general"]["simtimelim"]:
             ntime = ntime + 1


### PR DESCRIPTION
Set GENE output time to index when initialising dataset as it gets over written when loading the fields. 

Number of time steps initially calculated from `nrg` file. Now we scale the number of time steps by `istep_nrg / istep_field` which handles cases when output frequency is different.

Fixes a check for the output files as `omega.dat` file is not generated in nonlinear runs