### PR TITLE
Bugfix: Prevent __main__.py running when importing

### DIFF
--- a/pyrokinetics/__main__.py
+++ b/pyrokinetics/__main__.py
@@ -1,3 +1,4 @@
 from .cli import entrypoint
 
-entrypoint()
+if __name__ == "__main__":
+    entrypoint()


### PR DESCRIPTION
Updated `__main__.py` to use the `if __name__ == "__main__"` idiom.

I'd read somewhere that you shouldn't use this trick in `__main__.py` as it prevents you running a module that's saved as a zip file. I'm not sure when that would ever be relevant for this project, and in the meantime it's causing a bug in which the CLI is run every time we try to build the docs.