### PR TITLE
Pin idspy-toolkit version to 0.4.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - '**.py'
+      - 'pyproject.toml'
   pull_request:
     paths:
       - '**.py'
+      - 'pyproject.toml'
 
 jobs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "contourpy ~= 1.0",
     "xrft >= 1.0.0",
     "idspy-dictionaries >= 0.4.0, < 33900.1.2; python_version >= '3.9'",
-    "idspy-toolkit >= 0.4.1; python_version >= '3.9'",
+    "idspy-toolkit == 0.4.3; python_version >= '3.9'",
     "pyloidal >= 0.1.0",
     "xmltodict ~= 0.13.0",
     "typing-extensions >= 4.6.0",


### PR DESCRIPTION
Pin version of idspy-toolkits to 0.4.3 as the latest release seems to be missing a dependancy. I've raised an issue on the `idspy-toolkit` gitlab repo in the meantime