### PR TITLE
Change theta grid from original geometry to MXH geometry when loading…

### DIFF
--- a/pyrokinetics/databases/imas.py
+++ b/pyrokinetics/databases/imas.py
@@ -185,11 +185,15 @@ def ids_to_pyro(ids_path, file_format="hdf5"):
     pyro.set_reference_values(**reference_values)
 
     original_theta_geo = pyro.local_geometry.theta
+    original_lg = pyro.local_geometry
 
     pyro.switch_local_geometry("MXH")
 
     # Original local_geometry theta grid using MXH theta definition
     mxh_theta_geo = pyro.local_geometry.theta_eq
+
+    # Revert local geometry
+    pyro.local_geometry = original_lg
 
     pyro.load_gk_output(ids_path, gk_type="IDS", ids=ids, original_theta_geo=original_theta_geo, mxh_theta_geo=mxh_theta_geo)
 

--- a/pyrokinetics/databases/imas.py
+++ b/pyrokinetics/databases/imas.py
@@ -191,7 +191,13 @@ def ids_to_pyro(ids_path, file_format="hdf5"):
     # Original local_geometry theta grid using MXH theta definition
     mxh_theta_geo = pyro.local_geometry.theta_eq
 
-    pyro.load_gk_output(ids_path, gk_type="IDS", ids=ids, original_theta_geo=original_theta_geo, mxh_theta_geo=mxh_theta_geo)
+    pyro.load_gk_output(
+        ids_path,
+        gk_type="IDS",
+        ids=ids,
+        original_theta_geo=original_theta_geo,
+        mxh_theta_geo=mxh_theta_geo,
+    )
 
     return pyro
 
@@ -262,9 +268,12 @@ def pyro_to_imas_mapping(
     original_theta_output = pyro.gk_output["theta"].data
 
     # Need to interpolate on theta mod 2pi and then add back on each period
-    theta_interval = (original_theta_output // (2*np.pi))
-    theta_mod = original_theta_output % (2*np.pi)
-    mxh_theta_output = np.interp(theta_mod, original_theta_geo, mxh_theta_geo) + theta_interval * 2*np.pi
+    theta_interval = original_theta_output // (2 * np.pi)
+    theta_mod = original_theta_output % (2 * np.pi)
+    mxh_theta_output = (
+        np.interp(theta_mod, original_theta_geo, mxh_theta_geo)
+        + theta_interval * 2 * np.pi
+    )
 
     # Assign new theta coord
     pyro.gk_output.data = pyro.gk_output.data.assign_coords(theta=mxh_theta_output)

--- a/pyrokinetics/gk_code/gene.py
+++ b/pyrokinetics/gk_code/gene.py
@@ -175,7 +175,10 @@ class GKInputGENE(GKInput):
         """
         geometry_type = self.data["geometry"]["magn_geometry"]
         if geometry_type == "miller":
-            if self.data["geometry"].get("zeta", 0.0) != 0.0 or self.data["geometry"].get("zeta", 0.0) != 0.0:
+            if (
+                self.data["geometry"].get("zeta", 0.0) != 0.0
+                or self.data["geometry"].get("zeta", 0.0) != 0.0
+            ):
                 return self.get_local_geometry_miller_turnbull()
             else:
                 return self.get_local_geometry_miller()

--- a/pyrokinetics/gk_code/gene.py
+++ b/pyrokinetics/gk_code/gene.py
@@ -175,7 +175,7 @@ class GKInputGENE(GKInput):
         """
         geometry_type = self.data["geometry"]["magn_geometry"]
         if geometry_type == "miller":
-            if self.data.get("zeta", 0.0) != 0.0 or self.data.get("zeta", 0.0):
+            if self.data["geometry"].get("zeta", 0.0) != 0.0 or self.data["geometry"].get("zeta", 0.0) != 0.0:
                 return self.get_local_geometry_miller_turnbull()
             else:
                 return self.get_local_geometry_miller()

--- a/pyrokinetics/gk_code/ids.py
+++ b/pyrokinetics/gk_code/ids.py
@@ -38,7 +38,7 @@ class GKOutputReaderIDS(Reader):
         load_fluxes=True,
         load_moments=False,
         original_theta_geo=None,
-        mxh_theta_geo=None
+        mxh_theta_geo=None,
     ) -> GKOutput:
         gk_input = self._get_gk_input(ids)
         coords = self._get_coords(ids, gk_input, original_theta_geo, mxh_theta_geo)
@@ -111,7 +111,9 @@ class GKOutputReaderIDS(Reader):
         return gk_input
 
     @staticmethod
-    def _get_coords(ids: ids_gyrokinetics, gk_input: GKInput, original_theta_geo, mxh_theta_geo) -> Dict[str, Any]:
+    def _get_coords(
+        ids: ids_gyrokinetics, gk_input: GKInput, original_theta_geo, mxh_theta_geo
+    ) -> Dict[str, Any]:
         """
         Sets coords and attrs of a Pyrokinetics dataset from a collection of CGYRO
         files.
@@ -137,7 +139,7 @@ class GKOutputReaderIDS(Reader):
         ky = np.sort(np.unique(ky))
         mxh_theta_output = ids.wavevector[0].eigenmode[0].poloidal_angle
 
-        theta_interval = (mxh_theta_output // (2 * np.pi))
+        theta_interval = mxh_theta_output // (2 * np.pi)
         theta_norm = mxh_theta_output % (2 * np.pi)
         original_theta_output = np.interp(theta_norm, mxh_theta_geo, original_theta_geo)
         original_theta_output += theta_interval * 2 * np.pi


### PR DESCRIPTION
… in IMAS data dict and vice versa

When writing/reading IMAS data dictionaries we need to convert the geometry to `MXH`. We should have also changed the `theta` in the `gk_output` to the `MXH` equivalent as they don't map 1 to 1. This fixes this