### PR TITLE
WIP: Enhancements/gk output normalisation tweaks

### DIFF
--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -7,15 +7,12 @@ from pathlib import Path
 
 from .gk_output import (
     GKOutput,
-    get_flux_units,
-    get_field_units,
-    get_coord_units,
-    get_eigenvalues_units,
-    get_eigenfunctions_units,
-    get_moment_units,
-    FieldDict,
-    FluxDict,
-    MomentDict,
+    Coords,
+    Fields,
+    Fluxes,
+    Eigenvalues,
+    Eigenfunctions,
+    Moments,
 )
 from .GKInputCGYRO import GKInputCGYRO
 from ..constants import pi
@@ -48,80 +45,54 @@ class GKOutputReaderCGYRO(Reader):
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(filename)
         coords = self._get_coords(raw_data, gk_input, downsize)
-        if load_fields:
-            fields = self._get_fields(raw_data, gk_input, coords)
-        else:
-            fields = {}
-
-        if load_fluxes:
-            fluxes = self._get_fluxes(raw_data, coords)
-        else:
-            fluxes = {}
-
-        if load_moments:
-            moments = self._get_moments(raw_data, gk_input, coords)
-        else:
-            moments = {}
-
-        # Assign units and return GKOutput
-        convention = norm.cgyro
-        coord_units = get_coord_units(convention)
-        field_units = get_field_units(convention)
-        moments_units = get_moment_units(convention)
-        flux_units = get_flux_units(convention)
-        eig_units = get_eigenvalues_units(convention)
-        eigfunc_units = get_eigenfunctions_units(convention)
-
-        for field_name, field in fields.items():
-            fields[field_name] = field * field_units[field_name]
-
-        for moment_name, moment in moments.items():
-            moments[moment_name] = moment * moments_units[moment_name]
-
-        for flux_type, flux in fluxes.items():
-            fluxes[flux_type] = flux * flux_units[flux_type]
+        fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
+        fluxes = self._get_fluxes(raw_data, coords) if load_fluxes else None
+        moments = (
+            self._get_moments(raw_data, gk_input, coords) if load_moments else None
+        )
 
         if coords["linear"] and (
             coords["ntheta_plot"] != coords["ntheta_grid"] or not fields
         ):
             eigenvalues = self._get_eigenvalues(raw_data, coords, gk_input)
-            growth_rate = eigenvalues["growth_rate"] * eig_units["growth_rate"]
-            mode_frequency = eigenvalues["mode_frequency"] * eig_units["mode_frequency"]
-            eigenfunctions = (
-                self._get_eigenfunctions(raw_data, coords)
-                * eigfunc_units["eigenfunctions"]
-            )
-
+            eigenfunctions = self._get_eigenfunctions(raw_data, coords)
         else:
             # Rely on gk_output to generate eigenvalues
-            growth_rate = None
-            mode_frequency = None
+            eigenvalues = None
             eigenfunctions = None
 
+        # Assign units and return GKOutput
+        convention = norm.cgyro
+        field_dims = (("theta", "kx", "ky", "time"),)
+        flux_dims = (("field", "species", "ky", "time"),)
+        moment_dims = (("theta", "kx", "species", "ky", "time"),)
         return GKOutput(
-            time=coords["time"] * coord_units["time"],
-            kx=coords["kx"] * coord_units["kx"],
-            ky=coords["ky"] * coord_units["ky"],
-            theta=coords["theta"] * coord_units["theta"],
-            pitch=coords["pitch"] * coord_units["pitch"],
-            energy=coords["energy"] * coord_units["energy"],
-            field_dim=coords["field"],
-            flux_dim=coords["flux"],
-            moment_dim=coords["moment"],
-            field_var=("theta", "kx", "ky", "time"),
-            flux_var=("field", "species", "ky", "time"),
-            moment_var=("theta", "kx", "species", "ky", "time"),
-            species=coords["species"],
-            fields=fields,
-            fluxes=fluxes,
-            moments=moments,
+            coords=Coords(
+                time=coords["time"],
+                kx=coords["kx"],
+                ky=coords["ky"],
+                theta=coords["theta"],
+                pitch=coords["pitch"],
+                energy=coords["energy"],
+                species=coords["species"],
+            ).with_units(convention),
             norm=norm,
+            fields=Fields(**fields, dims=field_dims).with_units(convention)
+            if fields
+            else None,
+            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+            if fluxes
+            else None,
+            moments=Moments(**moments, dims=moment_dims).with_units(convention)
+            if moments
+            else None,
+            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
+            if eigenvalues
+            else None,
+            eigenfunctions=Eigenfunctions(eigenfunctions) if eigenfunctions else None,
             linear=coords["linear"],
             gk_code="CGYRO",
             input_file=input_str,
-            growth_rate=growth_rate,
-            mode_frequency=mode_frequency,
-            eigenfunctions=eigenfunctions,
         )
 
     def verify(self, dirname: PathLike):
@@ -318,7 +289,7 @@ class GKOutputReaderCGYRO(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputCGYRO,
         coords: Dict[str, Any],
-    ) -> FieldDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D fields over time.
         The field coordinates should be (field, theta, kx, ky, time)
@@ -415,7 +386,7 @@ class GKOutputReaderCGYRO(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputCGYRO,
         coords: Dict[str, Any],
-    ) -> MomentDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D moments over time.
         The moment coordinates should be (moment, theta, kx, species, ky, time)
@@ -497,7 +468,7 @@ class GKOutputReaderCGYRO(Reader):
     def _get_fluxes(
         raw_data: Dict[str, Any],
         coords: Dict,
-    ) -> FluxDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
         The flux coordinates should be (species, moment, field, ky, time)
@@ -528,7 +499,7 @@ class GKOutputReaderCGYRO(Reader):
     @classmethod
     def _get_eigenvalues(
         self, raw_data: Dict[str, Any], coords: Dict, gk_input: Optional[Any] = None
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, np.ndarray]:
         """
         Takes an xarray Dataset that has had coordinates and fields set.
         Uses this to add eigenvalues:
@@ -574,24 +545,21 @@ class GKOutputReaderCGYRO(Reader):
         mode_frequency = mode_sign * eigenvalue_over_time[0, :, :]
 
         growth_rate = eigenvalue_over_time[1, :, :]
-        eigenvalue = mode_frequency + 1j * growth_rate
         # Add kx axis for compatibility with GS2 eigenvalues
         # FIXME Is this appropriate? Should we drop the kx coordinate?
         shape_with_kx = (nkx, nky, ntime)
         mode_frequency = np.ones(shape_with_kx) * mode_frequency
         growth_rate = np.ones(shape_with_kx) * growth_rate
-        eigenvalue = np.ones(shape_with_kx) * eigenvalue
 
         result = {
             "growth_rate": growth_rate,
             "mode_frequency": mode_frequency,
-            "eigenvalues": eigenvalue,
         }
 
         return result
 
     @staticmethod
-    def _get_eigenfunctions(raw_data: Dict[str, Any], coords: Dict) -> Dict[str, Any]:
+    def _get_eigenfunctions(raw_data: Dict[str, Any], coords: Dict) -> np.ndarray:
         """
         Loads eigenfunctions into data with the following coordinates:
 

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -89,7 +89,9 @@ class GKOutputReaderCGYRO(Reader):
             eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
             if eigenvalues
             else None,
-            eigenfunctions=Eigenfunctions(eigenfunctions) if eigenfunctions else None,
+            eigenfunctions=None
+            if eigenfunctions is None
+            else Eigenfunctions(eigenfunctions),
             linear=coords["linear"],
             gk_code="CGYRO",
             input_file=input_str,

--- a/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
+++ b/pyrokinetics/gk_code/GKOutputReaderCGYRO.py
@@ -63,9 +63,9 @@ class GKOutputReaderCGYRO(Reader):
 
         # Assign units and return GKOutput
         convention = norm.cgyro
-        field_dims = (("theta", "kx", "ky", "time"),)
-        flux_dims = (("field", "species", "ky", "time"),)
-        moment_dims = (("theta", "kx", "species", "ky", "time"),)
+        field_dims = ("theta", "kx", "ky", "time")
+        flux_dims = ("field", "species", "ky", "time")
+        moment_dims = ("theta", "kx", "species", "ky", "time")
         return GKOutput(
             coords=Coords(
                 time=coords["time"],

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -426,7 +426,9 @@ class GKOutputReaderGENE(Reader):
         raise NotImplementedError
 
     @staticmethod
-    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    def _get_fluxes(
+        raw_data: Dict[str, Any], coords: Dict[str, Any]
+    ) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
         The flux coordinates should  be (species, flux, field, ky, time)
@@ -524,7 +526,9 @@ class GKOutputReaderGENE(Reader):
         return results
 
     @staticmethod
-    def _get_eigenvalues(raw_data: Dict[str, Any], coords: Dict) -> Dict[str, np.ndarray]:
+    def _get_eigenvalues(
+        raw_data: Dict[str, Any], coords: Dict
+    ) -> Dict[str, np.ndarray]:
         """
 
         Parameters

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -8,17 +8,7 @@ import h5py
 from typing import Tuple, Dict, Any
 from pathlib import Path
 
-from .gk_output import (
-    GKOutput,
-    get_flux_units,
-    get_field_units,
-    get_coord_units,
-    get_moment_units,
-    get_eigenvalues_units,
-    FieldDict,
-    FluxDict,
-    MomentDict,
-)
+from .gk_output import GKOutput, Coords, Fields, Fluxes, Eigenvalues, Moments
 from .GKInputGENE import GKInputGENE
 from ..constants import pi
 from ..typing import PathLike
@@ -40,22 +30,6 @@ class GKOutputReaderGENE(Reader):
         load_moments=False,
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(filename)
-        coords = self._get_coords(raw_data, gk_input, downsize)
-        if load_fields:
-            fields = self._get_fields(raw_data, gk_input, coords)
-        else:
-            fields = {}
-
-        if load_fluxes:
-            fluxes = self._get_fluxes(raw_data, coords)
-        else:
-            fluxes = {}
-
-        if load_moments:
-            moments = self._get_moments(raw_data, gk_input, coords)
-        else:
-            moments = {}
-
         # Determine normalisation used
         nml = gk_input.data
         if nml["geometry"].get("minor_r", 0.0) == 1.0:
@@ -67,54 +41,49 @@ class GKOutputReaderGENE(Reader):
                 "Pyro does not handle GENE cases where neither major_R and minor_r are 1.0"
             )
 
-        # Assign units and return GKOutput
-        coord_units = get_coord_units(convention)
-        field_units = get_field_units(convention)
-        moments_units = get_moment_units(convention)
-        flux_units = get_flux_units(convention)
-        eig_units = get_eigenvalues_units(convention)
-
-        for field_name, field in fields.items():
-            fields[field_name] = field * field_units[field_name]
-
-        for moment_name, moment in moments.items():
-            moments[moment_name] = moment * moments_units[moment_name]
-
-        for flux_type, flux in fluxes.items():
-            fluxes[flux_type] = flux * flux_units[flux_type]
+        coords = self._get_coords(raw_data, gk_input, downsize)
+        fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
+        fluxes = self._get_fluxes(raw_data, coords) if load_fluxes else None
+        moments = (
+            self._get_moments(raw_data, gk_input, coords) if load_moments else None
+        )
 
         if coords["linear"] and not fields:
             eigenvalues = self._get_eigenvalues(raw_data, coords)
-            growth_rate = eigenvalues["growth_rate"] * eig_units["growth_rate"]
-            mode_frequency = eigenvalues["mode_frequency"] * eig_units["mode_frequency"]
         else:
             # Rely on gk_output to generate eigenvalues
-            growth_rate = None
-            mode_frequency = None
+            eigenvalues = None
 
+        # Assign units and return GKOutput
+        field_dims = (("theta", "kx", "ky", "time"),)
+        flux_dims = (("field", "species", "time"),)
+        moment_dims = (("field", "species", "time"),)
         return GKOutput(
-            time=coords["time"] * coord_units["time"],
-            kx=coords["kx"] * coord_units["kx"],
-            ky=coords["ky"] * coord_units["ky"],
-            theta=coords["theta"] * coord_units["theta"],
-            pitch=coords["pitch"] * coord_units["pitch"],
-            energy=coords["energy"] * coord_units["energy"],
-            field_dim=coords["field"],
-            flux_dim=coords["flux"],
-            moment_dim=coords["moment"],
-            field_var=("theta", "kx", "ky", "time"),
-            flux_var=("field", "species", "time"),
-            moment_var=("field", "species", "time"),
-            species=coords["species"],
-            fields=fields,
-            fluxes=fluxes,
-            moments=moments,
+            coords=Coords(
+                time=coords["time"],
+                kx=coords["kx"],
+                ky=coords["ky"],
+                theta=coords["theta"],
+                pitch=coords["pitch"],
+                energy=coords["energy"],
+                species=coords["species"],
+            ).with_units(convention),
             norm=norm,
+            fields=Fields(**fields, dims=field_dims).with_units(convention)
+            if fields
+            else None,
+            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+            if fluxes
+            else None,
+            moments=Moments(**moments, dims=moment_dims).with_units(convention)
+            if moments
+            else None,
+            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
+            if eigenvalues
+            else None,
             linear=coords["linear"],
             gk_code="GENE",
             input_file=input_str,
-            growth_rate=growth_rate,
-            mode_frequency=mode_frequency,
             normalise_flux_moment=True,
         )
 
@@ -321,7 +290,7 @@ class GKOutputReaderGENE(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputGENE,
         coords: Dict[str, Any],
-    ) -> FieldDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D fields over time.
         The field coordinates should be (field, theta, kx, ky, time)
@@ -449,7 +418,7 @@ class GKOutputReaderGENE(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputGENE,
         coords: Dict[str, Any],
-    ) -> MomentDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D moments over time.
         The moment coordinates should be (moment, theta, kx, species, ky, time)
@@ -457,7 +426,7 @@ class GKOutputReaderGENE(Reader):
         raise NotImplementedError
 
     @staticmethod
-    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> FluxDict:
+    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
         The flux coordinates should  be (species, flux, field, ky, time)
@@ -555,7 +524,7 @@ class GKOutputReaderGENE(Reader):
         return results
 
     @staticmethod
-    def _get_eigenvalues(raw_data: Dict[str, Any], coords: Dict) -> Dict[str, Any]:
+    def _get_eigenvalues(raw_data: Dict[str, Any], coords: Dict) -> Dict[str, np.ndarray]:
         """
 
         Parameters

--- a/pyrokinetics/gk_code/GKOutputReaderGENE.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGENE.py
@@ -55,9 +55,9 @@ class GKOutputReaderGENE(Reader):
             eigenvalues = None
 
         # Assign units and return GKOutput
-        field_dims = (("theta", "kx", "ky", "time"),)
-        flux_dims = (("field", "species", "time"),)
-        moment_dims = (("field", "species", "time"),)
+        field_dims = ("theta", "kx", "ky", "time")
+        flux_dims = ("field", "species", "time")
+        moment_dims = ("field", "species", "time")
         return GKOutput(
             coords=Coords(
                 time=coords["time"],

--- a/pyrokinetics/gk_code/GKOutputReaderGS2.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGS2.py
@@ -41,8 +41,8 @@ class GKOutputReaderGS2(Reader):
         # Assign units and return GKOutput
         convention = norm.gs2
         field_dims = ("theta", "kx", "ky", "time")
-        flux_dims = (("field", "species", "ky", "time"),)
-        moment_dims = (("field", "species", "ky", "time"),)
+        flux_dims = ("field", "species", "ky", "time")
+        moment_dims = ("field", "species", "ky", "time")
         return GKOutput(
             coords=Coords(
                 time=coords["time"],

--- a/pyrokinetics/gk_code/GKOutputReaderGS2.py
+++ b/pyrokinetics/gk_code/GKOutputReaderGS2.py
@@ -5,19 +5,8 @@ import warnings
 
 import numpy as np
 import xarray as xr
-from numpy.typing import ArrayLike
 
-from .gk_output import (
-    GKOutput,
-    get_flux_units,
-    get_field_units,
-    get_coord_units,
-    get_moment_units,
-    get_eigenvalues_units,
-    FieldDict,
-    FluxDict,
-    MomentDict,
-)
+from .gk_output import GKOutput, Coords, Fields, Fluxes, Moments, Eigenvalues
 from .GKInputGS2 import GKInputGS2
 from ..typing import PathLike
 from ..readers import Reader
@@ -37,71 +26,49 @@ class GKOutputReaderGS2(Reader):
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(filename)
         coords = self._get_coords(raw_data, gk_input, downsize)
-
-        if load_fields:
-            fields = self._get_fields(raw_data)
-        else:
-            fields = {}
-
-        if load_fluxes:
-            fluxes = self._get_fluxes(raw_data, gk_input, coords)
-        else:
-            fluxes = {}
-
-        if load_moments:
-            moments = self._get_moments(raw_data, gk_input, coords)
-        else:
-            moments = {}
-
-        # Assign units and return GKOutput
-        convention = norm.gs2
-        coord_units = get_coord_units(convention)
-        field_units = get_field_units(convention)
-        moments_units = get_moment_units(convention)
-        flux_units = get_flux_units(convention)
-        eig_units = get_eigenvalues_units(convention)
-
-        for field_name, field in fields.items():
-            fields[field_name] = field * field_units[field_name]
-
-        for moment_name, moment in moments.items():
-            moments[moment_name] = moment * moments_units[moment_name]
-
-        for flux_type, flux in fluxes.items():
-            fluxes[flux_type] = flux * flux_units[flux_type]
+        fields = self._get_fields(raw_data) if load_fields else None
+        fluxes = self._get_fluxes(raw_data, gk_input, coords) if load_fluxes else None
+        moments = (
+            self._get_moments(raw_data, gk_input, coords) if load_moments else None
+        )
 
         if fields or coords["linear"]:
             # Rely on gk_output to generate eigenvalues
-            growth_rate = None
-            mode_frequency = None
+            eigenvalues = None
         else:
             eigenvalues = self._get_eigenvalues(raw_data, coords["time_divisor"])
-            growth_rate = eigenvalues["growth_rate"] * eig_units["growth_rate"]
-            mode_frequency = eigenvalues["mode_frequency"] * eig_units["mode_frequency"]
 
+        # Assign units and return GKOutput
+        convention = norm.gs2
+        field_dims = ("theta", "kx", "ky", "time")
+        flux_dims = (("field", "species", "ky", "time"),)
+        moment_dims = (("field", "species", "ky", "time"),)
         return GKOutput(
-            time=coords["time"] * coord_units["time"],
-            kx=coords["kx"] * coord_units["kx"],
-            ky=coords["ky"] * coord_units["ky"],
-            theta=coords["theta"] * coord_units["theta"],
-            pitch=coords["pitch"] * coord_units["pitch"],
-            energy=coords["energy"] * coord_units["energy"],
-            field_dim=coords["field"],
-            flux_dim=coords["flux"],
-            moment_dim=coords["moment"],
-            field_var=("theta", "kx", "ky", "time"),
-            flux_var=("field", "species", "ky", "time"),
-            moment_var=("field", "species", "ky", "time"),
-            species=coords["species"],
-            fields=fields,
-            fluxes=fluxes,
-            moments=moments,
+            coords=Coords(
+                time=coords["time"],
+                kx=coords["kx"],
+                ky=coords["ky"],
+                theta=coords["theta"],
+                pitch=coords["pitch"],
+                energy=coords["energy"],
+                species=coords["species"],
+            ).with_units(convention),
             norm=norm,
+            fields=Fields(**fields, dims=field_dims).with_units(convention)
+            if fields
+            else None,
+            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+            if fluxes
+            else None,
+            moments=Moments(**moments, dims=moment_dims).with_units(convention)
+            if moments
+            else None,
+            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
+            if eigenvalues
+            else None,
             linear=coords["linear"],
             gk_code="GS2",
             input_file=input_str,
-            growth_rate=growth_rate,
-            mode_frequency=mode_frequency,
             normalise_flux_moment=True,
         )
 
@@ -233,7 +200,7 @@ class GKOutputReaderGS2(Reader):
         }
 
     @staticmethod
-    def _get_fields(raw_data: xr.Dataset) -> FieldDict:
+    def _get_fields(raw_data: xr.Dataset) -> Dict[str, np.ndarray]:
         """
         For GS2 to print fields, we must have fphi, fapar and fbpar set to 1.0 in the
         input file under 'knobs'. We must also instruct GS2 to print each field
@@ -276,7 +243,7 @@ class GKOutputReaderGS2(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputGS2,
         coords: Dict[str, Any],
-    ) -> MomentDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D moments over time.
         The moment coordinates should be (moment, theta, kx, species, ky, time)
@@ -288,7 +255,7 @@ class GKOutputReaderGS2(Reader):
         raw_data: xr.Dataset,
         gk_input: GKInputGS2,
         coords: Dict,
-    ) -> FluxDict:
+    ) -> Dict[str, np.ndarray]:
         """
         For GS2 to print fluxes, we must have fphi, fapar and fbpar set to 1.0 in the
         input file under 'knobs'. We must also set the following in
@@ -351,7 +318,7 @@ class GKOutputReaderGS2(Reader):
     @staticmethod
     def _get_eigenvalues(
         raw_data: xr.Dataset, time_divisor: float
-    ) -> Dict[str, ArrayLike]:
+    ) -> Dict[str, np.ndarray]:
         # should only be called if no field data were found
         mode_frequency = raw_data.omega_average.isel(ri=0).transpose("kx", "ky", "time")
         growth_rate = raw_data.omega_average.isel(ri=1).transpose("kx", "ky", "time")

--- a/pyrokinetics/gk_code/GKOutputReaderTGLF.py
+++ b/pyrokinetics/gk_code/GKOutputReaderTGLF.py
@@ -4,17 +4,13 @@ from pathlib import Path
 
 from .gk_output import (
     GKOutput,
-    get_flux_units,
-    get_field_units,
-    get_moment_units,
-    get_coord_units,
-    get_eigenvalues_units,
-    get_eigenfunctions_units,
-    FieldDict,
-    FluxDict,
-    MomentDict,
+    Coords,
+    Fields,
+    Fluxes,
+    Eigenvalues,
+    Eigenfunctions,
+    Moments,
 )
-
 from .GKInputTGLF import GKInputTGLF
 from ..typing import PathLike
 from ..normalisation import SimulationNormalisation
@@ -41,79 +37,52 @@ class GKOutputReaderTGLF(Reader):
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(filename)
         coords = self._get_coords(raw_data, gk_input)
-        if load_fields:
-            fields = self._get_fields(raw_data, coords)
-        else:
-            fields = {}
-
-        if load_fluxes:
-            fluxes = self._get_fluxes(raw_data, coords)
-        else:
-            fluxes = {}
-
-        if load_moments:
-            moments = self._get_moments(raw_data, coords)
-        else:
-            moments = {}
+        fields = self._get_fields(raw_data, coords) if load_fields else None
+        fluxes = self._get_fluxes(raw_data, coords) if load_fluxes else None
+        moments = self._get_moments(raw_data, coords) if load_moments else None
+        eigenvalues = self._get_eigenvalues(raw_data, coords, gk_input)
+        eigenfunctions = (
+            self._get_eigenfunctions(raw_data, coords) if coords["linear"] else None
+        )
 
         # Assign units and return GKOutput
         convention = norm.cgyro
-        coord_units = get_coord_units(convention)
-        field_units = get_field_units(convention)
-        flux_units = get_flux_units(convention)
-        moment_units = get_moment_units(convention)
-        eig_units = get_eigenvalues_units(convention)
-        eigfunc_units = get_eigenfunctions_units(convention)
 
-        for field_name, field in fields.items():
-            fields[field_name] = field * field_units[field_name]
-
-        for flux_type, flux in fluxes.items():
-            fluxes[flux_type] = flux * flux_units[flux_type]
-
-        for moment_type, moment in moments.items():
-            moments[moment_type] = moment * moment_units[moment_type]
-
-        eigenvalues = self._get_eigenvalues(raw_data, coords, gk_input)
-        growth_rate = eigenvalues["growth_rate"] * eig_units["growth_rate"]
-        mode_frequency = eigenvalues["mode_frequency"] * eig_units["mode_frequency"]
-
-        if coords["linear"]:
-            eigenfunctions = (
-                self._get_eigenfunctions(raw_data, coords)["eigenfunctions"]
-                * eigfunc_units["eigenfunctions"]
-            )
-        else:
-            eigenfunctions = None
-
-        if coords["theta"] is not None:
-            coords["theta"] *= coord_units["theta"]
-
+        field_dims = (("ky", "mode"),)
+        flux_dims = (("field", "species", "ky"),)
+        moment_dims = (("field", "species", "ky"),)
+        eigenvalues_dims = (("ky", "mode"),)
+        eigenfunctions_dims = (("theta", "mode", "field"),)
         return GKOutput(
-            time=coords["time"] * coord_units["time"],
-            kx=coords["kx"] * coord_units["kx"],
-            ky=coords["ky"] * coord_units["ky"],
-            theta=coords["theta"],
-            mode=coords["mode"] * coord_units["mode"],
-            field_dim=coords["field"],
-            flux_dim=coords["flux"],
-            moment_dim=coords["moment"],
-            field_var=("ky", "mode"),
-            flux_var=("field", "species", "ky"),
-            moment_var=("field", "species", "ky"),
-            species=coords["species"],
-            fields=fields,
-            moments=moments,
-            fluxes=fluxes,
+            coords=Coords(
+                time=coords["time"],
+                kx=coords["kx"],
+                ky=coords["ky"],
+                theta=coords["theta"],
+                mode=coords["mode"],
+                species=coords["species"],
+            ).with_units(convention),
             norm=norm,
+            fields=Fields(**fields, dims=field_dims).with_units(convention)
+            if fields
+            else None,
+            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+            if fluxes
+            else None,
+            moments=Moments(**moments, dims=moment_dims).with_units(convention)
+            if moments
+            else None,
+            eigenvalues=Eigenvalues(**eigenvalues, dims=eigenvalues_dims).with_units(
+                convention
+            )
+            if eigenvalues
+            else None,
+            eigenfunctions=Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims)
+            if eigenfunctions
+            else None,
             linear=coords["linear"],
             gk_code="TGLF",
             input_file=input_str,
-            growth_rate=growth_rate,
-            mode_frequency=mode_frequency,
-            eigenfunctions=eigenfunctions,
-            eigval_var=("ky", "mode"),
-            eigenfunctions_var=("theta", "mode", "field"),
         )
 
     @staticmethod
@@ -280,7 +249,7 @@ class GKOutputReaderTGLF(Reader):
             }
 
     @staticmethod
-    def _get_fields(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> FieldDict:
+    def _get_fields(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
         """
         Sets fields over  for eac ky.
         The field coordinates should be (ky, mode, field)
@@ -313,7 +282,7 @@ class GKOutputReaderTGLF(Reader):
         raw_data: Dict[str, Any],
         gk_input: GKInputTGLF,
         coords: Dict[str, Any],
-    ) -> MomentDict:
+    ) -> Dict[str, np.ndarray]:
         """
         Sets 3D moments over time.
         The moment coordinates should be (moment, theta, kx, species, ky, time)
@@ -321,7 +290,7 @@ class GKOutputReaderTGLF(Reader):
         raise NotImplementedError
 
     @staticmethod
-    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> FluxDict:
+    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
         The flux coordinates should be (species, field, ky, moment)
@@ -342,6 +311,7 @@ class GKOutputReaderTGLF(Reader):
             full_data = [float(x.strip()) for x in full_data if is_float(x.strip())]
 
             fluxes = np.reshape(full_data, (nspecies, nfield, nky, nflux))
+            # Order should be (flux, field, species, ky)
             fluxes = fluxes.transpose((3, 1, 0, 2))
 
             # Pyro doesn't handle parallel/exchange fluxs yet
@@ -358,7 +328,7 @@ class GKOutputReaderTGLF(Reader):
         raw_data: Dict[str, Any],
         coords: Dict[str, Any],
         gk_input: Optional[Any] = None,
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, np.ndarray]:
         """
         Takes an xarray Dataset that has had coordinates and fields set.
         Uses this to add eigenvalues:
@@ -414,7 +384,6 @@ class GKOutputReaderTGLF(Reader):
             growth_rate = eigenvalues[:, :, 1]
 
             eigenvalues = mode_frequency + 1j * growth_rate
-            results["eigenvalues"] = eigenvalues
             results["growth_rate"] = growth_rate
             results["mode_frequency"] = mode_frequency
 
@@ -424,45 +393,39 @@ class GKOutputReaderTGLF(Reader):
     def _get_eigenfunctions(
         raw_data: Dict[str, Any],
         coords: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    ) -> np.ndarray:
         """
-        Loads eigenfunctions into data with the following coordinates:
-
-        data['eigenfunctions'] = eigenfunctions(mode, field, theta)
+        Returns eigenfunctions with the coordinates ``(mode, field, theta)``
 
         Only possible with single ky runs (USE_TRANSPORT_MODEL=False)
         """
 
-        results = {}
-
         # Load wavefunction if file exists
-        if "wavefunction" in raw_data:
-            f = raw_data["wavefunction"].splitlines()
-            grid = f[0].strip().split(" ")
-            grid = [x for x in grid if x]
+        if "wavefunction" not in raw_data:
+            return None
 
-            # In case no unstable modes are found
-            nmode_data = int(grid[0])
-            nmode = len(coords["mode"])
-            nfield = len(coords["field"])
-            ntheta = len(coords["theta"])
+        f = raw_data["wavefunction"].splitlines()
+        grid = f[0].strip().split(" ")
+        grid = [x for x in grid if x]
 
-            eigenfunctions = np.zeros((ntheta, nmode, nfield), dtype="complex")
+        # In case no unstable modes are found
+        nmode_data = int(grid[0])
+        nmode = len(coords["mode"])
+        nfield = len(coords["field"])
+        ntheta = len(coords["theta"])
 
-            full_data = " ".join(f[1:]).split(" ")
-            full_data = [float(x.strip()) for x in full_data if is_float(x.strip())]
-            full_data = np.reshape(full_data, (ntheta, (nmode_data * 2 * nfield) + 1))
+        eigenfunctions = np.zeros((ntheta, nmode, nfield), dtype="complex")
 
-            reshaped_data = np.reshape(
-                full_data[:, 1:], (ntheta, nmode_data, nfield, 2)
-            )
+        full_data = " ".join(f[1:]).split(" ")
+        full_data = [float(x.strip()) for x in full_data if is_float(x.strip())]
+        full_data = np.reshape(full_data, (ntheta, (nmode_data * 2 * nfield) + 1))
 
-            eigenfunctions[:, :nmode_data, :] = (
-                reshaped_data[:, :, :, 1] + 1j * reshaped_data[:, :, :, 0]
-            )
-            results["eigenfunctions"] = eigenfunctions
+        reshaped_data = np.reshape(full_data[:, 1:], (ntheta, nmode_data, nfield, 2))
 
-        return results
+        eigenfunctions[:, :nmode_data, :] = (
+            reshaped_data[:, :, :, 1] + 1j * reshaped_data[:, :, :, 0]
+        )
+        return eigenfunctions
 
 
 def is_float(element):

--- a/pyrokinetics/gk_code/GKOutputReaderTGLF.py
+++ b/pyrokinetics/gk_code/GKOutputReaderTGLF.py
@@ -61,6 +61,7 @@ class GKOutputReaderTGLF(Reader):
                 theta=coords["theta"],
                 mode=coords["mode"],
                 species=coords["species"],
+                field=coords["field"],
             ).with_units(convention),
             norm=norm,
             fields=Fields(**fields, dims=field_dims).with_units(convention)
@@ -77,9 +78,9 @@ class GKOutputReaderTGLF(Reader):
             )
             if eigenvalues
             else None,
-            eigenfunctions=Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims)
-            if eigenfunctions
-            else None,
+            eigenfunctions=None
+            if eigenfunctions is None
+            else Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims),
             linear=coords["linear"],
             gk_code="TGLF",
             input_file=input_str,
@@ -249,7 +250,9 @@ class GKOutputReaderTGLF(Reader):
             }
 
     @staticmethod
-    def _get_fields(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    def _get_fields(
+        raw_data: Dict[str, Any], coords: Dict[str, Any]
+    ) -> Dict[str, np.ndarray]:
         """
         Sets fields over  for eac ky.
         The field coordinates should be (ky, mode, field)
@@ -290,7 +293,9 @@ class GKOutputReaderTGLF(Reader):
         raise NotImplementedError
 
     @staticmethod
-    def _get_fluxes(raw_data: Dict[str, Any], coords: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    def _get_fluxes(
+        raw_data: Dict[str, Any], coords: Dict[str, Any]
+    ) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
         The flux coordinates should be (species, field, ky, moment)

--- a/pyrokinetics/gk_code/GKOutputReaderTGLF.py
+++ b/pyrokinetics/gk_code/GKOutputReaderTGLF.py
@@ -48,11 +48,11 @@ class GKOutputReaderTGLF(Reader):
         # Assign units and return GKOutput
         convention = norm.cgyro
 
-        field_dims = (("ky", "mode"),)
-        flux_dims = (("field", "species", "ky"),)
-        moment_dims = (("field", "species", "ky"),)
-        eigenvalues_dims = (("ky", "mode"),)
-        eigenfunctions_dims = (("theta", "mode", "field"),)
+        field_dims = ("ky", "mode")
+        flux_dims = ("field", "species", "ky")
+        moment_dims = ("field", "species", "ky")
+        eigenvalues_dims = ("ky", "mode")
+        eigenfunctions_dims = ("theta", "mode", "field")
         return GKOutput(
             coords=Coords(
                 time=coords["time"],

--- a/pyrokinetics/gk_code/gk_output.py
+++ b/pyrokinetics/gk_code/gk_output.py
@@ -167,6 +167,7 @@ class Fields:
             # If already has units, renormalise
             if hasattr(val, "units"):
                 kwargs[key] = val.to(c)
+                continue
             # If doesn't have units, add them
             kwargs[key] = val * self.units(key, c)
         return Fields(**kwargs)
@@ -243,6 +244,7 @@ class Fluxes:
             # If already has units, renormalise
             if hasattr(val, "units"):
                 kwargs[key] = val.to(c)
+                continue
             # If doesn't have units, add them
             kwargs[key] = val * self.units(key, c)
         return Fluxes(**kwargs)
@@ -319,6 +321,7 @@ class Moments:
             # If already has units, renormalise
             if hasattr(val, "units"):
                 kwargs[key] = val.to(c)
+                continue
             # If doesn't have units, add them
             kwargs[key] = val * self.units(key, c)
         return Moments(**kwargs)
@@ -386,6 +389,7 @@ class Eigenvalues:
             # If already has units, renormalise
             if hasattr(val, "units"):
                 kwargs[key] = val.to(c)
+                continue
             # If doesn't have units, add them
             kwargs[key] = val * self.units(c)
         return Eigenvalues(**kwargs)

--- a/pyrokinetics/gk_code/gk_output.py
+++ b/pyrokinetics/gk_code/gk_output.py
@@ -173,9 +173,6 @@ class Fields:
 
     def __post_init__(self):
         """Perform checks on the values assigned."""
-        # Fix weird issue where default dims is a tuple-of-tuples
-        if np.ndim(self.dims) == 2:
-            self.dims = self.dims[0]
         for name in self.names:
             field = vars(self)[name]
             if field is not None and np.ndim(field) != len(self.dims):
@@ -252,9 +249,6 @@ class Fluxes:
 
     def __post_init__(self):
         """Perform checks on the values assigned."""
-        # Fix weird issue where default dims is a tuple-of-tuples
-        if np.ndim(self.dims) == 2:
-            self.dims = self.dims[0]
         for name in self.names:
             flux = vars(self)[name]
             if flux is not None and np.ndim(flux) != len(self.dims):
@@ -331,9 +325,6 @@ class Moments:
 
     def __post_init__(self):
         """Perform checks on the values assigned."""
-        # Fix weird issue where default dims is a tuple-of-tuples
-        if np.ndim(self.dims) == 2:
-            self.dims = self.dims[0]
         for name in self.names:
             moment = vars(self)[name]
             if moment is not None and np.ndim(moment) != len(self.dims):
@@ -401,9 +392,6 @@ class Eigenvalues:
 
     def __post_init__(self):
         """Perform checks on the values assigned."""
-        # Fix weird issue where default dims is a tuple-of-tuples
-        if np.ndim(self.dims) == 2:
-            self.dims = self.dims[0]
         for name in self.names:
             eig = vars(self)[name]
             if np.ndim(eig) != len(self.dims):
@@ -432,9 +420,6 @@ class Eigenfunctions:
 
     def __post_init__(self):
         """Perform checks on the values assigned."""
-        # Fix weird issue where default dims is a tuple-of-tuples
-        if np.ndim(self.dims) == 2:
-            self.dims = self.dims[0]
         if np.ndim(self.data) != len(self.dims):
             raise ValueError("Eigenfunctions has incorrect number of dims")
 

--- a/pyrokinetics/gk_code/gk_output.py
+++ b/pyrokinetics/gk_code/gk_output.py
@@ -1,9 +1,9 @@
 import dataclasses
 from pathlib import Path
-from textwrap import dedent
-from typing import Callable, Dict, Optional, Type, TypedDict, List
+from typing import Callable, ClassVar, Dict, Iterable, Optional, Tuple, Type, List
 
 import numpy as np
+import pint
 import xarray as xr
 from numpy.typing import ArrayLike
 
@@ -14,144 +14,424 @@ from ..normalisation import SimulationNormalisation, ConventionNormalisation
 from ..typing import PathLike
 
 
-class FieldDict(TypedDict, total=False):
-    """
-    The dict used to pass field data into a GKOutput. No keys are strictly required.
-    """
+@dataclasses.dataclass
+class Coords:
+    """Utility dataclass type used to pass coordinates to ``GKOutput``"""
 
-    #: Electrostatic potential. Units of ``[tref * rhoref / (qref * lref)]``
-    phi: ArrayLike
+    #: Names of all possible coordinates.
+    names: ClassVar[Tuple[str, ...]] = (
+        "kx",
+        "ky",
+        "time",
+        "theta",
+        "species",
+        "energy",
+        "mode",
+        "pitch",
+    )
 
-    #: Parallel component of the magnetic vector potential. Units of
-    #: ``[bref * rhoref**2 / lref]``.
-    apar: ArrayLike
+    #: 1D grid of radial wave-numbers used in the simulation
+    #: Units of [rhoref ** -1]
+    kx: ArrayLike
 
-    #: Parallel component of the magnetic flux density. Units of
-    #: ``[bref * rhoref / lref]``.
-    bpar: ArrayLike
+    #: 1D grid of bi-normal wave-numbers used in the simulation
+    #: Units of [rhoref ** -1]
+    ky: ArrayLike
+
+    #: 1D grid of time of the simulation output
+    #: Units of [lref / vref]
+    time: ArrayLike
+
+    #: List of species names in the simulation
+    species: Iterable[str]
+
+    #: 1D grid of theta used in the simulation
+    #: Units of [radians]
+    theta: Optional[ArrayLike] = None
+
+    #: TODO document
+    mode: Optional[ArrayLike] = None
+
+    #: 1D grid of the energy in the simulation
+    #: Units of [dimensionless]
+    energy: Optional[ArrayLike] = None
+
+    #: 1D grid of the pitch angle in the simulation
+    #: Units of [dimensionless]
+    pitch: Optional[ArrayLike] = None
+
+    @classmethod
+    def units(cls, name: str, c: ConventionNormalisation) -> pint.Unit:
+        if name not in cls.names:
+            raise ValueError(f"The coord '{name}' is not recognised")
+        if name in ("kx", "ky"):
+            return c.rhoref**-1
+        if name == "time":
+            return c.lref / c.vref
+        if name == "theta":
+            return units.radians
+        return units.dimensionless
+
+    def with_units(self, c: ConventionNormalisation):
+        """
+        Apply units to each array in turn and return a new ``Coords``.
+        If units are already applied, renormalises according to the convention supplied.
+        """
+        kwargs = {}
+        for key, val in vars(self).items():
+            # If shouldn't have units, pass through
+            if key not in self.names or key == "species" or val is None:
+                kwargs[key] = val
+                continue
+            # If already has units, renormalise
+            if hasattr(val, "units"):
+                if key in ("kx", "ky", "time"):
+                    kwargs[key] = val.to(c)
+                else:
+                    kwargs[key] = val.to(self.units(key, c))
+                continue
+            # If doesn't have units, add them
+            kwargs[key] = val * self.units(key, c)
+        return Coords(**kwargs)
 
 
-@dataclasses.dataclass(frozen=True)
-class MomentDict:
-    """
-    Utility type used to identify the type of a moment array. Used to index the dict of
-    flux arrays passed to GKOutput.
-    """
+@dataclasses.dataclass
+class Fields:
+    """Utility dataclass type used to pass field data to ``GKOutput``."""
 
-    #: The type of flux. Possible moments, and their corresponding units, are:
+    #: Class variable for all possible names.
+    names: ClassVar[Tuple[str, ...]] = ("phi", "apar", "bpar")
 
-    #: - ``"density"``, units of ``[nref * rhoref / lref)]``.
-    density: ArrayLike
+    #: :math:`\phi`: the electrostatic potential.
+    #: Units of ``[tref * rhoref / (qref * lref)]``
+    phi: Optional[ArrayLike] = None
 
-    #: - ``"energy"``, units of ``[tref * rhoref / lref]
-    temperature: ArrayLike
+    #: :math:A_\parallel``: Parallel component of the magnetic vector potential.
+    #: Units of ``[bref * rhoref**2 / lref]``.
+    apar: Optional[ArrayLike] = None
 
-    #: - ``"velocity"``. units of ``[vref * rhoref / lref]``.
-    velocity: ArrayLike
+    #: :math:B_\parallel``: Parallel component of the magnetic flux density.
+    #: Units of ``[bref * rhoref / lref]``.
+    bpar: Optional[ArrayLike] = None
 
+    #: The dimensionality of the fields.
+    #: Each field should have the same number of dimensions.
+    dims: Tuple[str, ...] = ("theta", "kx", "ky", "t")
 
-@dataclasses.dataclass(frozen=True)
-class FluxDict:
-    """
-    Utility type used to identify the type of a flux array. Used to index the dict of
-    flux arrays passed to GKOutput.
-    """
+    @property
+    def coords(self) -> Tuple[str, ...]:
+        """
+        Tuple containing the names of each supplied field.
+        Used to generate the 'field' coordinate in ``GKOutput``.
+        """
+        return tuple(x for x in self.names if vars(self)[x] is not None)
 
-    #: The type of flux. Possible moments, and their corresponding units, are:
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Shape of field arrays. Raises error if all are None
+        """
+        for name in self.names:
+            if vars(self)[name] is not None:
+                return np.shape(vars(self)[name])
+        raise ValueError("Fields contains no data")
 
-    #: - ``"particle"``, units of ``[nref * vref * (rhoref / lref)**2]``.
-    particle: ArrayLike
+    @staticmethod
+    def units(name: str, c: ConventionNormalisation) -> pint.Unit:
+        """Return units associated with each field for a given convention"""
+        if name == "phi":
+            return c.tref * c.rhoref / (c.qref * c.lref)
+        elif name == "apar":
+            return c.bref * c.rhoref**2 / c.lref
+        elif name == "bpar":
+            return c.bref * c.rhoref / c.lref
+        else:
+            raise ValueError(f"Field name '{name}' not recognised")
 
-    #: - ``"heat"``, units of ``[nref * vref * tref * (rhoref / lref)**2]
-    heat: ArrayLike
-
-    #: - ``"momentum"``. units of ``[nref * lref * tref * (rhoref / lref)**2]``.
-    momentum: ArrayLike
+    def with_units(self, c: ConventionNormalisation):
+        """
+        Apply units to each array in turn and return a new ``Fields``.
+        If units are already applied, renormalises according to the convention supplied.
+        """
+        kwargs = {}
+        for key, val in vars(self).items():
+            # If shouldn't have units, pass through
+            if key not in self.names or val is None:
+                kwargs[key] = val
+                continue
+            # If already has units, renormalise
+            if hasattr(val, "units"):
+                kwargs[key] = val.to(c)
+            # If doesn't have units, add them
+            kwargs[key] = val * self.units(key, c)
+        return Fields(**kwargs)
 
     def __post_init__(self):
+        """Perform checks on the values assigned."""
+        # Fix weird issue where default dims is a tuple-of-tuples
+        if np.ndim(self.dims) == 2:
+            self.dims = self.dims[0]
+        for name in self.names:
+            field = vars(self)[name]
+            if field is not None and np.ndim(field) != len(self.dims):
+                raise ValueError(f"Field array '{name}' has incorrect number of dims")
+
+
+@dataclasses.dataclass
+class Fluxes:
+    """Utility dataclass type used to pass fluxes to ``GKOutput``."""
+
+    #: Class variable for all possible names.
+    names: ClassVar[Tuple[str, ...]] = ("particle", "heat", "momentum")
+
+    #: Units of ``[nref * vref * (rhoref / lref)**2]``.
+    particle: Optional[ArrayLike] = None
+
+    #: Units of ``[nref * vref * tref * (rhoref / lref)**2]``.
+    heat: Optional[ArrayLike] = None
+
+    #: units of ``[nref * lref * tref * (rhoref / lref)**2]``.
+    momentum: Optional[ArrayLike] = None
+
+    #: The dimensionality of the fluxes.
+    #: Each array should have the same dimensionality.
+    dims: Tuple[str, ...] = ("field", "species", "kx", "ky", "t")
+
+    @property
+    def coords(self) -> Tuple[str, ...]:
         """
-        Perform checks on the values assigned.
+        Tuple containing the names of each supplied fluxes.
+        Used to generate the 'flux' coordinate in ``GKOutput``.
         """
-        for name, var in vars(self).items():
-            if not isinstance(var, str):
-                raise TypeError(f"{name} must be of type str")
-        possible_moments = ("particle", "momentum", "heat")
-        if self.moment not in possible_moments:
-            err_msg = dedent(
-                f"""
-                moment must be one of '{"', '".join(possible_moments)}', but received
-                '{self.moment}'
-                """
-            )
-            raise ValueError(err_msg.replace("\n", " "))
-        possible_fields = ("phi", "apar", "bpar")
-        if self.field not in possible_fields:
-            err_msg = dedent(
-                f"""
-                field must be one of '{"', '".join(possible_fields)}', but received
-                '{self.field}'
-                """
-            )
-            raise ValueError(err_msg.replace("\n", " "))
+        return tuple(x for x in self.names if vars(self)[x] is not None)
 
-    def key(self) -> str:
+    @property
+    def shape(self) -> Tuple[int, ...]:
         """
-        Generates a key which can label the flux in a Dataset
+        Shape of flux arrays. Raises error if all are None
         """
-        return f"{self.field}_{self.species}_{self.moment}_flux"
+        for name in self.names:
+            if vars(self)[name] is not None:
+                return np.shape(vars(self)[name])
+        raise ValueError("Fluxes contains no data")
+
+    @staticmethod
+    def units(name: str, c: ConventionNormalisation) -> pint.Unit:
+        """Return units associated with each flux for a given convention"""
+        if name == "particle":
+            return c.nref * c.vref * (c.rhoref / c.lref) ** 2
+        elif name == "momentum":
+            return c.nref * c.lref * c.tref * (c.rhoref / c.lref) ** 2
+        elif name == "heat":
+            return c.nref * c.vref * c.tref * (c.rhoref / c.lref) ** 2
+        else:
+            raise ValueError(f"Flux name '{name}' not recognised.")
+
+    def with_units(self, c: ConventionNormalisation):
+        """
+        Apply units to each array in turn and return a new ``Fluxes``.
+        If units are already applied, renormalises according to the convention supplied.
+        """
+        kwargs = {}
+        for key, val in vars(self).items():
+            # If shouldn't have units, pass through
+            if key not in self.names or val is None:
+                kwargs[key] = val
+                continue
+            # If already has units, renormalise
+            if hasattr(val, "units"):
+                kwargs[key] = val.to(c)
+            # If doesn't have units, add them
+            kwargs[key] = val * self.units(key, c)
+        return Fluxes(**kwargs)
+
+    def __post_init__(self):
+        """Perform checks on the values assigned."""
+        # Fix weird issue where default dims is a tuple-of-tuples
+        if np.ndim(self.dims) == 2:
+            self.dims = self.dims[0]
+        for name in self.names:
+            flux = vars(self)[name]
+            if flux is not None and np.ndim(flux) != len(self.dims):
+                raise ValueError(f"Flux array '{name}' has incorrect number of dims")
 
 
-def get_eigenvalues_units(c: ConventionNormalisation):
-    return {
-        "eigenvalues": c.lref / c.vref,
-        "growth_rate": c.lref / c.vref,
-        "mode_frequency": c.lref / c.vref,
-    }
+@dataclasses.dataclass
+class Moments:
+    """Utility dataclass type used to pass moments to ``GKOutput``."""
+
+    #: Class variable for all possible names.
+    names: ClassVar[Tuple[str, ...]] = ("density", "energy", "velocity")
+
+    #: Units of ``[nref * rhoref / lref)]``.
+    density: Optional[ArrayLike] = None
+
+    #: Units of ``[tref * rhoref / lref]
+    energy: Optional[ArrayLike] = None
+
+    #: Units of ``[vref * rhoref / lref]``.
+    velocity: Optional[ArrayLike] = None
+
+    #: The dimensionality of the moments
+    #: Each array should have the same dimensionality.
+    dims: Tuple[str, ...] = ("theta", "kx", "species", "ky", "t")
+
+    @property
+    def coords(self) -> Tuple[str, ...]:
+        """
+        Tuple containing the names of each supplied moments.
+        Used to generate the 'moment' coordinate in ``GKOutput``.
+        """
+        return tuple(x for x in self.names if vars(self)[x] is not None)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Shape of moment arrays. Raises error if all are None
+        """
+        for name in self.names:
+            if vars(self)[name] is not None:
+                return np.shape(vars(self)[name])
+        raise ValueError("Moments contains no data")
+
+    @staticmethod
+    def units(name: str, c: ConventionNormalisation) -> pint.Unit:
+        """Return units associated with each moment for a given convention"""
+        if name == "density":
+            return c.nref * c.rhoref / c.lref
+        elif name == "temperature":
+            return c.tref * c.rhoref / c.lref
+        elif name == "velocity":
+            return c.vref * c.rhoref / c.lref
+        else:
+            raise ValueError(f"Moment name '{name}' not recognised.")
+
+    def with_units(self, c: ConventionNormalisation):
+        """
+        Apply units to each array in turn and return a new ``Moments``.
+        If units are already applied, renormalises according to the convention supplied.
+        """
+        kwargs = {}
+        for key, val in vars(self).items():
+            # If shouldn't have units, pass through
+            if key not in self.names or val is None:
+                kwargs[key] = val
+                continue
+            # If already has units, renormalise
+            if hasattr(val, "units"):
+                kwargs[key] = val.to(c)
+            # If doesn't have units, add them
+            kwargs[key] = val * self.units(key, c)
+        return Moments(**kwargs)
+
+    def __post_init__(self):
+        """Perform checks on the values assigned."""
+        # Fix weird issue where default dims is a tuple-of-tuples
+        if np.ndim(self.dims) == 2:
+            self.dims = self.dims[0]
+        for name in self.names:
+            moment = vars(self)[name]
+            if moment is not None and np.ndim(moment) != len(self.dims):
+                raise ValueError(f"Moment array '{name}' has incorrect number of dims")
 
 
-def get_eigenfunctions_units(c: ConventionNormalisation):
-    return {
-        "eigenfunctions": units.dimensionless,
-    }
+@dataclasses.dataclass
+class Eigenvalues:
+    """
+    Utility dataclass type used to pass eigenvalues to ``GKOutput``.
+    Unlike the classes ``Fields``, ``Fluxes``, and ``Moments``, entries to
+    ``Eigenvalues`` are non-optional.
+    """
+
+    #: Class variable for all possible names.
+    names: ClassVar[Tuple[str, ...]] = ("growth_rate", "mode_frequency")
+
+    #: Units of ``[lref / vref]``.
+    growth_rate: ArrayLike
+
+    #: Units of ``[lref / vref]``.
+    mode_frequency: ArrayLike
+
+    #: The dimensionality of the eigenvalues
+    #: Each array should have the same dimensionality.
+    dims: Tuple[str, ...] = ("kx", "ky", "time")
+
+    @property
+    def coords(self) -> Tuple[str, ...]:
+        """
+        Tuple containing the names of each supplied fluxes.
+        Used to generate the 'moment' coordinate in ``GKOutput``.
+        """
+        return self.names
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Shape of eigenvalue arrays.
+        """
+        return np.shape(self.growth_rate)
+
+    @staticmethod
+    def units(c: ConventionNormalisation) -> pint.Unit:
+        """Return units for a given convention"""
+        return c.lref / c.vref
+
+    def with_units(self, c: ConventionNormalisation):
+        """
+        Apply units to each array in turn and return a new ``Eigenvalues``.
+        If units are already applied, renormalises according to the convention supplied.
+        """
+        kwargs = {}
+        for key, val in vars(self).items():
+            # If shouldn't have units, pass through
+            if key not in self.names:
+                kwargs[key] = val
+                continue
+            # If already has units, renormalise
+            if hasattr(val, "units"):
+                kwargs[key] = val.to(c)
+            # If doesn't have units, add them
+            kwargs[key] = val * self.units(c)
+        return Eigenvalues(**kwargs)
+
+    def __post_init__(self):
+        """Perform checks on the values assigned."""
+        # Fix weird issue where default dims is a tuple-of-tuples
+        if np.ndim(self.dims) == 2:
+            self.dims = self.dims[0]
+        for name in self.names:
+            eig = vars(self)[name]
+            if np.ndim(eig) != len(self.dims):
+                raise ValueError(f"Eigenvalue '{name}' has incorrect number of dims")
 
 
-def get_flux_units(c: ConventionNormalisation):
-    return {
-        "particle": c.nref * c.vref * (c.rhoref / c.lref) ** 2,
-        "momentum": c.nref * c.lref * c.tref * (c.rhoref / c.lref) ** 2,
-        "heat": c.nref * c.vref * c.tref * (c.rhoref / c.lref) ** 2,
-    }
+@dataclasses.dataclass
+class Eigenfunctions:
+    """Utility dataclass type used to pass eigenfunctions to ``GKOutput``."""
 
+    #: Eigenfunction data to pass to ``GKOutput``
+    data: ArrayLike
 
-def get_field_units(c: ConventionNormalisation):
-    return {
-        "phi": c.tref * c.rhoref / (c.qref * c.lref),
-        "apar": c.bref * c.rhoref**2 / c.lref,
-        "bpar": c.bref * c.rhoref / c.lref,
-    }
+    #: The dimensionality of the eigenfunctions. Should match ``data``.
+    dims: Tuple[str, ...] = ("field", "theta", "kx", "ky", "time")
 
+    #: The units of the eigenfunctions
+    units: ClassVar[pint.Unit] = units.dimensionless
 
-def get_moment_units(c: ConventionNormalisation):
-    return {
-        "density": c.nref * c.rhoref / c.lref,
-        "temperature": c.tref * c.rhoref / c.lref,
-        "velocity": c.vref * c.rhoref / c.lref,
-    }
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Shape of eigenfunction arrays.
+        """
+        return np.shape(self.data)
 
-
-def get_coord_units(c: ConventionNormalisation):
-    return {
-        "ky": c.rhoref**-1,
-        "kx": c.rhoref**-1,
-        "time": c.lref / c.vref,
-        "theta": units.radians,
-        "energy": units.dimensionless,
-        "pitch": units.dimensionless,
-        "field": units.dimensionless,
-        "moment": units.dimensionless,
-        "species": units.dimensionless,
-        "mode": units.dimensionless,
-    }
+    def __post_init__(self):
+        """Perform checks on the values assigned."""
+        # Fix weird issue where default dims is a tuple-of-tuples
+        if np.ndim(self.dims) == 2:
+            self.dims = self.dims[0]
+        if np.ndim(self.data) != len(self.dims):
+            raise ValueError("Eigenfunctions has incorrect number of dims")
 
 
 # TODO define Diagnostics stuff on this class. could use accessors
@@ -174,43 +454,30 @@ class GKOutput(DatasetWrapper):
 
     Parameters
     ----------
-    time: ArrayLike, units [vref / lref]
-        1D grid of time of the simulation output
-    kx: ArrayLike, units [1.0 / rhoref]
-        1D grid of radial wave-numbers used in the simulation
-    ky: ArrayLike, units [1.0 / rhoref]
-        1D grid of bi-normal wave-numbers used in the simulation
-    theta: ArrayLike, units [radians]
-        1D grid of theta used in the simulation
-    energy: ArrayLike, units [dimensionless]
-        1D grid of energy grid used in the simulation. (TODO are the units here really
-        dimensionless? Is it relative to some reference energy?)
-    pitch: ArrayLike, units [dimensionless]
-        1D grid of pitch-angle grid used in the simulation. (TODO which definition of
-        pitch angle are we using? Are the units correct?)
-    fields: FieldDict
-        Complex field data as a function of ``(theta, kx, ky, time)``.
-    fluxes: Dict[FluxDict, ArrayLike]
-        Flux data as a function of ``(ky, time)``. ``FluxDict`` is a dataclass
-        denoting the moment, species, and field of each flux.
-    norm: SimulationNormalisation
+    coords
+        Dataclass specifying the coordinates of the simulation
+    norm
         The normalisation scheme of the simulation.
-    linear: bool, default True
+    fields
+        Dataclass specifying the fields in the simulation
+    fluxes
+        Dataclass specifying the fluxes in the simulation
+    moments
+        Dataclass specifying the moments in the simulation
+    eigenvalues
+        Dataclass specifying the eigenvalues in the simulation. Should only be supplied
+        for linear runs. If not provided, will be set from field data.
+    eigenfunctions
+        Dataclass specifying the eigenfunctions in the simulation Should only be
+        supplied for linear runs. If not provided, will be set from field data.
+    linear
         Set True for linear gyrokinetics runs, False for nonlinear runs.
-    gk_code: Optional[str], default None
+    normalise_flux_moment
+        TODO write docs
+    gk_code:
         The gyrokinetics code that generated the results.
-    input_file: Optional[str], default None
+    input_file
         The input file used to generate the results.
-    growth_rate: Optional[ArrayLike], default None
-        Function of ``(kx, ky, time)``. Only included for linear runs. If not provided,
-        will be set from field data.
-    mode_frequency: Optional[ArrayLike], default None
-        Function of ``(kx, ky, time)``. Only included for linear runs. If not provided,
-        will be set from field data.
-    eigenfunctions: Optional[FieldDict], default None
-        Complex function of ``(theta, kx, ky, time)``. One should be provided for
-        each field. Only included for linear runs. If not provided, will be set from
-        field data.
 
     Attributes
     ----------
@@ -238,263 +505,208 @@ class GKOutput(DatasetWrapper):
     def __init__(
         self,
         *,  # args are keyword only
-        time: ArrayLike,
-        kx: ArrayLike,
-        ky: ArrayLike,
-        theta: ArrayLike,
-        field_dim: ArrayLike,
-        flux_dim: ArrayLike,
-        moment_dim: ArrayLike,
-        species: ArrayLike,
-        fields: FieldDict,
-        fluxes: FluxDict,
-        moments: MomentDict,
-        field_var: tuple,
-        moment_var: tuple,
-        flux_var: tuple,
+        coords: Coords,
         norm: SimulationNormalisation,
+        fields: Optional[Fields] = None,
+        fluxes: Optional[Fluxes] = None,
+        moments: Optional[Moments] = None,
+        eigenvalues: Optional[Eigenvalues] = None,
+        eigenfunctions: Optional[Eigenfunctions] = None,
         linear: bool = True,
-        mode: Optional[ArrayLike] = None,
-        energy: Optional[ArrayLike] = None,
-        pitch: Optional[ArrayLike] = None,
+        normalise_flux_moment: bool = False,
         gk_code: Optional[str] = None,
         input_file: Optional[str] = None,
-        growth_rate: Optional[ArrayLike] = None,
-        mode_frequency: Optional[ArrayLike] = None,
-        eigenfunctions: Optional[FieldDict] = None,
-        normalise_flux_moment: bool = False,
-        eigval_var: tuple = ("kx", "ky", "time"),
-        eigenfunctions_var: tuple = ("field", "theta", "kx", "ky", "time"),
     ):
         self.norm = norm
         convention = norm.pyrokinetics
-        coord_units = get_coord_units(convention)
 
-        def _renormalise(data: ArrayLike, convention: ConventionNormalisation, units):
-            """
-            Assign units to data if it doesn't have any. If it does, convert it to the
-            provided convention.
-            """
-            # Not sure on type hints for units or return type here
-            if hasattr(data, "units"):
-                return data.to(convention)
-            return np.asarray(data) * units
+        # Renormalise inputs
+        coords = coords.with_units(convention)
 
-        def _assign_units(data: ArrayLike, units):
-            """
-            Assign non-normalised units to data if it doesn't have any. If it does,
-            convert to the provided units.
-            """
-            if data is None:
-                return None
-            # Not sure on type hints for units or return type here
-            if hasattr(data, "units"):
-                return data.to(units)
-            return np.asarray(data) * units
+        if fields is not None:
+            fields = fields.with_units(convention)
 
-        # Assign correct normalised units to each input
-        time = _renormalise(time, convention, coord_units["time"])
-        kx = _renormalise(kx, convention, coord_units["kx"])
-        ky = _renormalise(ky, convention, coord_units["ky"])
-        theta = _assign_units(theta, coord_units["theta"])
-        energy = _assign_units(energy, coord_units["energy"])
-        pitch = _assign_units(pitch, coord_units["pitch"])
-        mode = _assign_units(mode, coord_units["mode"])
+        if fluxes is not None:
+            fluxes = fluxes.with_units(convention)
 
-        field_units = get_field_units(convention)
-        for name, field in fields.items():
-            fields[name] = _renormalise(field, convention, field_units[name])
+        if moments is not None:
+            moments = moments.with_units(convention)
 
-        moment_units = get_moment_units(convention)
-        for name, moment in moments.items():
-            moments[name] = _renormalise(moment, convention, moment_units[name])
-
-        flux_units = get_flux_units(convention)
-        for flux_type, flux in fluxes.items():
-            fluxes[flux_type] = _renormalise(
-                fluxes[flux_type], convention, flux_units[flux_type]
-            )
-
-        # Normalise QL fluxes and moments if linear and needed
-        if fields and linear and normalise_flux_moment:
-            if fluxes:
-                fluxes = self._normalise_to_fields(fields, theta, fluxes)
-            if moments:
-                moments = self._normalise_to_fields(fields, theta, moments)
-
-        # Assemble grids into underlying xarray Dataset
+        # Get coords to hand over to underlying Dataset
         def make_var(dim, val, desc):
             if val is None:
                 return None
-            else:
-                return (
-                    dim,
-                    val.magnitude,
-                    {"units": str(val.units), "long_name": desc},
-                )
+            if hasattr(val, "units"):
+                return (dim, val.m, {"units": str(val.u), "long_name": desc})
+            return (dim, val, {"units": None, "long_name": desc})
 
-        def make_var_unitless(dim, val, desc):
-            if val is None:
-                return None
-            else:
-                return (dim, val, {"units": None, "long_name": desc})
-
-        coords = {
-            "time": make_var("time", time, "Time"),
-            "kx": make_var("kx", kx, "Radial wavenumber"),
-            "ky": make_var("ky", ky, "Bi-normal wavenumber"),
-            "theta": make_var("theta", theta, "Angle"),
-            "energy": make_var("energy", energy, "Energy"),
-            "pitch": make_var("pitch", pitch, "Pitch angle"),
-            "field": make_var_unitless("field", field_dim, "Field"),
-            "moment": make_var_unitless("moment", moment_dim, "Moment"),
-            "flux": make_var_unitless("flux", flux_dim, "Flux"),
-            "species": make_var_unitless("species", species, "Species"),
-            "mode": make_var_unitless("mode", mode, "Mode"),
+        dataset_coords = {
+            "time": make_var("time", coords.time, "Time"),
+            "kx": make_var("kx", coords.kx, "Radial wavenumber"),
+            "ky": make_var("ky", coords.ky, "Bi-normal wavenumber"),
+            "theta": make_var("theta", coords.theta, "Angle"),
+            "energy": make_var("energy", coords.energy, "Energy"),
+            "pitch": make_var("pitch", coords.pitch, "Pitch angle"),
+            "mode": make_var("mode", coords.mode, "Mode"),
+            "species": make_var("species", coords.species, "Species"),
         }
 
-        coords = {key: value for key, value in coords.items() if value is not None}
+        # Add field, flux and moment coords
+        if fields is not None:
+            dataset_coords["field"] = make_var("field", list(fields.coords), "Field")
+        if fluxes is not None:
+            dataset_coords["flux"] = make_var("flux", list(fluxes.coords), "Flux")
+        if moments is not None:
+            dataset_coords["moment"] = make_var("moment", list(moments.coords), "Moment")
 
-        data_vars = {}
-        field_desc = {
-            "phi": "Electrostatic potential",
-            "apar": "Parallel magnetic vector potential",
-            "bpar": "Parallel magnetic flux density",
-        }
+        # Remove None entries
+        dataset_coords = {k: v for k, v in dataset_coords.items() if v is not None}
+
+        # Renormalise fields, fluxes, moments
+
+        # Normalise QL fluxes and moments if linear and needed
+        if fields is not None and linear and normalise_flux_moment:
+            if fluxes is not None:
+                fluxes = self._normalise_to_fields(fields, coords.theta, fluxes)
+            if moments is not None:
+                moments = self._normalise_to_fields(fields, coords.theta, moments)
 
         # Normalise fields to GKDB standard
-        if "time" in field_var and linear and fields:
-            fields = self._normalise_linear_fields(fields, theta.m)
+        if fields is not None and "time" in fields.dims and linear:
+            fields = self._normalise_linear_fields(fields, coords.theta.m)
 
-        for key, value in fields.items():
-            data_vars[key] = make_var(
-                field_var,
-                value,
-                field_desc[key],
+        # Set up data vars to hand over to underlying Dataset
+        data_vars = {}
+
+        if fields is not None:
+            field_desc = {
+                "phi": "Electrostatic potential",
+                "apar": "Parallel magnetic vector potential",
+                "bpar": "Parallel magnetic flux density",
+            }
+            for key in fields.coords:
+                data_vars[key] = make_var(
+                    fields.dims, getattr(fields, key), field_desc[key]
+                )
+
+        if moments is not None:
+            moment_desc = {
+                "density": "Density fluctuations",
+                "temperature": "Temperature fluctuations",
+                "velocity": "Velocity fluctuations",
+            }
+            for key in moments.coords:
+                data_vars[key] = make_var(
+                    moments.dims, getattr(moments, key), moment_desc[key]
+                )
+
+        if fluxes is not None:
+            flux_desc = {
+                "particle": "Particle flux",
+                "heat": "Heat flux",
+                "momentum": "Momentum flux",
+            }
+            for key in fluxes.coords:
+                data_vars[key] = make_var(
+                    fluxes.dims, getattr(fluxes, key), flux_desc[key]
+                )
+
+        # Add eigenvalues. If not provided, try to generate from fields
+        if eigenvalues is None and fields is not None and linear:
+            eigenvalues = self._eigenvalues_from_fields(
+                fields, coords.theta.magnitude, coords.time.magnitude
             )
 
-        moment_desc = {
-            "density": "Density fluctuations",
-            "temperature": "Temperature fluctuations",
-            "velocity": "Velocity fluctuations",
-        }
+        if eigenvalues is not None:
+            eigenvalues = eigenvalues.with_units(convention)
 
-        for key, value in moments.items():
-            data_vars[key] = make_var(
-                moment_var,
-                value,
-                moment_desc[key],
+            data_vars["growth_rate"] = make_var(
+                eigenvalues.dims, eigenvalues.growth_rate, "Growth rate"
+            )
+            data_vars["mode_frequency"] = make_var(
+                eigenvalues.dims, eigenvalues.mode_frequency, "Mode frequency"
+            )
+            data_vars["eigenvalues"] = make_var(
+                eigenvalues.dims,
+                eigenvalues.mode_frequency + 1.0j * eigenvalues.growth_rate,
+                "Eigenvalues",
             )
 
-        for flux_type, flux in fluxes.items():
-            data_vars[flux_type] = make_var(
-                flux_var,
-                flux,
-                flux_type,
+        # Add eigenfunctions. If not provided, try to generate from fields
+        if eigenfunctions is None and fields is not None and linear:
+            eigenfunctions = self._eigenfunctions_from_fields(fields, coords.theta.m)
+
+        if eigenfunctions is not None:
+            data_vars["eigenfunctions"] = (
+                eigenfunctions.dims,
+                eigenfunctions.data,
+                {"long_name": "Eigenfunctions"},
             )
 
-        # TODO need way to stringify norm so we can keep track of units in the dataset
+        # Set up attrs to hand over to underlying dataset
         attrs = {
             "linear": linear,
             "gk_code": gk_code if gk_code is not None else "",
             "input_file": input_file if input_file is not None else "",
         }
 
-        # Add eigenvalues. If not provided, try to generate from fields
-        eigenvalues_none = sum([growth_rate is None, mode_frequency is None])
-        if eigenvalues_none == 1:
-            raise ValueError(
-                "Must provide both growth_rate and mode_frequency or neither one"
-            )
-        eig_units = get_eigenvalues_units(convention)
-        if eigenvalues_none:
-            if fields and linear:
-                eigenvalues_dict = self._eigenvalues_from_fields(
-                    fields, theta.magnitude, time.magnitude
-                )
-                for key, value in eigenvalues_dict.items():
-                    eigenvalues_dict[key] = value * eig_units[key]
-            else:
-                eigenvalues_dict = {}
-        else:
-            growth_rate = _renormalise(
-                growth_rate, convention, eig_units["growth_rate"]
-            )
-            mode_frequency = _renormalise(
-                mode_frequency, convention, eig_units["mode_frequency"]
-            )
-            eigenvalues_dict = {
-                "growth_rate": growth_rate,
-                "mode_frequency": mode_frequency,
-                "eigenvalues": mode_frequency + 1j * growth_rate,
-            }
+        # Hand over to underlying dataset
+        super().__init__(data_vars=data_vars, coords=dataset_coords, attrs=attrs)
 
-        for key, value in eigenvalues_dict.items():
-            data_vars[key] = make_var(eigval_var, value, key)
-
-        if "time" in eigval_var and linear:
-            attrs["growth_rate_tolerance"] = self.get_growth_rate_tolerance(
-                time, data_vars
-            )
-
-        # Add eigenfunctions. If not provided, try to generate from fields
-        eigenfunctions_dict = {}
-        if eigenfunctions is None:
-            if fields and linear:
-                eigenfunctions_dict[
-                    "eigenfunctions"
-                ] = self._eigenfunctions_from_fields(fields, theta.magnitude)
-        else:
-            eigenfunctions_dict["eigenfunctions"] = eigenfunctions
-
-        for key, value in eigenfunctions_dict.items():
-            data_vars[key] = (
-                eigenfunctions_var,
-                value,
-                {"long_name": "Eigenfunctions"},
-            )
-
-        super().__init__(data_vars=data_vars, coords=coords, attrs=attrs)
+        # Calculate growth_rate_tolerance with default inputs
+        if eigenvalues is not None and "time" in eigenvalues.dims and linear:
+            self.data.attrs["growth_rate_tolerance"] = self.get_growth_rate_tolerance()
 
     def field(self, name: str) -> xr.DataArray:
-        if name not in ("phi", "apar", "bpar"):
+        if name not in Fields.names:
             raise ValueError(
-                f"name should be one of 'phi', 'apar', 'bpar'. Received '{name}'"
+                f"'name' should be one of {', '.join(Fields.names)}. "
+                f"Received '{name}'."
             )
         if name not in self.data_vars:
             raise ValueError(f"GKOutput does not contain the field '{name}'")
         return self.data_vars[name]
 
     def flux(self, name: str) -> xr.DataArray:
-        if name not in ("particle", "heat", "momentum"):
+        if name not in Fluxes.names:
             raise ValueError(
-                f"name should be one of 'particle', 'heat', 'momentum'. Received '{name}'"
+                f"'name' should be one of {', '.join(Fluxes.names)}. "
+                f"Received '{name}'"
             )
         if name not in self.data_vars:
-            raise ValueError(f"GKOutput does not contain the field '{name}'")
+            raise ValueError(f"GKOutput does not contain the flux '{name}'")
         return self.data_vars[name]
 
-    def get_growth_rate_tolerance(
-        self, time, data_vars, time_range: float = 0.8
-    ) -> float:
+    def moment(self, name: str) -> xr.DataArray:
+        if name not in Moments.names:
+            raise ValueError(
+                f"'name' should be one of {', '.join(Moments.names)}. "
+                f"Received '{name}'"
+            )
+        if name not in self.data_vars:
+            raise ValueError(f"GKOutput does not contain the moment '{name}'")
+        return self.data_vars[name]
+
+    def get_growth_rate_tolerance(self, time_range: float = 0.8) -> float:
         """
         Given a pyrokinetics output dataset with eigenvalues determined, calculate the
         growth rate tolerance. This is calculated starting at the time given by
         time_range * max_time.
         """
 
-        if "growth_rate" not in data_vars:
+        if "growth_rate" not in self.data_vars:
             raise ValueError(
                 "GKOutput does not have 'growth rate'. Only results associated with "
                 "linear gyrokinetics runs will have this."
             )
-        growth_rate = data_vars["growth_rate"][1].flatten()
+        breakpoint()
+        growth_rate = self.data_vars["growth_rate"][1].flatten()
         final_growth_rate = growth_rate[-1]
 
         difference = np.abs((growth_rate - final_growth_rate) / final_growth_rate)
-        final_time = time[-1]
+        final_time = self.time[-1]
         # Average over the end of the simulation, starting at time_range*final_time
-        within_time_range = time > time_range * final_time
+        within_time_range = self.time > time_range * final_time
         tolerance = np.sum(
             np.where(within_time_range, difference, 0), axis=-1
         ) / np.sum(within_time_range, axis=-1)
@@ -503,16 +715,18 @@ class GKOutput(DatasetWrapper):
 
     @staticmethod
     def _eigenvalues_from_fields(
-        fields: FieldDict, theta: ArrayLike, time: ArrayLike
-    ) -> Dict[str, np.ndarray]:
+        fields: Fields, theta: ArrayLike, time: ArrayLike
+    ) -> Eigenvalues:
         """
         Call during __init__ after converting to pyro normalisations
         """
         # field dims are (theta, kx, ky, time)
-        shape = np.shape([*fields.values()][0])
+        # FIXME field dims are now variable!
+        shape = fields.shape
         sum_fields = np.zeros(shape, dtype=complex)
         square_fields = np.zeros(shape)
-        for field in fields.values():
+        for field_name in fields.coords:
+            field = getattr(fields, field_name)
             sum_fields += field.magnitude
             square_fields += np.abs(field.magnitude) ** 2
 
@@ -536,39 +750,43 @@ class GKOutput(DatasetWrapper):
 
         mode_frequency = -np.gradient(field_angle, time, axis=-1)
 
-        eigenvalues = mode_frequency + 1j * growth_rate
-
-        return {
-            "growth_rate": growth_rate,
-            "mode_frequency": mode_frequency,
-            "eigenvalues": eigenvalues,
-        }
+        return Eigenvalues(
+            growth_rate=growth_rate,
+            mode_frequency=mode_frequency,
+        )
 
     @staticmethod
-    def _eigenfunctions_from_fields(fields: FieldDict, theta: ArrayLike) -> FieldDict:
+    def _eigenfunctions_from_fields(fields: Fields, theta: ArrayLike) -> Eigenfunctions:
         # field coords are (theta, kx, ky, time)
-        square_fields = np.zeros(np.shape([*fields.values()][0]))
-        for name, field in fields.items():
+        square_fields = np.zeros(fields.shape)
+        for field_name in fields.coords:
+            field = getattr(fields, field_name)
             square_fields += np.abs(field.magnitude) ** 2
         field_amplitude = np.sqrt(np.trapz(square_fields, theta, axis=0)) / (2 * np.pi)
-        eigenfunctions = np.zeros((len(fields),) + square_fields.shape, dtype=complex)
-        for ifield, (name, field) in enumerate(fields.items()):
+        eigenfunctions = np.zeros(
+            (len(fields.coords),) + square_fields.shape, dtype=complex
+        )
+        for ifield, field_name in enumerate(fields.coords):
+            field = getattr(fields, field_name)
             eigenfunctions[ifield] = field.magnitude / field_amplitude
-        return eigenfunctions
+        # TODO are these fields correct?
+        return Eigenfunctions(eigenfunctions, dims=("fields",) + fields.dims)
 
     @staticmethod
-    def _get_field_amplitude(fields: FieldDict, theta):
+    def _get_field_amplitude(fields: Fields, theta):
         field_squared = 0.0
-        for field in fields.values():
+        for field_name in fields.coords:
+            field = getattr(fields, field_name)
             field_squared += np.abs(field.m) ** 2
 
         amplitude = np.sqrt(np.trapz(field_squared, theta, axis=0) / 2 * np.pi)
 
         return amplitude
 
-    def _normalise_linear_fields(self, fields: FieldDict, theta) -> FieldDict:
+    def _normalise_linear_fields(self, fields: Fields, theta) -> Fields:
         """
         Normalise fields as done in GKDB manual sec 5.5.3->5.5.5
+
         Parameters
         ----------
         fields
@@ -580,25 +798,30 @@ class GKOutput(DatasetWrapper):
 
         amplitude = self._get_field_amplitude(fields, theta)[:, :, -1]
 
-        if "phi" in fields.keys():
+        if "phi" in fields.coords:
             phase_field = "phi"
         else:
-            phase_field = list(fields.keys())[0]
+            phase_field = fields.coords[0]
 
-        phi = fields[phase_field][:, :, :, -1]
+        phi = getattr(fields, phase_field)[:, :, :, -1]
         theta_star = np.argmax(np.abs(phi), axis=0)
         phi_theta_star = phi[theta_star, :, :]
         phase = np.abs(phi_theta_star) / phi_theta_star
 
-        for field in fields:
-            fields[field] *= phase / amplitude
+        for field_name in fields.coords:
+            setattr(
+                fields,
+                field_name,
+                getattr(fields, field_name) * phase / amplitude,
+            )
 
         return fields
 
-    def _normalise_to_fields(self, fields: FieldDict, theta, outputs):
+    def _normalise_to_fields(self, fields: Fields, theta, outputs):
         """
         Normalise output (moments/fluxes) to fields to obtain quasi-linear value
         Only valid for linear simulations
+
         Parameters
         ----------
         fields : FieldDict
@@ -616,8 +839,10 @@ class GKOutput(DatasetWrapper):
 
         amplitude = self._get_field_amplitude(fields, theta)
 
-        for output in outputs:
-            outputs[output] *= 1 / amplitude**2
+        for output_name in outputs.coords:
+            setattr(
+                outputs, output_name, getattr(outputs, output_name) / amplitude**2
+            )
 
         return outputs
 

--- a/pyrokinetics/gk_code/gk_output.py
+++ b/pyrokinetics/gk_code/gk_output.py
@@ -57,7 +57,10 @@ class GKOutputArgs:
         return getattr(self, key)
 
     def __setitem__(self, key: str, val: Any) -> None:
-        """Set quantities with dict-like inteface"""
+        """
+        Set quantities with dict-like inteface.
+        Warning: No validity checking is performed.
+        """
         if key not in self.names:
             raise KeyError(key)
         setattr(self, key, val)

--- a/tests/diagnostics/test_poincare.py
+++ b/tests/diagnostics/test_poincare.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from pathlib import Path
 
 from pyrokinetics import Pyro, template_dir
@@ -34,4 +35,4 @@ def test_poincare():
     coords = call_poincare(pyro)
     filename = Path(__file__).parent / "golden_answers/poincare.npy"
     data = np.load(filename)
-    assert np.all(np.abs(coords - data) < 1e-6)
+    assert_allclose(coords, data, rtol=1e-6)

--- a/tests/gk_code/test_gk_output.py
+++ b/tests/gk_code/test_gk_output.py
@@ -1,0 +1,93 @@
+import dataclasses
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from pyrokinetics.gk_code.gk_output import (
+    Fields,
+    Fluxes,
+    Moments,
+    Eigenvalues,
+    Eigenfunctions,
+)
+
+# TODO Difficult to test units handling, not currently included.
+
+
+@pytest.mark.parametrize("cls", (Fields, Fluxes, Moments, Eigenvalues, Eigenfunctions))
+def test_gk_output_args_adding_dims(cls):
+    """Check that default dims are successfully overwritten"""
+    val = np.linspace(0.0, 10.0, 24).reshape((2, 3, 4))
+    dims = ("foo", "bar", "baz")
+    names = tuple(f.name for f in dataclasses.fields(cls))
+    instance = cls(**{name: val for name in names}, dims=dims)
+    assert instance.dims == dims
+
+
+@pytest.mark.parametrize("cls", (Fields, Fluxes, Moments, Eigenvalues, Eigenfunctions))
+def test_gk_output_args_iteration(cls):
+    """Check that iteration produces all field names"""
+    val = np.linspace(0.0, 10.0, 24).reshape((2, 3, 4))
+    dims = ("foo", "bar", "baz")
+    names = tuple(f.name for f in dataclasses.fields(cls))
+    instance = cls(**{name: val for name in names}, dims=dims)
+    # Check iter
+    instance_names = tuple(x for x in instance)
+    for name in names:
+        assert name in instance_names
+    # Check values()
+    vals = tuple(x for x in instance.values())
+    for v in vals:
+        assert_array_equal(v, val)
+    # Check items()
+    items = {k: v for k, v in instance.items()}
+    for k, v in items.items():
+        assert k in names
+        assert_array_equal(v, val)
+
+
+@pytest.mark.parametrize("cls", (Fields, Fluxes, Moments, Eigenvalues, Eigenfunctions))
+def test_gk_output_args_shape(cls):
+    """Check that shape function returns expected value"""
+    val = np.linspace(0.0, 10.0, 24).reshape((2, 3, 4))
+    dims = ("foo", "bar", "baz")
+    names = tuple(f.name for f in dataclasses.fields(cls))
+    instance = cls(**{name: val for name in names}, dims=dims)
+    assert_array_equal(instance.shape, val.shape)
+
+
+@pytest.mark.parametrize("cls", (Fields, Fluxes, Moments, Eigenvalues, Eigenfunctions))
+def test_gk_output_args_get_and_set(cls):
+    """Check that iteration produces all field names"""
+    val = np.linspace(0.0, 10.0, 24).reshape((2, 3, 4))
+    dims = ("foo", "bar", "baz")
+    names = tuple(f.name for f in dataclasses.fields(cls))
+    instance = cls(**{name: val for name in names}, dims=dims)
+    assert_array_equal(instance[names[0]], val)
+    # Note: no checking is done on __setitem__
+    instance[names[0]] = "hello world"
+    assert instance[names[0]] == "hello world"
+
+
+@pytest.mark.parametrize("cls", (Fields, Fluxes, Moments))
+def test_gk_output_args_missing_fields(cls):
+    """Check that only non-None fields appear in coords"""
+    val = np.linspace(0.0, 10.0, 24).reshape((2, 3, 4))
+    dims = ("foo", "bar", "baz")
+    names = tuple(f.name for f in dataclasses.fields(cls))
+    instance = cls(**{names[0]: val}, dims=dims)
+    # Check coords
+    assert_array_equal(instance.coords, (names[0],))
+    # Check iter -- should only include the first field
+    instance_names = tuple(x for x in instance)
+    assert len(instance_names) == 1
+    assert instance_names[0] == names[0]
+    # Check values()
+    vals = tuple(x for x in instance.values())
+    assert len(vals) == 1
+    assert_array_equal(vals[0], val)
+    # Check items()
+    items = {k: v for k, v in instance.items()}
+    assert len(items) == 1
+    assert_array_equal(items[names[0]], val)


### PR DESCRIPTION
I'd intended to do a quick clean up of some docs and type hints, but this turned into a much bigger edit than I'd originally hoped for. I'd noticed that the helper classes `FieldDict`, `FluxType` (later renamed `FluxDict`) and `MomentDict` were non-functional, and the number of `__init__` arguments to `GKOutput` was becoming unreasonable. The docs and type hints also didn't match the code in some places.

I tried to improve matters by defining some helper dataclasses that could be used to organise the inputs to `GKOutput` and also wrap up some of the units handling: `Coords`, `Fields`, `Fluxes`, `Moments`, `Eigenvalues`, and `Eigenfunctions`. These classes:

- Define the names of each entry and whether they're optional
- Define the units for each entry
- The function `.with_units()` automatically adds units to the contents and converts across normalisations.
- The `dims` attribute can be set for GK codes that have output data with non-default dimensions.

Although the definitions of these classes add quite a few lines of code, it reduces the complexity within `GKOutput.__init__` and the `read` functions for each reader class. Very few changes were otherwise needed to the reader classes.

Current minor issues that would be nice to fix:
- A lot of the functions in these classes look very similar, so there's probably an inheritance trick I could use to reduce repeat code.
- There's a bit too much `getattr` and `setattr` going on for my liking. Could do with implementing a dict-like interface.

Current major issues that are causing me to lose my sanity:
- Failing a bunch of golden answer tests, but I have no idea what changes could have led to this. The differences are severe enough that I'll have to fix it before this will be ready to merge.