### PR TITLE
Enhancements/ion normalsation inputs

### DIFF
--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -633,16 +633,22 @@ class GKInputCGYRO(GKInput):
         return is_basic_miller
 
     def get_ne_te_normalisation(self):
-        # Get electron temp/dens first
-
+        found_electron = False
         if self.data.get("AE_FLAG", 0) == 1:
             ne = self.data["DENS_AE"]
             Te = self.data["TEMP_AE"]
+            found_electron = True
         else:
             for i_sp in range(self.data["N_SPECIES"]):
                 if self.data[f"Z_{i_sp+1}"] == -1:
                     ne = self.data[f"DENS_{i_sp+1}"]
                     Te = self.data[f"TEMP_{i_sp+1}"]
+                    found_electron = True
                     break
+
+        if not found_electron:
+            raise TypeError(
+                "Pyro currently requires an electron species in the input file"
+            )
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputCGYRO.py
+++ b/pyrokinetics/gk_code/GKInputCGYRO.py
@@ -634,10 +634,15 @@ class GKInputCGYRO(GKInput):
 
     def get_ne_te_normalisation(self):
         # Get electron temp/dens first
-        for i_sp in range(self.data["N_SPECIES"]):
-            if self.data[f"Z_{i_sp+1}"] == -1:
-                ne = self.data[f"DENS_{i_sp+1}"]
-                Te = self.data[f"TEMP_{i_sp+1}"]
-                break
+
+        if self.data.get("AE_FLAG", 0) == 1:
+            ne = self.data["DENS_AE"]
+            Te = self.data["TEMP_AE"]
+        else:
+            for i_sp in range(self.data["N_SPECIES"]):
+                if self.data[f"Z_{i_sp+1}"] == -1:
+                    ne = self.data[f"DENS_{i_sp+1}"]
+                    Te = self.data[f"TEMP_{i_sp+1}"]
+                    break
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -411,7 +411,7 @@ class GKInputGENE(GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         numerics_data["beta"] = (
-            self.data["general"]["beta"] * ureg.beta_ref_ee_B0 * ne * Te
+            self.data["general"]["beta"] * ureg.beta_ref_ee_B0 * ne_norm * Te_norm
         )
 
         return Numerics(**numerics_data)
@@ -591,8 +591,8 @@ class GKInputGENE(GKInput):
     def get_ne_te_normalisation(self):
         # Get electron temp and density to normalise input
         for i_sp in range(self.data["box"]["n_spec"]):
-            if self.data["species"][i_sp]["z"] == -1:
-                ne = self.data["species"]["dens"]
-                Te = self.data["species"]["temp"]
+            if self.data["species"][i_sp]["charge"] == -1:
+                ne = self.data["species"][i_sp]["dens"]
+                Te = self.data["species"][i_sp]["temp"]
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -589,7 +589,6 @@ class GKInputGENE(GKInput):
             self.data[name] = convert_dict(namelist, local_norm.gene)
 
     def get_ne_te_normalisation(self):
-
         adiabatic_electrons = True
         # Get electron temp and density to normalise input
         for i_sp in range(self.data["box"]["n_spec"]):
@@ -601,7 +600,10 @@ class GKInputGENE(GKInput):
         if adiabatic_electrons:
             ne = 0.0
             for i_sp in range(self.data["box"]["n_spec"]):
-                ne += self.data["species"][i_sp]["dens"] * self.data["species"][i_sp]["charge"]
+                ne += (
+                    self.data["species"][i_sp]["dens"]
+                    * self.data["species"][i_sp]["charge"]
+                )
 
             Te = self.data["species"][0]["temp"]
 

--- a/pyrokinetics/gk_code/GKInputGENE.py
+++ b/pyrokinetics/gk_code/GKInputGENE.py
@@ -589,10 +589,20 @@ class GKInputGENE(GKInput):
             self.data[name] = convert_dict(namelist, local_norm.gene)
 
     def get_ne_te_normalisation(self):
+
+        adiabatic_electrons = True
         # Get electron temp and density to normalise input
         for i_sp in range(self.data["box"]["n_spec"]):
             if self.data["species"][i_sp]["charge"] == -1:
                 ne = self.data["species"][i_sp]["dens"]
                 Te = self.data["species"][i_sp]["temp"]
+                adiabatic_electrons = False
+
+        if adiabatic_electrons:
+            ne = 0.0
+            for i_sp in range(self.data["box"]["n_spec"]):
+                ne += self.data["species"][i_sp]["dens"] * self.data["species"][i_sp]["charge"]
+
+            Te = self.data["species"][0]["temp"]
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -561,12 +561,18 @@ class GKInputGS2(GKInput):
             self.data[name] = convert_dict(namelist, local_norm.gs2)
 
     def get_ne_te_normalisation(self):
+
+        found_electron = False
         # Load each species into a dictionary
         for i_sp in range(self.data["species_knobs"]["nspec"]):
             gs2_key = f"species_parameters_{i_sp + 1}"
-            if self.data[gs2_key]["z"] == -1:
+            if self.data[gs2_key]["z"] == -1 and self.data[gs2_key]["type"] == "electron":
                 ne = self.data[gs2_key]["dens"]
                 Te = self.data[gs2_key]["temp"]
+                found_electron = True
                 break
+
+        if not found_electron:
+            raise TypeError("Pyro currently only supports electron species with charge = -1")
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputGS2.py
+++ b/pyrokinetics/gk_code/GKInputGS2.py
@@ -561,18 +561,22 @@ class GKInputGS2(GKInput):
             self.data[name] = convert_dict(namelist, local_norm.gs2)
 
     def get_ne_te_normalisation(self):
-
         found_electron = False
         # Load each species into a dictionary
         for i_sp in range(self.data["species_knobs"]["nspec"]):
             gs2_key = f"species_parameters_{i_sp + 1}"
-            if self.data[gs2_key]["z"] == -1 and self.data[gs2_key]["type"] == "electron":
+            if (
+                self.data[gs2_key]["z"] == -1
+                and self.data[gs2_key]["type"] == "electron"
+            ):
                 ne = self.data[gs2_key]["dens"]
                 Te = self.data[gs2_key]["temp"]
                 found_electron = True
                 break
 
         if not found_electron:
-            raise TypeError("Pyro currently only supports electron species with charge = -1")
+            raise TypeError(
+                "Pyro currently only supports electron species with charge = -1"
+            )
 
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -453,8 +453,8 @@ class GKInputTGLF(GKInput):
 
     def get_ne_te_normalisation(self):
         for i_sp in range(self.data["ns"]):
-            if self.data["zs_{i_sp+1}"] == -1:
-                ne = self.data["as_{i_sp+1}"]
-                Te = self.data["taus_{i_sp+1}"]
+            if self.data[f"zs_{i_sp+1}"] == -1:
+                ne = self.data[f"as_{i_sp+1}"]
+                Te = self.data[f"taus_{i_sp+1}"]
                 break
         return ne, Te

--- a/pyrokinetics/gk_code/GKInputTGLF.py
+++ b/pyrokinetics/gk_code/GKInputTGLF.py
@@ -452,9 +452,17 @@ class GKInputTGLF(GKInput):
                 self.data[key] = value.to(local_norm.cgyro).magnitude
 
     def get_ne_te_normalisation(self):
+        found_electron = False
         for i_sp in range(self.data["ns"]):
             if self.data[f"zs_{i_sp+1}"] == -1:
                 ne = self.data[f"as_{i_sp+1}"]
                 Te = self.data[f"taus_{i_sp+1}"]
+                found_electron = True
                 break
+
+        if not found_electron:
+            raise TypeError(
+                "Pyro currently requires an electron species in TGLF input files"
+            )
+
         return ne, Te

--- a/pyrokinetics/templates/input.gene
+++ b/pyrokinetics/templates/input.gene
@@ -54,6 +54,7 @@
     ntimesteps = 1000000
     simtimelim = 300.0
     timelim = 129000
+    zeff = 1.0
 /
 
 &geometry
@@ -75,7 +76,6 @@
     sign_ip_cw = 1
     trpeps = 0.16666666666666666
     zeta = 0.0
-    zeff = 1.0
 /
 
 &species

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -263,6 +263,27 @@ def test_pyro_write_gk_file(tmp_path, start_gk_code, end_gk_code):
     assert pyro.local_geometry is local_geometry
 
 
+@pytest.mark.parametrize("gk_code", ["GS2", "CGYRO", "TGLF"])
+def test_pyro_no_electrons_gk_file(tmp_path, gk_code):
+    pyro = Pyro()
+    pyro.read_gk_file(gk_templates[gk_code])
+
+    # Change electron charge to +1
+    pyro.local_species.electron.z *= -1
+
+    # Write new file without electrons
+    output_dir = tmp_path / "pyrokinetics_read_gk_file_no_electron_test"
+    output_dir.mkdir()
+    output_file = output_dir / f"{gk_code}.out"
+    pyro.write_gk_file(output_file, gk_code)
+
+    pyro_no_electron = Pyro()
+
+    # Assert reading file fails
+    with pytest.raises(TypeError):
+        pyro_no_electron.read_gk_file(output_file)
+
+
 @pytest.mark.parametrize(
     "gk_code,path",
     [


### PR DESCRIPTION
Re-normalised GK input files such that the electron temp and density is the reference values, in line with the units applied to `LocalSpecies`. 

Particularly relevant if an ion species has been used as the normalising species. Working out which species is being used is a bit longer (would likely require guessing given the charges and mass) but this method basically guarantees that we get the electron as the normalising speices.

Requires re-normalising density, temperature and beta.