### PR TITLE
Remove deprecated system_packages for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true


### PR DESCRIPTION
Read the docs no longer supports the use of `system_packages: True` in the yaml file. Removed to allow for build to succeed

https://blog.readthedocs.com/drop-support-system-packages/