### PR TITLE
How to read equilibrium and profiles to create a GK input file 

### DIFF
--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -10,12 +10,17 @@ starting from equilibrium and profile files.
 Let's first import ``pyrokinetics`` and define our equilibrium and input files. 
 
 .. code-block:: python
+
    >>> from pyrokinetics import Pyro, template_dir
-   >>> eq_file = template / "test.geqdsk"
+   >>> eq_file = template_dir / "test.geqdsk"
    >>> kinetics_file = template_dir / "jetto.cdf"
+   >>> gk_file = template_dir / "input.cgyro"
 
 The equilibrium file ``test.geqdsk`` and the kinetics file ``jetto.cdf``
 are stored in the template foder and used here as an example.
+The gyrokinetic file ``input.cgyro`` is our input file template where
+we set all the extra flags we need. The input parameters related to the
+geometry and species will be added to this template by ``pyrokinetics``.
 We now load these files into ``pyrokinetics``:
 
 .. code-block:: python
@@ -25,14 +30,15 @@ We now load these files into ``pyrokinetics``:
         kinetics_file=kinetics_file,
 	kinetics_type="JETTO",
         kinetics_kwargs={"time": 550},
+	gk_file=gk_file,
     )
 
 
-During initialization, ``Pyro`` calls ``read_equilibrium`` from
+During initialization, `Pyro` calls `read_equilibrium` from
 the class :py:class:`Equilibrium` and initializes the class :py:class:`Kinetics`.
 The global equilibrium and proofiles are now stored in ``pyro``.
 Let's suppose we want to generate an input file for a local gyrokinetic
-simulation at :math:`Psi_n = 0.5`. This requires loading the local geometry
+simulation at :math:`\Psi_n = 0.5`. This requires loading the local geometry
 at the chosen surface, which can be done by simply calling the ``load_local`` method:
 
 .. code-block:: python
@@ -44,16 +50,19 @@ parametrizations are possible in ``pyrokinetics``. See the output of ``pyro.supp
 Before generating an input file, we need to specify ``gk_code``:
 
 .. code-block:: python
-   >>> pyro.gk_code = "GS2"
+
+   >>> pyro.gk_code = "CGYRO"
 
 Note that ``gk_code`` can be any code supported in ``pyrokinetics``, which can
 be found in ``pyro.supported_gk_inputs``. 
 We are now ready to write our input file:
 
 .. code-block:: python
+
    >>> pyro.write_gk_file(file_name="test_jetto.cgyro")
 
 Alternatively, ``gk_code`` can be pass as keyword argument to ``write_gk_file``,
 .. code-block:: python
-   >>> pyro.write_gk_file(file_name="test_jetto.cgyro", gk_code="GS2")
+
+   >>> pyro.write_gk_file(file_name="test_jetto.cgyro", gk_code="CGYRO")
 

--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -35,7 +35,7 @@ We now load these files into ``pyrokinetics``:
 
 
 During initialization, `Pyro` calls `read_equilibrium` from
-the class :py:class:`Equilibrium` and initializes the class :py:class:`Kinetics`.
+the class `Equilibrium` and initializes the class `Kinetics`.
 The global equilibrium and proofiles are now stored in ``pyro``.
 Let's suppose we want to generate an input file for a local gyrokinetic
 simulation at :math:`\Psi_n = 0.5`. This requires loading the local geometry

--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -1,0 +1,59 @@
+====================================================
+Generate an input file from equilibrium and profiles
+====================================================
+
+Here a step-by-step guide on how to generate an input file
+for any gyrokinetic codes supported in ``pyrokinetics``,
+starting from equilibrium and profile files.
+
+
+Let's first import ``pyrokinetics`` and define our equilibrium and input files. 
+
+.. code-block:: python
+   >>> from pyrokinetics import Pyro, template_dir
+   >>> eq_file = template / "test.geqdsk"
+   >>> kinetics_file = template_dir / "jetto.cdf"
+
+The equilibrium file ``test.geqdsk`` and the kinetics file ``jetto.cdf``
+are stored in the template foder and used here as an example.
+We now load these file into ``pyrokinetics``:
+
+.. code-block:: python
+
+   >>> pyro = Pyro(
+        eq_file=eq_file,
+        kinetics_file=kinetics_file,
+	kinetics_type="JETTO",
+        kinetics_kwargs={"time": 550},
+    )
+
+
+During initialization, ``Pyro`` calls ``read_equilibrium`` from
+the class :py:class:`Equilibrium` and initializes the class :py:class:`Kinetics`.
+The global equilibrium and proofiles are now stored in ``pyro``.
+Let's suppose we want to generate an input file for a local gyrokinetic
+simulation at :math:`Psi_n = 0.5`. This requires loading the local geometry
+at the chosen surface, which can be done by simply calling the ``load_local`` method:
+
+.. code-block:: python
+
+   >>> pyro.load_local(psi_n=0.5, local_geometry="Miller")
+
+Here we have used the ``Miller`` parametrization of the local surface. Other
+parametrization are possible in ``pyrokinetics``. See....
+Before generating an input file, we need to specify ``gk_code``:
+
+.. code-block:: python
+   >>> pyro.gk_code = "GS2"
+
+Note that ``gk_code`` can be any code supported in ``pyrokinetics``, which can
+be view from ``pyro.supported_gk_inputs``. 
+We are now ready to write our input file:
+
+.. code-block:: python
+   >>> pyro.write_gk_file(file_name="test_jetto.cgyro")
+
+Alternatively, ``gk_code`` can be pass as keyword argument to ``write_gk_file``,
+.. code-block:: python
+   >>> pyro.write_gk_file(file_name="test_jetto.cgyro", gk_code="GS2")
+

--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -62,6 +62,7 @@ We are now ready to write our input file:
    >>> pyro.write_gk_file(file_name="test_jetto.cgyro")
 
 Alternatively, ``gk_code`` can be pass as keyword argument to ``write_gk_file``,
+
 .. code-block:: python
 
    >>> pyro.write_gk_file(file_name="test_jetto.cgyro", gk_code="CGYRO")

--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -16,7 +16,7 @@ Let's first import ``pyrokinetics`` and define our equilibrium and input files.
 
 The equilibrium file ``test.geqdsk`` and the kinetics file ``jetto.cdf``
 are stored in the template foder and used here as an example.
-We now load these file into ``pyrokinetics``:
+We now load these files into ``pyrokinetics``:
 
 .. code-block:: python
 
@@ -40,14 +40,14 @@ at the chosen surface, which can be done by simply calling the ``load_local`` me
    >>> pyro.load_local(psi_n=0.5, local_geometry="Miller")
 
 Here we have used the ``Miller`` parametrization of the local surface. Other
-parametrization are possible in ``pyrokinetics``. See....
+parametrizations are possible in ``pyrokinetics``. See the output of ``pyro.supported_local_geometries``.
 Before generating an input file, we need to specify ``gk_code``:
 
 .. code-block:: python
    >>> pyro.gk_code = "GS2"
 
 Note that ``gk_code`` can be any code supported in ``pyrokinetics``, which can
-be view from ``pyro.supported_gk_inputs``. 
+be found in ``pyro.supported_gk_inputs``. 
 We are now ready to write our input file:
 
 .. code-block:: python

--- a/docs/howtos/read_eq_prof.rst
+++ b/docs/howtos/read_eq_prof.rst
@@ -17,7 +17,7 @@ Let's first import ``pyrokinetics`` and define our equilibrium and input files.
    >>> gk_file = template_dir / "input.cgyro"
 
 The equilibrium file ``test.geqdsk`` and the kinetics file ``jetto.cdf``
-are stored in the template foder and used here as an example.
+are stored in the template folder and used here as an example.
 The gyrokinetic file ``input.cgyro`` is our input file template where
 we set all the extra flags we need. The input parameters related to the
 geometry and species will be added to this template by ``pyrokinetics``.
@@ -28,15 +28,15 @@ We now load these files into ``pyrokinetics``:
    >>> pyro = Pyro(
         eq_file=eq_file,
         kinetics_file=kinetics_file,
-	kinetics_type="JETTO",
+        kinetics_type="JETTO",
         kinetics_kwargs={"time": 550},
-	gk_file=gk_file,
+        gk_file=gk_file,
     )
 
 
 During initialization, `Pyro` calls `read_equilibrium` from
 the class `Equilibrium` and initializes the class `Kinetics`.
-The global equilibrium and proofiles are now stored in ``pyro``.
+The global equilibrium and profiles are now stored in ``pyro``.
 Let's suppose we want to generate an input file for a local gyrokinetic
 simulation at :math:`\Psi_n = 0.5`. This requires loading the local geometry
 at the chosen surface, which can be done by simply calling the ``load_local`` method:


### PR DESCRIPTION
I have added to the documentation the file `read_eq_prof.rst` that explains how to generate an input file for a gyrokinetic simulation starting from an equilibrium and a kinetic file. This how-to follows the example script `example_JETTO.py`. 