### PR TITLE
Minor JOSS edits

### DIFF
--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -21,6 +21,9 @@ authors:
   - name: Peter Hill
     orcid: 0000-0003-3092-1858
     affiliation: 2
+  - name: Liam Pattinson
+    orcid: 0000-0001-8604-6904
+    affiliation: 2
   - name: Harry G. Dudding
     orcid: 0000-0002-3413-0861
     affiliation: 1

--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'Pyrokinetics - A python library to standardise gyrokinetic analysis'
+title: 'Pyrokinetics - A Python library to standardise gyrokinetic analysis'
 tags:
   - Python
   - gyrokinetics
@@ -52,7 +52,7 @@ plasmas, accounting for the majority of the particle and heat loss. Gyrokinetic 
 quantify the level of turbulent transport in fusion reactors and can be used to understand the 
 major drivers of turbulence. The realisation of fusion critically depends on understanding how to
 mitigate turbulent transport and thus requires high levels of confidence in the tools being
-used. Many different gyrokinetic modelling codes are available for use and pyrokinetics aims to 
+used. Many different gyrokinetic modelling codes are available for use and Pyrokinetics aims to
 standardise the analysis of such simulations.
 
 # Statement of need
@@ -81,7 +81,7 @@ same method such that the modeller is confident that the output is consistent ac
 Pyrokinetics was designed to be used by gyrokinetics modellers and has already been used in a 
 number of scientific publications 
 [@giacomin:2023a; @giacomin:2023b; @kennedy:2023]. Furthermore, the 
-python interface opens up gyrokinetic analysis to the wide variety of python packages available, 
+Python interface opens up gyrokinetic analysis to the wide variety of Python packages available,
 allowing for a range of analyses from simple parameter scans to using 
 thousands of linear gyrokinetic runs to develop Gaussian process regression models of the
 linear properties of electromagnetic turbulence [@hornsby:2023]. Pyrokinetics also maintains 
@@ -89,7 +89,7 @@ compatibility with IMAS, a community wide standard for data format [@imbeaux:201
 further interfacing with the whole fusion community and the potential to develop a global gyrokinetic
 database.
 
-We hope that pyrokinetics makes gyrokinetics modelling more accessible and will help to increase the
+We hope that Pyrokinetics makes gyrokinetics modelling more accessible and will help to increase the
 communities confidence in tools available.
 
 

--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -71,11 +71,11 @@ wide variety of modelling tools outside of gyrokinetics. Pyrokinetics interfaces
 these allowing for the easy generation of both linear and nonlinear gyrokinetic input files and 
 has been designed to be extensible and easy to add new sources of data. 
 
-The output of gyrokinetic codes is often multidimensional and each code stores this data in a
-different format with different normalisations, and potentially across multiple files. Pyrokinetics will seamlessly read in all this data and
+The output of gyrokinetic codes is often multidimensional, and each code stores this data in a
+different format with different normalisations, potentially across multiple files. Pyrokinetics will seamlessly read in all this data and
 store it in a single object using an [`xarray`](https://pypi.org/project/xarray/) Dataset, automatically converting the outputs to a 
 standard normalisation (using [`pint`](https://pypi.org/project/Pint/)), allowing for direct comparisons between codes. Furthermore, additional derived
-outputs such as the linear growth rate of a turbulent instability, can be calculated using the exact
+outputs, such as the linear growth rate of a turbulent instability, can be calculated using the exact
 same method such that the modeller is confident that the output is consistent across codes.
 
 Pyrokinetics was designed to be used by gyrokinetics modellers and has already been used in a 
@@ -85,7 +85,7 @@ Python interface opens up gyrokinetic analysis to the wide variety of Python pac
 allowing for a range of analyses from simple parameter scans to using 
 thousands of linear gyrokinetic runs to develop Gaussian process regression models of the
 linear properties of electromagnetic turbulence [@hornsby:2023]. Pyrokinetics also maintains 
-compatibility with IMAS, a community wide standard for data format [@imbeaux:2015], allowing for 
+compatibility with IMAS, a community-wide standard data schema [@imbeaux:2015], allowing for
 further interfacing with the whole fusion community and the potential to develop a global gyrokinetic
 database.
 

--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -46,7 +46,7 @@ bibliography: paper.bib
 
 Fusion energy offers the potential for a near limitless source of low carbon energy and is often 
 regarded as a solution for the world's long term energy needs. To realise such a scenario requires
-the design of high performance fusion reactors capable of maintaining the extreme conditions
+the design of high-performance fusion reactors capable of maintaining the extreme conditions
 necessary to enable fusion. Turbulence is typically the dominant source of transport in fusion
 plasmas, accounting for the majority of the particle and heat loss. Gyrokinetic modelling aims to 
 quantify the level of turbulent transport in fusion reactors and can be used to understand the 
@@ -60,11 +60,11 @@ standardise the analysis of such simulations.
 [Pyrokinetics](https://github.com/pyro-kinetics/pyrokinetics) is a Python project (package: 
 [`pyrokinetics`](https://pypi.org/project/pyrokinetics/))
 that aims to simplify and standardise gyrokinetic analysis. A wide 
-variety of different gyrokinetic solvers exist that utilise different input file formats and
-use different normalisations for plasma parameters such as densities, temperatures, velocities,
+variety of gyrokinetic solvers are used in practice, each utilising different input file formats and
+normalisations for plasma parameters such as densities, temperatures, velocities,
 and magnetic fields. To improve confidence in the predictions from gyrokinetic solvers it is often 
 desirable to benchmark the results of one code against another. Pyrokinetics aims to make this
-easier for researchers by acting as an interface between the different codes, automatically 
+easier for researchers by acting as an interface between each code, automatically
 handling the conversion of physical input parameters between different normalisations
 and file formats. Furthermore, gyrokinetics inputs can come from a
 wide variety of modelling tools outside of gyrokinetics. Pyrokinetics interfaces with
@@ -74,7 +74,7 @@ has been designed to be extensible and easy to add new sources of data.
 The output of gyrokinetic codes is often multidimensional, and each code stores this data in a
 different format with different normalisations, potentially across multiple files. Pyrokinetics will seamlessly read in all this data and
 store it in a single object using an [`xarray`](https://pypi.org/project/xarray/) Dataset, automatically converting the outputs to a 
-standard normalisation (using [`pint`](https://pypi.org/project/Pint/)), allowing for direct comparisons between codes. Furthermore, additional derived
+standard normalisation (using [`pint`](https://pypi.org/project/Pint/)), permitting direct comparisons between codes. Furthermore, additional derived
 outputs, such as the linear growth rate of a turbulent instability, can be calculated using the exact
 same method such that the modeller is confident that the output is consistent across codes.
 
@@ -85,12 +85,12 @@ Python interface opens up gyrokinetic analysis to the wide variety of Python pac
 allowing for a range of analyses from simple parameter scans to using 
 thousands of linear gyrokinetic runs to develop Gaussian process regression models of the
 linear properties of electromagnetic turbulence [@hornsby:2023]. Pyrokinetics also maintains 
-compatibility with IMAS, a community-wide standard data schema [@imbeaux:2015], allowing for
-further interfacing with the whole fusion community and the potential to develop a global gyrokinetic
+compatibility with IMAS, a standard data schema for magnetic confinement fusion [@imbeaux:2015], enabling
+greater interoperability with the wider fusion community and the potential development of a global gyrokinetic
 database.
 
 We hope that Pyrokinetics makes gyrokinetics modelling more accessible and will help to increase the
-communities confidence in tools available.
+community's confidence in the tools available.
 
 
 # Acknowledgements


### PR DESCRIPTION
The JOSS paper mostly looks good to me. I've added myself to the author list, and recommended a few minor edits:

- Always capitalise Pyrokinetics and Python.
- Fixed some minor grammar points.
- Tweaked the wording in a few places to avoid frequently repeated words and phrases (mostly 'different' and 'allowing for')

Let me know if you'd prefer me to revert any of these changes.