### PR TITLE
Shift in kx coord, not ky coord in GENE

### DIFF
--- a/pyrokinetics/gk_code/cgyro.py
+++ b/pyrokinetics/gk_code/cgyro.py
@@ -335,7 +335,9 @@ class GKInputCGYRO(GKInput):
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
         if mxh.B0 is not None:
-            mxh.beta_prime = -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
+            mxh.beta_prime = (
+                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
+            )
         else:
             mxh.beta_prime = 0.0
 

--- a/pyrokinetics/gk_code/gene.py
+++ b/pyrokinetics/gk_code/gene.py
@@ -1073,7 +1073,7 @@ class GKOutputReaderGENE(AbstractFileReader):
         fields = fields.transpose(0, 3, 1, 2, 4)
 
         # Shift kx component to middle of array
-        fields = np.roll(np.fft.fftshift(fields, axes=2), -1, axis=-2)
+        fields = np.roll(np.fft.fftshift(fields, axes=2), -1, axis=2)
 
         result = {}
 


### PR DESCRIPTION
Nonlinear GENE simulations were shifting ky by one, rather than kx meaning the zonal was on the wrong end of the box and the kx mid point was one off, shown blow

![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/e7cd1d63-8a5e-4aca-ac8c-7e98aaad5653)

Here are the fixed grid
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/312c5153-89c8-48d5-8ca0-950502d06af4)

