### PR TITLE
Select fields to load from data coords

### DIFF
--- a/pyrokinetics/gk_code/gs2.py
+++ b/pyrokinetics/gk_code/gs2.py
@@ -881,6 +881,9 @@ class GKOutputReaderGS2(AbstractFileReader):
 
         coord_names = ["flux", "field", "species", "ky", "time"]
         fluxes = np.zeros([len(coords[name]) for name in coord_names])
+        fields = {
+            field: value for field, value in fields.items() if field in coords["field"]
+        }
 
         for (ifield, (field, gs2_field)), (iflux, gs2_flux) in product(
             enumerate(fields.items()), enumerate(fluxes_dict.values())


### PR DESCRIPTION
When loading fields in `GS2`, if `apar` is turned off, pyro tried to load in the `apar` field data regardless of whether that data exists or not. Here we check for which fields to load