### PR TITLE
Enhancement/reduce memory usage

### DIFF
--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -729,7 +729,7 @@ class GKOutputReaderCGYRO(Reader):
         load_fluxes=True,
         load_moments=False,
     ) -> GKOutput:
-        raw_data, gk_input, input_str = self._get_raw_data(filename)
+        raw_data, gk_input, input_str = self._get_raw_data(filename, load_fields, load_moments)
         coords = self._get_coords(raw_data, gk_input, downsize)
         fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
         fluxes = self._get_fluxes(raw_data, coords) if load_fluxes else None
@@ -810,7 +810,7 @@ class GKOutputReaderCGYRO(Reader):
 
     @classmethod
     def _get_raw_data(
-        cls, dirname: PathLike
+        cls, dirname: PathLike, load_fields, load_moments
     ) -> Tuple[Dict[str, Any], GKInputCGYRO, str]:
         dirname = Path(dirname)
         if not dirname.exists():
@@ -833,13 +833,13 @@ class GKOutputReaderCGYRO(Reader):
             "eigenvalues_out": CGYROFile(dirname / "out.cgyro.freq", required=False),
             **{
                 f"field_{f}": CGYROFile(dirname / f"bin.cgyro.kxky_{f}", required=False)
-                for f in cls.fields
+                for f in cls.fields if load_fields
             },
             **{
                 f"moment_{m}": CGYROFile(
                     dirname / f"bin.cgyro.kxky_{m}", required=False
                 )
-                for m in cls.moments
+                for m in cls.moments if load_moments
             },
             **{
                 f"eigenfunctions_{f}": CGYROFile(

--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -729,7 +729,9 @@ class GKOutputReaderCGYRO(Reader):
         load_fluxes=True,
         load_moments=False,
     ) -> GKOutput:
-        raw_data, gk_input, input_str = self._get_raw_data(filename, load_fields, load_moments)
+        raw_data, gk_input, input_str = self._get_raw_data(
+            filename, load_fields, load_moments
+        )
         coords = self._get_coords(raw_data, gk_input, downsize)
         fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
         fluxes = self._get_fluxes(raw_data, coords) if load_fluxes else None
@@ -833,13 +835,15 @@ class GKOutputReaderCGYRO(Reader):
             "eigenvalues_out": CGYROFile(dirname / "out.cgyro.freq", required=False),
             **{
                 f"field_{f}": CGYROFile(dirname / f"bin.cgyro.kxky_{f}", required=False)
-                for f in cls.fields if load_fields
+                for f in cls.fields
+                if load_fields
             },
             **{
                 f"moment_{m}": CGYROFile(
                     dirname / f"bin.cgyro.kxky_{m}", required=False
                 )
-                for m in cls.moments if load_moments
+                for m in cls.moments
+                if load_moments
             },
             **{
                 f"eigenfunctions_{f}": CGYROFile(

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -343,6 +343,9 @@ class PyroScan:
                         growth_rate.append(pyro.gk_output["growth_rate"])
                         mode_frequency.append(pyro.gk_output["mode_frequency"])
                         eigenfunctions.append(pyro.gk_output["eigenfunctions"])
+                        
+                    # Remove GKOutput to conserve memory
+                    pyro.gk_output = None
 
                 except (FileNotFoundError, OSError, IndexError, RuntimeError, KeyError):
                     growth_rate.append(growth_rate[0] * np.nan)

--- a/pyrokinetics/pyroscan.py
+++ b/pyrokinetics/pyroscan.py
@@ -343,7 +343,7 @@ class PyroScan:
                         growth_rate.append(pyro.gk_output["growth_rate"])
                         mode_frequency.append(pyro.gk_output["mode_frequency"])
                         eigenfunctions.append(pyro.gk_output["eigenfunctions"])
-                        
+
                     # Remove GKOutput to conserve memory
                     pyro.gk_output = None
 


### PR DESCRIPTION
Reduces required memory for CGYRO/Pyroscan analysis. 

When loading CGYRO output, all the data is read in regardless of `load_fields` and `load_moments`. This remedies that.

Also when reading data from a `PyroScan` we can remove the `GKOutput` from each run when complete. I do that by setting it to `None` which doesn't seem like the best way of doing things...

