### PR TITLE
Need |q| for balloon transform in CGYRO

### DIFF
--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -1064,7 +1064,7 @@ class GKOutputReaderCGYRO(Reader):
                     )
 
                 # Poisson Sum (no negative in exponent to match frequency convention)
-                q = gk_input.get_local_geometry_miller().q
+                q = np.abs(gk_input.get_local_geometry_miller().q)
                 for i_radial in range(nradial):
                     nx = -nradial // 2 + (i_radial - 1)
                     field_data[i_radial, ...] *= np.exp(2j * pi * nx * q)

--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -391,11 +391,7 @@ class GKInputCGYRO(GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
 
-        domega_drho = (
-            self.data["Q"]
-            / self.data["RMIN"]
-            * self.data.get("GAMMA_E", 0.0)
-        )
+        domega_drho = self.data["Q"] / self.data["RMIN"] * self.data.get("GAMMA_E", 0.0)
 
         # Load each species into a dictionary
         for i_sp in range(self.data["N_SPECIES"]):

--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -395,7 +395,6 @@ class GKInputCGYRO(GKInput):
             self.data["Q"]
             / self.data["RMIN"]
             * self.data.get("GAMMA_E", 0.0)
-            * ureg.vref_nrl
         )
 
         # Load each species into a dictionary
@@ -988,8 +987,6 @@ class GKOutputReaderCGYRO(Reader):
         Sets 3D fields over time.
         The field coordinates should be (field, theta, kx, ky, time)
         """
-        field_names = ("phi", "apar", "bpar")
-
         nkx = len(coords["kx"])
         nradial = coords["nradial"]
         nky = len(coords["ky"])
@@ -997,6 +994,9 @@ class GKOutputReaderCGYRO(Reader):
         ntheta_plot = coords["ntheta_plot"]
         ntheta_grid = coords["ntheta_grid"]
         ntime = len(coords["time"])
+        nfield = len(coords["field"])
+
+        field_names = ["phi", "apar", "bpar"][:nfield]
 
         raw_field_data = {f: raw_data.get(f"field_{f}", None) for f in field_names}
 


### PR DESCRIPTION
CGYRO needs to use |q| when doing ballooning transform otherwise phase between connected `2 pi` segments are wrong if `q<0` (depends on field/current directions)

E.g. MTM eigenfunction with negative q before fix:
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/20d0f7df-2b19-4607-9c7c-3f61c043c32e)


After fix:
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/8d2d8d25-bdc0-4603-be95-012ac84e1d20)


