### PR TITLE
Restrict IDSPy features to Python version >= 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
     "pint-xarray ~= 0.3",
     "contourpy ~= 1.0",
     "xrft >= 1.0.0",
-    "idspy-dictionaries >= 0.4.0",
-    "idspy-toolkit >= 0.4.1",
+    "idspy-dictionaries >= 0.4.0; python_version >= '3.9'",
+    "idspy-toolkit >= 0.4.1; python_version >= '3.9'",
     "pyloidal >= 0.1.0",
     "xmltodict ~= 0.13.0"
 ]

--- a/pyrokinetics/databases/__init__.py
+++ b/pyrokinetics/databases/__init__.py
@@ -1,4 +1,8 @@
-from .imas import pyro_to_ids, ids_to_pyro
+from platform import python_version_tuple
 
+__all__ = []
 
-__all__ = ["pyro_to_ids", "ids_to_pyro"]
+if tuple(int(x) for x in python_version_tuple()[:2]) >= (3, 9):
+    from .imas import pyro_to_ids, ids_to_pyro
+
+    __all__.extend(["pyro_to_ids", "ids_to_pyro"])

--- a/pyrokinetics/gk_code/__init__.py
+++ b/pyrokinetics/gk_code/__init__.py
@@ -1,3 +1,5 @@
+from platform import python_version_tuple
+
 from .GKInput import GKInput, gk_inputs
 from .GKInputGS2 import GKInputGS2
 from .GKInputCGYRO import GKInputCGYRO
@@ -14,6 +16,9 @@ from .GKOutputReaderGS2 import GKOutputReaderGS2  # noqa
 from .GKOutputReaderCGYRO import GKOutputReaderCGYRO  # noqa
 from .GKOutputReaderGENE import GKOutputReaderGENE  # noqa
 from .GKOutputReaderTGLF import GKOutputReaderTGLF  # noqa
-from .GKOutputReaderIDS import GKOutputReaderIDS  # noqa
+
+# Only import IDS if Python version is greater than 3.9
+if tuple(int(x) for x in python_version_tuple()[:2]) >= (3, 9):
+    from .GKOutputReaderIDS import GKOutputReaderIDS  # noqa
 
 __all__ = ["GKInput", "gk_inputs", "GKOutput", "supported_gk_output_types"]


### PR DESCRIPTION
Disables IMAS data dictionary interoperability for older Python versions. Also restricts the import of IMAS features in `pyrokinetics.databases`.

When this is integrated with the new docs system, I think docs will fail to build for Python 3.8. I've bumped the readthedocs Python version to 3.9 to account for this, but as it stands I don't think users will be able to build their own docs with Python 3.8.