### PR TITLE
Feature/write normalisations

### DIFF
--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -366,7 +366,7 @@ def pyro_to_imas_mapping(
     species_all = convert_dict(
         {
             "beta_reference": numerics.beta,
-            "velocity_tor_norm": pyro.local_species.electron.vel,
+            "velocity_tor_norm": pyro.local_species.electron.omega0,
             "zeff": pyro.local_species.zeff,
             "debye_length_reference": None,
             "shearing_rate_norm": None,
@@ -383,7 +383,7 @@ def pyro_to_imas_mapping(
                 "temperature_log_gradient_norm": species.inverse_lt,
                 "density_norm": species.dens,
                 "density_log_gradient_norm": species.inverse_ln,
-                "velocity_tor_gradient_norm": species.inverse_lv,
+                "velocity_tor_gradient_norm": species.domega_drho,
             },
             norms.imas,
         )

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -599,14 +599,13 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         for i_sp, name in enumerate(local_species.names):
             pyro_cgyro_species = self.get_pyro_cgyro_species(i_sp + 1)
-
             for pyro_key, cgyro_key in pyro_cgyro_species.items():
                 self.data[cgyro_key] = local_species[name][pyro_key].to(
                     local_norm.cgyro
                 )
         self.data["MACH"] = local_species.electron.omega0 * self.data["RMAJ"]
         self.data["GAMMA_P"] = (
-            -local_species.electron.domega_drho
+            -local_species.electron.domega_drho.to(local_norm.cgyro)
             * self.data["RMAJ"]
             * local_norm.cgyro.lref
         )

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -276,7 +276,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            miller.B0 = 1 / (miller.bunit_over_b0 * beta**0.5)
+            miller.B0 = 1 / (miller.bunit_over_b0 * beta ** 0.5)
         else:
             miller.B0 = None
 
@@ -286,7 +286,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if miller.B0 is not None:
             miller.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / miller.B0**2
+                -local_species.inverse_lp.m * beta_prime_scale / miller.B0 ** 2
             )
         else:
             miller.beta_prime = 0.0
@@ -325,7 +325,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            mxh.B0 = 1 / (mxh.bunit_over_b0 * beta**0.5)
+            mxh.B0 = 1 / (mxh.bunit_over_b0 * beta ** 0.5)
         else:
             mxh.B0 = None
 
@@ -335,7 +335,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if mxh.B0 is not None:
             mxh.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
+                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0 ** 2
             )
         else:
             mxh.beta_prime = 0.0
@@ -365,7 +365,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta**0.5)
+            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta ** 0.5)
         else:
             fourier.B0 = None
 
@@ -375,7 +375,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if fourier.B0 is not None:
             fourier.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / fourier.B0**2
+                -local_species.inverse_lp.m * beta_prime_scale / fourier.B0 ** 2
             )
         else:
             fourier.beta_prime = 0.0
@@ -393,7 +393,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
 
-        domega_drho = self.data["Q"] / self.data["RMIN"] * self.data.get("GAMMA_E", 0.0)
+        domega_drho = -self.data.get("GAMMA_P", 0.0) / self.data["RMAJ"]
 
         # Load each species into a dictionary
         for i_sp in range(self.data["N_SPECIES"]):
@@ -402,10 +402,11 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             for p_key, c_key in pyro_cgyro_species.items():
                 species_data[p_key] = self.data[c_key]
 
-            species_data.vel = 0.0 * ureg.vref_nrl
-            species_data.inverse_lv = 0.0 / ureg.lref_minor_radius
+            species_data.omega0 = (
+                self.data.get("MACH", 0.0) * ureg.vref_nrl / ureg.lref_minor_radius
+            )
             species_data.domega_drho = (
-                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2
+                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius ** 2
             )
 
             if species_data.z == -1:
@@ -424,8 +425,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             species_data.mass *= ureg.mref_deuterium
             species_data.temp *= ureg.tref_electron / Te_norm
             species_data.z *= ureg.elementary_charge
-            species_data.inverse_lt *= ureg.lref_minor_radius**-1
-            species_data.inverse_ln *= ureg.lref_minor_radius**-1
+            species_data.inverse_lt *= ureg.lref_minor_radius ** -1
+            species_data.inverse_ln *= ureg.lref_minor_radius ** -1
 
             # Add individual species data to dictionary of species
             local_species.add_species(name=name, species_data=species_data)
@@ -446,8 +447,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion**4 * nion / tion**1.5 / mion**0.5)
-                / (ne / te**1.5 / me**0.5)
+                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
+                / (ne / te ** 1.5 / me ** 0.5)
             ).m * nu_ee.units
 
         # Normalise to pyrokinetics normalisations and calculate total pressure gradient
@@ -558,7 +559,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 self.data[val] = local_geometry[key]
 
             self.data["S_DELTA"] = local_geometry.s_delta * np.sqrt(
-                1 - local_geometry.delta**2
+                1 - local_geometry.delta ** 2
             )
             self.data["ZMAG"] = local_geometry.Z0
             self.data["DZMAG"] = local_geometry.dZ0dr
@@ -594,6 +595,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                     local_norm.cgyro
                 )
 
+        self.data["MACH"] = local_species.electron.omega0
+        self.data["GAMMA_P"] = -local_species.electron.domega_drho * self.data["RMAJ"]
         self.data["Z_EFF_METHOD"] = 1
         self.data["Z_EFF"] = local_species.zeff
 
@@ -606,7 +609,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         # Calculate beta_prime_scale
         if beta != 0.0:
             beta_prime_scale = -local_geometry.beta_prime / (
-                local_species.inverse_lp.m * beta * local_geometry.bunit_over_b0**2
+                local_species.inverse_lp.m * beta * local_geometry.bunit_over_b0 ** 2
             )
         else:
             beta_prime_scale = 1.0

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -403,7 +403,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 species_data[p_key] = self.data[c_key]
 
             species_data.omega0 = (
-                self.data.get("MACH", 0.0) * ureg.vref_nrl / ureg.lref_minor_radius
+                self.data.get("MACH", 0.0) * ureg.vref_nrl / ureg.lref_minor_radius / self.data["RMAJ"]
+
             )
             species_data.domega_drho = (
                 domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2
@@ -595,7 +596,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                     local_norm.cgyro
                 )
 
-        self.data["MACH"] = local_species.electron.omega0
+        self.data["MACH"] = local_species.electron.omega0 * self.data["RMAJ"]
         self.data["GAMMA_P"] = -local_species.electron.domega_drho * self.data["RMAJ"]
         self.data["Z_EFF_METHOD"] = 1
         self.data["Z_EFF"] = local_species.zeff

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -508,6 +508,13 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         return Numerics(**numerics_data)
 
+    def get_normalisation(self, local_norm: Normalisation) -> Dict[str, Any]:
+        """
+        Reads in normalisation values from input file
+
+        """
+        return {}
+
     def set(
         self,
         local_geometry: LocalGeometry,
@@ -597,9 +604,12 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 self.data[cgyro_key] = local_species[name][pyro_key].to(
                     local_norm.cgyro
                 )
-
         self.data["MACH"] = local_species.electron.omega0 * self.data["RMAJ"]
-        self.data["GAMMA_P"] = -local_species.electron.domega_drho * self.data["RMAJ"]
+        self.data["GAMMA_P"] = (
+            -local_species.electron.domega_drho
+            * self.data["RMAJ"]
+            * local_norm.cgyro.lref
+        )
         self.data["Z_EFF_METHOD"] = 1
         self.data["Z_EFF"] = local_species.zeff
 

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -276,7 +276,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            miller.B0 = 1 / (miller.bunit_over_b0 * beta ** 0.5)
+            miller.B0 = 1 / (miller.bunit_over_b0 * beta**0.5)
         else:
             miller.B0 = None
 
@@ -286,7 +286,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if miller.B0 is not None:
             miller.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / miller.B0 ** 2
+                -local_species.inverse_lp.m * beta_prime_scale / miller.B0**2
             )
         else:
             miller.beta_prime = 0.0
@@ -325,7 +325,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            mxh.B0 = 1 / (mxh.bunit_over_b0 * beta ** 0.5)
+            mxh.B0 = 1 / (mxh.bunit_over_b0 * beta**0.5)
         else:
             mxh.B0 = None
 
@@ -335,7 +335,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if mxh.B0 is not None:
             mxh.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0 ** 2
+                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
             )
         else:
             mxh.beta_prime = 0.0
@@ -365,7 +365,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data["BETAE_UNIT"] * ne_norm * Te_norm
         if beta != 0:
-            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta ** 0.5)
+            fourier.B0 = 1 / (fourier.bunit_over_b0 * beta**0.5)
         else:
             fourier.B0 = None
 
@@ -375,7 +375,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
 
         if fourier.B0 is not None:
             fourier.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / fourier.B0 ** 2
+                -local_species.inverse_lp.m * beta_prime_scale / fourier.B0**2
             )
         else:
             fourier.beta_prime = 0.0
@@ -406,7 +406,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 self.data.get("MACH", 0.0) * ureg.vref_nrl / ureg.lref_minor_radius
             )
             species_data.domega_drho = (
-                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius ** 2
+                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2
             )
 
             if species_data.z == -1:
@@ -425,8 +425,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             species_data.mass *= ureg.mref_deuterium
             species_data.temp *= ureg.tref_electron / Te_norm
             species_data.z *= ureg.elementary_charge
-            species_data.inverse_lt *= ureg.lref_minor_radius ** -1
-            species_data.inverse_ln *= ureg.lref_minor_radius ** -1
+            species_data.inverse_lt *= ureg.lref_minor_radius**-1
+            species_data.inverse_ln *= ureg.lref_minor_radius**-1
 
             # Add individual species data to dictionary of species
             local_species.add_species(name=name, species_data=species_data)
@@ -447,8 +447,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         # Normalise to pyrokinetics normalisations and calculate total pressure gradient
@@ -559,7 +559,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 self.data[val] = local_geometry[key]
 
             self.data["S_DELTA"] = local_geometry.s_delta * np.sqrt(
-                1 - local_geometry.delta ** 2
+                1 - local_geometry.delta**2
             )
             self.data["ZMAG"] = local_geometry.Z0
             self.data["DZMAG"] = local_geometry.dZ0dr
@@ -609,7 +609,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         # Calculate beta_prime_scale
         if beta != 0.0:
             beta_prime_scale = -local_geometry.beta_prime / (
-                local_species.inverse_lp.m * beta * local_geometry.bunit_over_b0 ** 2
+                local_species.inverse_lp.m * beta * local_geometry.bunit_over_b0**2
             )
         else:
             beta_prime_scale = 1.0

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -403,8 +403,10 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 species_data[p_key] = self.data[c_key]
 
             species_data.omega0 = (
-                self.data.get("MACH", 0.0) * ureg.vref_nrl / ureg.lref_minor_radius / self.data["RMAJ"]
-
+                self.data.get("MACH", 0.0)
+                * ureg.vref_nrl
+                / ureg.lref_minor_radius
+                / self.data["RMAJ"]
             )
             species_data.domega_drho = (
                 domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -225,7 +225,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             miller.B0 = None
 
         miller.beta_prime = -self.data["geometry"].get("amhd", 0.0) / (
-            miller.q ** 2 * miller.Rmaj
+            miller.q**2 * miller.Rmaj
         )
 
         dpdx = self.data["geometry"].get("dpdx_pm", -2)
@@ -284,7 +284,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             miller.B0 = None
 
         miller.beta_prime = -self.data["geometry"].get("amhd", 0.0) / (
-            miller.q ** 2 * miller.Rmaj
+            miller.q**2 * miller.Rmaj
         )
 
         return miller
@@ -367,7 +367,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                 external_contr["Omega0_tor"] * ureg.vref_nrl / self.lref_gene
             )
             species_data["domega_drho"] = (
-                domega_drho * ureg.vref_nrl / self.lref_gene ** 2
+                domega_drho * ureg.vref_nrl / self.lref_gene**2
             )
 
             if species_data.z == -1:
@@ -406,8 +406,8 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         local_species.zeff = (
@@ -525,7 +525,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                 self.data[gene_param][gene_key] = local_geometry[pyro_key]
 
         self.data["geometry"]["amhd"] = (
-            -(local_geometry.q ** 2) * local_geometry.Rmaj * local_geometry.beta_prime
+            -(local_geometry.q**2) * local_geometry.Rmaj * local_geometry.beta_prime
         )
         self.data["geometry"]["dpdx_pm"] = -2
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -476,6 +476,34 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         return Numerics(**numerics_data)
 
+    def get_normalisation(self, local_norm: Normalisation) -> Dict[str, Any]:
+        """
+        Reads in normalisation values from input file
+
+        """
+        if "units" not in self.data.keys():
+            return {}
+
+        norms = {}
+
+        if "minor_r" in self.data["geometry"]:
+            lref_scale = self.data["geometry"]["minor_r"]
+            lref_key = "minor_radius"
+        elif "major_R" in self.data["geometry"]:
+            lref_scale = self.data["geometry"]["major_R"]
+            lref_key = "major_radius"
+
+        norms["tref_electron"] = self.data["units"]["Tref"] * local_norm.units.keV
+        norms["nref_electron"] = (
+            self.data["units"]["nref"] * local_norm.units.meter**-3 * 1e19
+        )
+        norms["bref_B0"] = self.data["units"]["Bref"] * local_norm.units.tesla
+        norms[f"lref_{lref_key}"] = (
+            self.data["units"]["lref"] * local_norm.units.meter / lref_scale
+        )
+
+        return norms
+
     def set(
         self,
         local_geometry: LocalGeometry,
@@ -605,15 +633,17 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                     "Omega0_tor": local_species.electron.omega0,
                     "pfsrate": -local_species.electron.domega_drho
                     * local_geometry.rho
-                    / self.data["geometry"]["q0"],
+                    / self.data["geometry"]["q0"]
+                    * local_norm.gene.lref,
                 }
             )
         else:
             self.data["external_contr"]["Omega0_tor"] = local_species.electron.omega0
             self.data["external_contr"]["pfsrate"] = (
-                -local_species.electron.domega_drho
+                -local_species.electron.domega_drho.to(local_norm.gene)
                 * local_geometry.rho
                 / self.data["geometry"]["q0"]
+                * local_norm.gene.lref
             )
 
         self.data["general"]["zeff"] = local_species.zeff
@@ -672,6 +702,25 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         if not local_norm:
             return
+
+        try:
+            (1 * local_norm.gene.tref).to("keV")
+            si_units = True
+        except pint.errors.DimensionalityError:
+            si_units = False
+
+        if si_units:
+            if "units" not in self.data.keys():
+                self.data["units"] = f90nml.Namelist()
+
+            self.data["units"]["Tref"] = (1 * local_norm.gene.tref).to("keV")
+            self.data["units"]["nref"] = (1e-19 * local_norm.gene.nref).to("meter**-3")
+            self.data["units"]["mref"] = (1 * local_norm.gene.mref).to("proton_mass")
+            self.data["units"]["Bref"] = (1 * local_norm.gene.bref).to("tesla")
+            self.data["units"]["Lref"] = (1 * local_norm.gene.lref).to("meter")
+            self.data["units"]["omegatorref"] = local_species.electron.omega0.to(
+                local_norm.gene
+            ).to("radians/second")
 
         for name, namelist in self.data.items():
             self.data[name] = convert_dict(namelist, local_norm.gene)

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -484,6 +484,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         if "units" not in self.data.keys():
             return {}
 
+        if not self.data["units"].keys():
+            return {}
+
         norms = {}
 
         if "minor_r" in self.data["geometry"]:
@@ -631,7 +634,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             self.data["external_contr"] = f90nml.Namelist(
                 {
                     "Omega0_tor": local_species.electron.omega0,
-                    "pfsrate": -local_species.electron.domega_drho
+                    "pfsrate": -local_species.electron.domega_drho.to(local_norm.gene)
                     * local_geometry.rho
                     / self.data["geometry"]["q0"]
                     * local_norm.gene.lref,

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -509,7 +509,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
             self.data[species_key]["uprim"] = (
                 local_species[name]["domega_drho"]
-                / self.data["theta_grid_parameters"]["rmaj"]
+                * self.data["theta_grid_parameters"]["rmaj"]
             )
 
         self.data["dist_fn_knobs"]["mach"] = local_species.electron.omega0

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -235,8 +235,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
                 species_data[pyro_key] = gs2_data[gs2_key]
 
             domega_drho = (
-                gs2_data.get("uprim", 0.0)
-                / self.data["theta_grid_parameters"]["rmaj"]
+                gs2_data.get("uprim", 0.0) / self.data["theta_grid_parameters"]["rmaj"]
             )
             species_data.omega0 = (
                 self.data["dist_fn_knobs"].get("mach", 0.0)
@@ -244,7 +243,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
                 / ureg.lref_minor_radius
             )
             species_data.domega_drho = (
-                domega_drho * ureg.vref_most_probable / ureg.lref_minor_radius ** 2
+                domega_drho * ureg.vref_most_probable / ureg.lref_minor_radius**2
             )
 
             if species_data.z == -1:
@@ -261,8 +260,8 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             species_data.nu *= ureg.vref_most_probable / ureg.lref_minor_radius
             species_data.temp *= ureg.tref_electron / Te_norm
             species_data.z *= ureg.elementary_charge
-            species_data.inverse_lt *= ureg.lref_minor_radius ** -1
-            species_data.inverse_ln *= ureg.lref_minor_radius ** -1
+            species_data.inverse_lt *= ureg.lref_minor_radius**-1
+            species_data.inverse_ln *= ureg.lref_minor_radius**-1
 
             # Add individual species data to dictionary of species
             local_species.add_species(name=name, species_data=species_data)

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -226,7 +226,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data.get("betae", 0.0) * ne_norm * Te_norm
-        miller.B0 = 1 / (beta ** 0.5) / miller.bunit_over_b0 if beta != 0 else None
+        miller.B0 = 1 / (beta**0.5) / miller.bunit_over_b0 if beta != 0 else None
 
         # FIXME: This actually needs to be scaled (or overwritten?) by
         # local_species.inverse_lp and self.data["BETA_STAR_SCALE"]. So we
@@ -235,7 +235,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             self.data.get("p_prime_loc", 0.0)
             * miller_data["rho"]
             / miller_data["q"]
-            * miller.bunit_over_b0 ** 2
+            * miller.bunit_over_b0**2
             * (8 * np.pi)
         )
 
@@ -267,7 +267,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
         beta = self.data.get("betae", 0.0) * ne_norm * Te_norm
-        mxh.B0 = 1 / (beta ** 0.5) / mxh.bunit_over_b0 if beta != 0 else None
+        mxh.B0 = 1 / (beta**0.5) / mxh.bunit_over_b0 if beta != 0 else None
 
         # FIXME: This actually needs to be scaled (or overwritten?) by
         # local_species.inverse_lp and self.data["BETA_STAR_SCALE"]. So we
@@ -276,7 +276,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             self.data.get("p_prime_loc", 0.0)
             * mxh_data["rho"]
             / mxh_data["q"]
-            * mxh.bunit_over_b0 ** 2
+            * mxh.bunit_over_b0**2
             * (8 * np.pi)
         )
 
@@ -294,7 +294,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
 
-        domega_drho = - self.data.get("vpar_shear_1", 0.0) / self.data["rmaj_loc"]
+        domega_drho = -self.data.get("vpar_shear_1", 0.0) / self.data["rmaj_loc"]
         # Load each species into a dictionary
         for i_sp in range(self.data["ns"]):
             pyro_TGLF_species = self.pyro_TGLF_species(i_sp + 1)
@@ -308,7 +308,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 / ureg.lref_minor_radius
             )
             species_data.domega_drho = (
-                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius ** 2
+                domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2
             )
 
             if species_data.z == -1:
@@ -327,8 +327,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             species_data.mass *= ureg.mref_deuterium
             species_data.temp *= ureg.tref_electron / Te_norm
             species_data.z *= ureg.elementary_charge
-            species_data.inverse_lt *= ureg.lref_minor_radius ** -1
-            species_data.inverse_ln *= ureg.lref_minor_radius ** -1
+            species_data.inverse_lt *= ureg.lref_minor_radius**-1
+            species_data.inverse_ln *= ureg.lref_minor_radius**-1
 
             # Add individual species data to dictionary of species
             local_species.add_species(name=name, species_data=species_data)
@@ -349,8 +349,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             # Not exact at log(Lambda) does change but pretty close...
             local_species[key]["nu"] = (
                 nu_ee
-                * (zion ** 4 * nion / tion ** 1.5 / mion ** 0.5)
-                / (ne / te ** 1.5 / me ** 0.5)
+                * (zion**4 * nion / tion**1.5 / mion**0.5)
+                / (ne / te**1.5 / me**0.5)
             ).m * nu_ee.units
 
         local_species.normalise()
@@ -432,7 +432,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 self.data[value] = local_geometry[key]
 
             self.data["s_delta_loc"] = local_geometry.s_delta * np.sqrt(
-                1 - local_geometry.delta ** 2
+                1 - local_geometry.delta**2
             )
 
         elif eq_type == "MXH":
@@ -456,7 +456,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 local_norm.cgyro
             )
             self.data[f"vpar_shear_{iSp+1}"] = (
-                - local_species[name]["domega_drho"].to(local_norm.cgyro)
+                -local_species[name]["domega_drho"].to(local_norm.cgyro)
                 * self.data["rmaj_loc"]
             )
 
@@ -471,7 +471,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             local_geometry.beta_prime
             * local_geometry.q
             / local_geometry.rho
-            / local_geometry.bunit_over_b0 ** 2
+            / local_geometry.bunit_over_b0**2
             / (8 * np.pi)
         )
 

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -388,6 +388,13 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         return Numerics(**numerics_data)
 
+    def get_normalisation(self, local_norm: Normalisation) -> Dict[str, Any]:
+        """
+        Reads in normalisation values from input file
+
+        """
+        return {}
+
     def set(
         self,
         local_geometry: LocalGeometry,
@@ -459,6 +466,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             self.data[f"vpar_shear_{iSp+1}"] = (
                 -local_species[name]["domega_drho"].to(local_norm.cgyro)
                 * self.data["rmaj_loc"]
+                * local_norm.tglf.lref
             )
 
         self.data["xnue"] = local_species.electron.nu.to(local_norm.cgyro)

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -454,10 +454,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 self.data[TGLF_key] = local_species[name][pyro_key].to(local_norm.cgyro)
 
             self.data[f"vpar_{iSp+1}"] = (
-                local_species[name]["omega0"]
-                * self.data["rmaj_loc"]).to(
-                local_norm.cgyro
-            )
+                local_species[name]["omega0"] * self.data["rmaj_loc"]
+            ).to(local_norm.cgyro)
             self.data[f"vpar_shear_{iSp+1}"] = (
                 -local_species[name]["domega_drho"].to(local_norm.cgyro)
                 * self.data["rmaj_loc"]

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -306,6 +306,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 self.data.get(f"vpar_{i_sp}", 0.0)
                 * ureg.vref_nrl
                 / ureg.lref_minor_radius
+                / self.data["rmaj_loc"]
             )
             species_data.domega_drho = (
                 domega_drho * ureg.vref_nrl / ureg.lref_minor_radius**2
@@ -452,7 +453,9 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             for pyro_key, TGLF_key in tglf_species.items():
                 self.data[TGLF_key] = local_species[name][pyro_key].to(local_norm.cgyro)
 
-            self.data[f"vpar_{iSp+1}"] = local_species[name]["omega0"].to(
+            self.data[f"vpar_{iSp+1}"] = (
+                local_species[name]["omega0"]
+                * self.data["rmaj_loc"]).to(
                 local_norm.cgyro
             )
             self.data[f"vpar_shear_{iSp+1}"] = (

--- a/src/pyrokinetics/kinetics/jetto.py
+++ b/src/pyrokinetics/kinetics/jetto.py
@@ -62,15 +62,6 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
         electron_dens_data = kinetics_data["NETF"][time_index, :] * units.meter**-3
         electron_dens_func = UnitSpline(psi_n, electron_dens_data)
 
-        # Rotation at Rmaj
-        rotation_data = (
-            (kinetics_data["VTOR"][time_index, :] * units.meter / units.second)
-            * Rmaj
-            / Rmax
-        )
-
-        rotation_func = UnitSpline(psi_n, rotation_data)
-
         omega_data = kinetics_data["ANGF"][time_index, :] * units.second**-1
 
         omega_func = UnitSpline(psi_n, omega_data)
@@ -85,8 +76,7 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
             mass=electron_mass,
             dens=electron_dens_func,
             temp=electron_temp_func,
-            rot=rotation_func,
-            ang=omega_func,
+            omega0=omega_func,
             rho=rho_func,
         )
 
@@ -176,8 +166,7 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
                 mass=species["mass"],
                 dens=density_func,
                 temp=ion_temp_func,
-                rot=rotation_func,
-                ang=omega_func,
+                omega0=omega_func,
                 rho=rho_func,
             )
 

--- a/src/pyrokinetics/kinetics/jetto.py
+++ b/src/pyrokinetics/kinetics/jetto.py
@@ -51,7 +51,6 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
         Rmin = kinetics_data["RI"][time_index, :]
 
         r = (Rmax - Rmin) / 2
-        Rmaj = (Rmax + Rmin) / 2
         rho = r / r[-1] * units.lref_minor_radius
         rho_func = UnitSpline(psi_n, rho)
 

--- a/src/pyrokinetics/kinetics/jetto.py
+++ b/src/pyrokinetics/kinetics/jetto.py
@@ -84,17 +84,18 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
         # JETTO only has one temp for impurities and main ions
         thermal_temp_data = kinetics_data["TI"][time_index, :] * units.eV
         thermal_temp_func = UnitSpline(psi_n, thermal_temp_data)
-        fast_temp_data = (
-            np.nan_to_num(
-                2.0
-                / 3.0
-                * kinetics_data["WALD"][time_index, :]
-                / kinetics_data["NALF"][time_index, :]
-                / electron_charge.m
+        if not np.all(kinetics_data["NALF"][time_index, :] == 0):
+            fast_temp_data = (
+                np.nan_to_num(
+                    2.0
+                    / 3.0
+                    * kinetics_data["WALD"][time_index, :]
+                    / kinetics_data["NALF"][time_index, :]
+                    / electron_charge.m
+                )
+                * units.eV
             )
-            * units.eV
-        )
-        fast_temp_func = UnitSpline(psi_n, fast_temp_data)
+            fast_temp_func = UnitSpline(psi_n, fast_temp_data)
 
         possible_species = [
             {

--- a/src/pyrokinetics/kinetics/kinetics.py
+++ b/src/pyrokinetics/kinetics/kinetics.py
@@ -26,7 +26,7 @@ class Kinetics(ReadableFromFile):
         1D array of the species temperature profile
     - Density: ArrayLike     [units] meter**-3
         1D array of the species density profile
-    - Rotation: ArrayLike    [units] meter/second
+    - Rotation: ArrayLike    [units] /second
         1D array of the species rotation profile
 
     Parameters

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -108,17 +108,6 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
 
         omega_func = UnitSpline(omega_psi_n, omega_data)
 
-        if "vtor1" in profiles.keys():
-            rot_psi_n = profiles["vtor1"]["psinorm"] * units.dimensionless
-            rotation_data = profiles["vtor1"]["data"] * 1e3 * units.meter / units.second
-        else:
-            rot_psi_n = te_psi_n * units.dimensionless
-            rotation_data = (
-                np.zeros(len(rot_psi_n), dtype="float") * units.meter / units.second
-            )
-
-        rotation_func = UnitSpline(rot_psi_n, rotation_data)
-
         electron_charge = UnitSpline(
             psi_n_g, -1 * unit_charge_array * units.elementary_charge
         )
@@ -129,8 +118,7 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
             mass=electron_mass,
             dens=electron_dens_func,
             temp=electron_temp_func,
-            ang=omega_func,
-            rot=rotation_func,
+            omega0=omega_func,
             rho=rho_func,
         )
 
@@ -171,8 +159,7 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
                     mass=ion_mass,
                     dens=ion_dens_func,
                     temp=ion_temp_func,
-                    ang=omega_func,
-                    rot=rotation_func,
+                    omega0=omega_func,
                     rho=rho_func,
                 )
 
@@ -204,8 +191,7 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
                     mass=impurity_mass,
                     dens=impurity_dens_func,
                     temp=ion_temp_func,
-                    ang=omega_func,
-                    rot=rotation_func,
+                    omega0=omega_func,
                     rho=rho_func,
                 )
 
@@ -239,8 +225,7 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
                 mass=fast_ion_mass,
                 dens=fast_ion_dens_func,
                 temp=fast_ion_temp_func,
-                ang=omega_func,
-                rot=rotation_func,
+                omega0=omega_func,
                 rho=rho_func,
             )
 

--- a/src/pyrokinetics/kinetics/scene.py
+++ b/src/pyrokinetics/kinetics/scene.py
@@ -32,10 +32,10 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
             electron_density_data = kinetics_data["Ne"][::-1] * units.meter**-3
             electron_density_func = UnitSpline(psi_n, electron_density_data)
 
-            electron_rotation_data = (
-                electron_temp_data.pint.dequantify() * 0.0 * units.meter / units.second
+            electron_omega_data = (
+                electron_temp_data.pint.dequantify() * 0.0 / units.second
             )
-            electron_rotation_func = UnitSpline(psi_n, electron_rotation_data)
+            electron_omega_func = UnitSpline(psi_n, electron_omega_data)
 
             electron_charge = UnitSpline(
                 psi_n, -1 * unit_charge_array * units.elementary_charge
@@ -47,13 +47,13 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
                 mass=electron_mass,
                 dens=electron_density_func,
                 temp=electron_temp_func,
-                rot=electron_rotation_func,
+                omega0=electron_omega_func,
                 rho=rho_func,
             )
 
             # Determine ion data
             ion_temperature_func = electron_temp_func
-            ion_rotation_func = electron_rotation_func
+            ion_omega_func = electron_omega_func
 
             ion_density_func = UnitSpline(psi_n, electron_density_data / 2)
 
@@ -67,7 +67,7 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
                 mass=deuterium_mass,
                 dens=ion_density_func,
                 temp=ion_temperature_func,
-                rot=ion_rotation_func,
+                omega0=ion_omega_func,
                 rho=rho_func,
             )
 
@@ -81,7 +81,7 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
                 mass=1.5 * deuterium_mass,
                 dens=ion_density_func,
                 temp=ion_temperature_func,
-                rot=ion_rotation_func,
+                omega0=ion_omega_func,
                 rho=rho_func,
             )
 

--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -69,7 +69,7 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
                 mass=electron_mass,
                 dens=electron_dens_func,
                 temp=electron_temp_func,
-                ang=omega_func,
+                omega0=omega_func,
                 rho=rho_func,
             )
 
@@ -150,7 +150,7 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
                     mass=species["mass"],
                     dens=density_func,
                     temp=ion_temp_func,
-                    ang=omega_func,
+                    omega0=omega_func,
                     rho=rho_func,
                 )
 

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -628,7 +628,9 @@ class SimulationNormalisation(Normalisation):
 
         if lref_minor_radius and lref_major_radius:
             if lref_major_radius != pyro.local_geometry.Rmaj * lref_minor_radius:
-                raise ValueError("Specified major radius and minor radius do not match, please check the data")
+                raise ValueError(
+                    "Specified major radius and minor radius do not match, please check the data"
+                )
         elif lref_minor_radius:
             lref_major_radius = lref_minor_radius / pyro.local_geometry.Rmaj
         elif lref_major_radius:

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -499,7 +499,7 @@ class SimulationNormalisation(Normalisation):
             bunit_over_b0 = local_geometry.bunit_over_b0
 
         self.units.define(
-            f"rhoref_pyro_{self.name} = vref_nrl_{self.name} / (bref_B0_{self.name} / mref_deuterium_{self.name} * qref)"
+            f"rhoref_pyro_{self.name} = {self.vref} / ({self.bref} / {self.mref} * qref)"
         )
 
         self.units.define(
@@ -628,9 +628,11 @@ class SimulationNormalisation(Normalisation):
 
         if lref_minor_radius and lref_major_radius:
             if lref_major_radius != pyro.local_geometry.Rmaj * lref_minor_radius:
-                raise ValueError("Specified major radius and minor radius do not match, please check the data")
+                raise ValueError(
+                    "Specified major radius and minor radius do not match, please check the data"
+                )
         elif lref_minor_radius:
-            lref_major_radius = lref_minor_radius / pyro.local_geometry.Rmaj
+            lref_major_radius = lref_minor_radius * pyro.local_geometry.Rmaj
         elif lref_major_radius:
             lref_minor_radius = lref_major_radius / pyro.local_geometry.Rmaj
 

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -499,7 +499,7 @@ class SimulationNormalisation(Normalisation):
             bunit_over_b0 = local_geometry.bunit_over_b0
 
         self.units.define(
-            f"rhoref_pyro_{self.name} = vref_nrl_{self.name} / (bref_B0_{self.name} / mref_deuterium_{self.name})"
+            f"rhoref_pyro_{self.name} = vref_nrl_{self.name} / (bref_B0_{self.name} / mref_deuterium_{self.name} * qref)"
         )
 
         self.units.define(
@@ -606,7 +606,6 @@ class SimulationNormalisation(Normalisation):
 
         # Transformations for mixed units because pint can't handle
         # them automatically.
-
         self.context.add_transformation(
             "[vref]",
             self.pyrokinetics.vref,
@@ -620,15 +619,23 @@ class SimulationNormalisation(Normalisation):
         nref=None,
         bref_B0=None,
         lref_minor_radius=None,
+        lref_major_radius=None,
     ):
         self.units.define(f"tref_electron_{self.name} = {tref}")
         self.units.define(f"nref_electron_{self.name} = {nref}")
 
         self.units.define(f"mref_deuterium_{self.name} = mref_deuterium")
 
-        major_radius = pyro.local_geometry.Rmaj * lref_minor_radius
+        if lref_minor_radius and lref_major_radius:
+            if lref_major_radius != pyro.local_geometry.Rmaj * lref_minor_radius:
+                raise ValueError("Specified major radius and minor radius do not match, please check the data")
+        elif lref_minor_radius:
+            lref_major_radius = lref_minor_radius / pyro.local_geometry.Rmaj
+        elif lref_major_radius:
+            lref_minor_radius = lref_major_radius / pyro.local_geometry.Rmaj
+
         self.units.define(f"lref_minor_radius_{self.name} = {lref_minor_radius}")
-        self.units.define(f"lref_major_radius_{self.name} = {major_radius}")
+        self.units.define(f"lref_major_radius_{self.name} = {lref_major_radius}")
 
         # Physical units
         bunit = bref_B0 * pyro.local_geometry.bunit_over_b0
@@ -647,7 +654,7 @@ class SimulationNormalisation(Normalisation):
         )
 
         self.units.define(
-            f"rhoref_pyro_{self.name} = vref_nrl_{self.name} / (bref_B0_{self.name} / mref_deuterium_{self.name})"
+            f"rhoref_pyro_{self.name} = vref_nrl_{self.name} / (bref_B0_{self.name} / mref_deuterium_{self.name} * qref)"
         )
 
         self.units.define(
@@ -836,7 +843,9 @@ class ConventionNormalisation(Normalisation):
         self.vref = getattr(self._registry, f"{self.convention.vref}_{self.run_name}")
         self.lref = getattr(self._registry, f"{self.convention.lref}_{self.run_name}")
         self.bref = getattr(self._registry, f"{self.convention.bref}_{self.run_name}")
-        self.rhoref = getattr(self._registry, f"{self.convention.rhoref}")
+        self.rhoref = getattr(
+            self._registry, f"{self.convention.rhoref}_{self.run_name}"
+        )
         self._update_system()
 
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1022,7 +1022,9 @@ class Pyro:
 
         # Check if data requiring LocalGeometry & LocalSpecies has been loaded
         if not self._local_geometry_species_dependancy:
-            self._load_local_geometry_species_dependancy(set_beta=False, set_gamma_exb=False)
+            self._load_local_geometry_species_dependancy(
+                set_beta=False, set_gamma_exb=False
+            )
 
         # Get record of current gyrokinetics context
         prev_gk_code = self.gk_code
@@ -1721,7 +1723,9 @@ class Pyro:
 
         self._load_local_geometry_species_dependancy()
 
-    def _load_local_geometry_species_dependancy(self, set_rhoref=True, set_beta=True, set_gamma_exb=True):
+    def _load_local_geometry_species_dependancy(
+        self, set_rhoref=True, set_beta=True, set_gamma_exb=True
+    ):
         """
         Load data that requires both LocalGeometry and LocalSpecies to be present
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -171,7 +171,7 @@ class Pyro:
         # gk_file, file_name, run_directory, local_geometry, local_species, and
         # numerics.
         if gk_file is not None:
-            self.read_gk_file(gk_file, gk_code)
+            self.read_gk_file(gk_file, gk_code, norms=self.norms)
 
         # Set gyrokinetics context
         # If we just read a file, or gk_code is None, this won't do anything. Otherwise,
@@ -797,6 +797,7 @@ class Pyro:
         gk_file: PathLike,
         gk_code: Optional[str] = None,
         no_process: List[str] = None,
+        norms: SimulationNormalisation = None,
     ) -> None:
         """
         Reads a gyrokinetics input file, and set the gyrokinetics context to match the
@@ -870,6 +871,11 @@ class Pyro:
             self.local_species = self.gk_input.get_local_species()
         if "numerics" not in no_process:
             self.numerics = self.gk_input.get_numerics()
+
+        if norms:
+            norm_dict = self.gk_input.get_normalisation(norms)
+            if norm_dict:
+                self.set_reference_values(**norm_dict)
 
     def read_gk_dict(
         self,
@@ -1707,6 +1713,7 @@ class Pyro:
         self.load_local_geometry(psi_n, local_geometry=local_geometry)
         self.load_local_species(psi_n)
 
+        self.norms.set_rhoref(local_geometry=self.local_geometry)
         # If we have both kinetics and eq file we should set beta/gamma_exb from there
         if self.numerics:
             self.numerics.beta = None
@@ -1728,6 +1735,7 @@ class Pyro:
         nref_electron=None,
         bref_B0=None,
         lref_minor_radius=None,
+        lref_major_radius=None,
     ):
         """
         Manually set the reference values used in normalisations

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1022,7 +1022,7 @@ class Pyro:
 
         # Check if data requiring LocalGeometry & LocalSpecies has been loaded
         if not self._local_geometry_species_dependancy:
-            self._load_local_geometry_species_dependancy()
+            self._load_local_geometry_species_dependancy(set_beta=False, set_gamma_exb=False)
 
         # Get record of current gyrokinetics context
         prev_gk_code = self.gk_code
@@ -1721,7 +1721,7 @@ class Pyro:
 
         self._load_local_geometry_species_dependancy()
 
-    def _load_local_geometry_species_dependancy(self, set_rhoref=True):
+    def _load_local_geometry_species_dependancy(self, set_rhoref=True, set_beta=True, set_gamma_exb=True):
         """
         Load data that requires both LocalGeometry and LocalSpecies to be present
 
@@ -1732,6 +1732,10 @@ class Pyro:
         ----------
         set_rhoref: bool, default True
             Sets rhoref if True
+        set_beta: bool, default True
+            Sets beta=None if True
+        set_gamma_exb: bool, default True
+            Sets gamma_exb
 
         Returns
         -------
@@ -1754,17 +1758,18 @@ class Pyro:
             self.norms.set_rhoref(local_geometry=self.local_geometry)
 
         # If we have both kinetics and eq file we should set beta/gamma_exb from there
-        if self.numerics:
+        if self.numerics and set_beta:
             self.numerics.beta = None
 
+            self._check_beta_consistency()
+
+        if self.numerics and set_gamma_exb:
             self.numerics.gamma_exb = (
                 -self.local_geometry.rho
                 * self.norms.lref
                 / self.local_geometry.q
                 * self.local_species.domega_drho.to(self.norms)
             ).to(self.norms.vref / self.norms.lref)
-
-        self._check_beta_consistency()
 
         self._local_geometry_species_dependancy = True
 

--- a/src/pyrokinetics/species.py
+++ b/src/pyrokinetics/species.py
@@ -11,8 +11,7 @@ class Species:
     Mass
     Density
     Temperature
-    Rotation
-    Omega
+    Angular rotation
 
     Also need r/a (rho) as a function of psi for a/Lt etc.
     May need to add psi_toroidal
@@ -25,17 +24,15 @@ class Species:
         mass=None,
         dens=None,
         temp=None,
-        rot=None,
         rho=None,
-        ang=None,
+        omega0=None,
     ):
         self.species_type = species_type
         self.charge = charge
         self.mass = mass
         self.dens = dens
         self.temp = temp
-        self.rotation = rot
-        self.omega = ang
+        self.omega = omega0
         self.rho = rho
 
     def grad_rho(self, psi_n=None):
@@ -109,24 +106,6 @@ class Species:
         """
 
         return self._norm_gradient(self.temp, psi_n)
-
-    def get_velocity(self, psi_n=None):
-        if not hasattr(psi_n, "units"):
-            psi_n *= units.dimensionless
-
-        if self.rotation is not None:
-            return self.rotation(psi_n)
-        return 0.0 * units.meter / units.second
-
-    def get_norm_vel_gradient(self, psi_n=None):
-        """
-        - 1/v dv/drho
-        """
-
-        if self.rotation is None:
-            return 0.0 / units.lref_minor_radius
-
-        return self._norm_gradient(self.rotation, psi_n)
 
     def get_angular_velocity(self, psi_n=None):
         if not hasattr(psi_n, "units"):

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -253,7 +253,7 @@ class PyroUnitRegistry(pint.UnitRegistry):
                 try:
                     value_power = value**power
                 except ValueError:
-                    value_power = float(value) ** dst_power
+                    value_power = float(value) ** power
                     force_int = True
                 except ZeroDivisionError:
                     value_power = value
@@ -264,7 +264,7 @@ class PyroUnitRegistry(pint.UnitRegistry):
                     value, new_unit = converted
                     # Undo any inversions
                     try:
-                        value = value**dst_power
+                        value = value ** (1.0 / dst_power)
                     except ZeroDivisionError:
                         value = value
                     if force_int:

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -42,8 +42,8 @@ def check_species(
     midpoint_density_gradient,
     midpoint_temperature,
     midpoint_temperature_gradient,
-    midpoint_velocity,
-    midpoint_velocity_gradient,
+    midpoint_angular_velocity,
+    midpoint_angular_velocity_gradient,
 ):
     assert species.species_type == name
     assert species.mass == mass
@@ -55,8 +55,8 @@ def check_species(
     assert np.isclose(
         species.get_norm_temp_gradient(0.5).m, midpoint_temperature_gradient
     )
-    assert np.isclose(species.get_velocity(0.5).m, midpoint_velocity)
-    assert np.isclose(species.get_norm_vel_gradient(0.5).m, midpoint_velocity_gradient)
+    assert np.isclose(species.get_angular_velocity(0.5).m, midpoint_angular_velocity)
+    assert np.isclose(species.get_norm_ang_vel_gradient(0.5).m, midpoint_angular_velocity_gradient)
 
 
 @pytest.mark.parametrize("kinetics_type", ["SCENE", None])
@@ -77,8 +77,8 @@ def test_read_scene(scene_file, kinetics_type):
         midpoint_density_gradient=0.4247526509961558,
         midpoint_temperature=12174.554122236143,
         midpoint_temperature_gradient=2.782385669107711,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         scene.species_data["deuterium"],
@@ -89,8 +89,8 @@ def test_read_scene(scene_file, kinetics_type):
         midpoint_density_gradient=0.4247526509961558,
         midpoint_temperature=12174.554122236143,
         midpoint_temperature_gradient=2.782385669107711,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         scene.species_data["tritium"],
@@ -101,8 +101,8 @@ def test_read_scene(scene_file, kinetics_type):
         midpoint_density_gradient=0.4247526509961558,
         midpoint_temperature=12174.554122236143,
         midpoint_temperature_gradient=2.782385669107711,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
 
 
@@ -125,8 +125,8 @@ def test_read_jetto(jetto_file, kinetics_type):
         midpoint_density_gradient=0.24934713314306212,
         midpoint_temperature=2048.70870657,
         midpoint_temperature_gradient=1.877960703115299,
-        midpoint_velocity=75600.47570394,
-        midpoint_velocity_gradient=1.3620162177136412,
+        midpoint_angular_velocity=30084.42620196,
+        midpoint_angular_velocity_gradient=1.3539597923978433,
     )
     check_species(
         jetto.species_data["deuterium"],
@@ -137,8 +137,8 @@ def test_read_jetto(jetto_file, kinetics_type):
         midpoint_density_gradient=0.15912588033334082,
         midpoint_temperature=1881.28998733,
         midpoint_temperature_gradient=1.2290413714311896,
-        midpoint_velocity=75600.47570394,
-        midpoint_velocity_gradient=1.3620162177136412,
+        midpoint_angular_velocity=30084.42620196,
+        midpoint_angular_velocity_gradient=1.3539597923978433,
     )
     check_species(
         jetto.species_data["impurity1"],
@@ -149,8 +149,8 @@ def test_read_jetto(jetto_file, kinetics_type):
         midpoint_density_gradient=0.37761249,
         midpoint_temperature=1881.28998733,
         midpoint_temperature_gradient=1.2290413714311896,
-        midpoint_velocity=75600.47570394,
-        midpoint_velocity_gradient=1.3620162177136412,
+        midpoint_angular_velocity=30084.42620196,
+        midpoint_angular_velocity_gradient=1.3539597923978433,
     )
 
 
@@ -173,8 +173,8 @@ def test_read_transp(transp_file, kinetics_type):
         midpoint_density_gradient=0.2045522220475293,
         midpoint_temperature=12469.654886858232,
         midpoint_temperature_gradient=2.515253525050096,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["deuterium"],
@@ -185,8 +185,8 @@ def test_read_transp(transp_file, kinetics_type):
         midpoint_density_gradient=0.13986183752938153,
         midpoint_temperature=12469.654886858232,
         midpoint_temperature_gradient=2.515253525050096,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["tritium"],
@@ -197,8 +197,8 @@ def test_read_transp(transp_file, kinetics_type):
         midpoint_density_gradient=0.4600323954647866,
         midpoint_temperature=12469.654886858232,
         midpoint_temperature_gradient=2.515253525050096,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["impurity"],
@@ -209,8 +209,8 @@ def test_read_transp(transp_file, kinetics_type):
         midpoint_density_gradient=0.20453530330985722,
         midpoint_temperature=12469.654886858232,
         midpoint_temperature_gradient=2.515253525050096,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
 
 
@@ -233,8 +233,8 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
         midpoint_density_gradient=0.20538268693802364,
         midpoint_temperature=12479.79840937,
         midpoint_temperature_gradient=2.5225424443317688,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["deuterium"],
@@ -245,8 +245,8 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
         midpoint_density_gradient=0.14042679198682875,
         midpoint_temperature=12479.798409368073,
         midpoint_temperature_gradient=2.5225424443317688,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["tritium"],
@@ -257,8 +257,8 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
         midpoint_density_gradient=0.3731053213184641,
         midpoint_temperature=12479.798409368073,
         midpoint_temperature_gradient=2.5225424443317688,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
     check_species(
         transp.species_data["impurity"],
@@ -269,8 +269,8 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
         midpoint_density_gradient=0.20536537726005905,
         midpoint_temperature=12479.798409368073,
         midpoint_temperature_gradient=2.5225424443317688,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
     )
 
 
@@ -293,8 +293,8 @@ def test_read_pFile(pfile_file, geqdsk_file, kinetics_type):
         midpoint_density_gradient=1.10742399,
         midpoint_temperature=770.37876268,
         midpoint_temperature_gradient=3.1457586490506135,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
     )
     check_species(
         pfile.species_data["deuterium"],
@@ -305,8 +305,8 @@ def test_read_pFile(pfile_file, geqdsk_file, kinetics_type):
         midpoint_density_gradient=1.7807398428788435,
         midpoint_temperature=742.54533496,
         midpoint_temperature_gradient=2.410566291534264,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
     )
     check_species(
         pfile.species_data["impurity"],
@@ -317,8 +317,8 @@ def test_read_pFile(pfile_file, geqdsk_file, kinetics_type):
         midpoint_density_gradient=-1.3392585682314078,
         midpoint_temperature=742.54533496,
         midpoint_temperature_gradient=2.410566291534264,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
     )
     check_species(
         pfile.species_data["deuterium_fast"],
@@ -329,8 +329,8 @@ def test_read_pFile(pfile_file, geqdsk_file, kinetics_type):
         midpoint_density_gradient=1.1074239891222437,
         midpoint_temperature=1379.36939199,
         midpoint_temperature_gradient=3.0580150015690317,
-        midpoint_velocity=0.0,
-        midpoint_velocity_gradient=0.0,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
     )
 
 

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -56,7 +56,9 @@ def check_species(
         species.get_norm_temp_gradient(0.5).m, midpoint_temperature_gradient
     )
     assert np.isclose(species.get_angular_velocity(0.5).m, midpoint_angular_velocity)
-    assert np.isclose(species.get_norm_ang_vel_gradient(0.5).m, midpoint_angular_velocity_gradient)
+    assert np.isclose(
+        species.get_norm_ang_vel_gradient(0.5).m, midpoint_angular_velocity_gradient
+    )
 
 
 @pytest.mark.parametrize("kinetics_type", ["SCENE", None])

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -193,7 +193,7 @@ def test_pyro_load_local_geometry(eq_type):
 def test_pyro_load_local_species(kinetics_type):
     pyro = Pyro(gk_file=gk_templates["CGYRO"])
     local_species = pyro.local_species
-    pyro.load_global_kinetics(kinetics_templates["SCENE"])
+    pyro.load_global_kinetics(kinetics_templates[kinetics_type])
     pyro.load_local_species(psi_n=0.5, a_minor=0.7)
     assert isinstance(pyro.local_species, LocalSpecies)
     # Ensure local_species was overwritten

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -65,32 +65,32 @@ def test_temperature_gradient():
     assert np.isclose(species.get_norm_temp_gradient(0.5), 4.0 / 3.0)
 
 
-def test_rotation():
+def test_angular_rotation():
     psi = np.linspace(0.0, 1.0) * units.dimensionless
-    rotation_data = (3.0 - 3.0 * (psi**2)) * units.meter / units.second
-    rotation_func = UnitSpline(psi, rotation_data)
+    angular_rotation_data = (3.0 - 3.0 * (psi**2)) / units.second
+    angular_rotation_func = UnitSpline(psi, angular_rotation_data)
 
-    species = Species(rot=rotation_func)
+    species = Species(omega0=angular_rotation_func)
 
-    assert np.isclose(species.get_velocity(0.5).m, 2.25)
+    assert np.isclose(species.get_angular_velocity(0.5).m, 2.25)
 
 
-def test_rotation_gradient():
+def test_angular_rotation_gradient():
     psi = np.linspace(0.0, 1.0) * units.dimensionless
     rho_func = UnitSpline(psi, psi**2)
-    rotation_data = (3.0 - 3.0 * (psi**2)) * units.meter / units.second
-    rotation_func = UnitSpline(psi, rotation_data)
+    angular_rotation_data = (3.0 - 3.0 * (psi**2)) / units.second
+    angular_rotation_func = UnitSpline(psi, angular_rotation_data)
 
-    species = Species(rot=rotation_func, rho=rho_func)
+    species = Species(omega0=angular_rotation_func, rho=rho_func)
 
-    assert np.isclose(species.get_norm_vel_gradient(0.5), 4.0 / 3.0)
+    assert np.isclose(species.get_norm_ang_vel_gradient(0.5), 4.0 / 3.0)
 
 
 def test_no_rotation():
     species = Species()
-    assert np.isclose(species.get_velocity(0.5), 0.0)
+    assert np.isclose(species.get_angular_velocity(0.5), 0.0)
 
 
 def test_no_rotation_gradient():
     species = Species()
-    assert np.isclose(species.get_norm_vel_gradient(0.5), 0.0)
+    assert np.isclose(species.get_norm_ang_vel_gradient(0.5), 0.0)


### PR DESCRIPTION
Pyro now reads/writes normalisations for GS2/GENE input files. I have raised a request for this on TGLF/CGYRO but that may take a while so I wouldn't wait on that.

Found quite a few bugs along the way in normalisations as `rhoref` wasn't always set at the right time depending on how to loaded in the data. I've tidied up how data that depends on both `LocalSpecies` and `LocalGeometry` is loaded in so we can be more specific about how we load this data. 

This was branched off of  `modify/rotation_velocity` so we should probably wait on that first