### PR TITLE
Bugfix/tglf transport eigval

### DIFF
--- a/pyrokinetics/gk_code/tglf.py
+++ b/pyrokinetics/gk_code/tglf.py
@@ -861,7 +861,6 @@ class GKOutputReaderTGLF(Reader):
             eigenvalues = np.reshape(full_data, (nky, nmode, 2))
             eigenvalues = -eigenvalues[:, :, 1] + 1j * eigenvalues[:, :, 0]
 
-            results["eigenvalues"] = eigenvalues
             results["growth_rate"] = np.imag(eigenvalues)
             results["mode_frequency"] = np.real(eigenvalues)
 

--- a/tests/gk_code/test_gk_output_reader_tglf.py
+++ b/tests/gk_code/test_gk_output_reader_tglf.py
@@ -76,6 +76,13 @@ def test_infer_path_from_input_file_tglf():
     assert output_path == Path("dir/to/")
 
 
+def test_read_tglf_transport():
+    path = template_dir / "outputs" / "TGLF_transport"
+    pyro = Pyro(gk_file=path / "input.tglf", name="test_gk_output_tglf_transport")
+    pyro.load_gk_output()
+    assert isinstance(pyro.gk_output, GKOutput)
+
+
 # Golden answer tests
 # Compares against results obtained using GKCode methods from commit 7d551eaa
 # Update: Commit d3da468c accounts for new gkoutput structure


### PR DESCRIPTION
Remove `eigenvalues` from TGLF transport `Eigenvalues` object as we only need `growth_rate` and `mode_frequency`. Add a test to try and read output data.

Fixes #235 