### PR TITLE
Better error messages from file readers

### DIFF
--- a/src/pyrokinetics/equilibrium/transp.py
+++ b/src/pyrokinetics/equilibrium/transp.py
@@ -266,12 +266,14 @@ class EquilibriumReaderTRANSP(FileReader, file_type="TRANSP", reads=Equilibrium)
         try:
             # Given it is a netcdf, check it has the attribute TRANSP_version
             data.TRANSP_version
-        except AttributeError:
+        except AttributeError as exc:
             # Failing this, check for a subset of expected data_vars
             var_names = ["TIME3", "XB", "RAXIS", "YAXIS", "PSI0_TR", "PLFLXA", "PLFMP"]
             if not np.all(np.isin(var_names, list(data.variables))):
+                var_str = "', '".join(var_names)
                 raise ValueError(
-                    f"The netCDF {filename} can't be read by TRANSPEquilibriumReader"
-                )
+                    f"The netCDF {filename} can't be read as a TRANSP file. "
+                    f"The following vars are needed: '{var_str}'."
+                ) from exc
         finally:
             data.close()

--- a/src/pyrokinetics/factory.py
+++ b/src/pyrokinetics/factory.py
@@ -35,10 +35,10 @@ class Factory:
         """
         try:
             return self._registered_types[key]
-        except KeyError:
+        except KeyError as exc:
             raise KeyError(
-                f"'{key}' is not registered with {self._super_class.__name__} factory"
-            )
+                f"'{key}' is not recognised as a type of {self._super_class.__name__}"
+            ) from exc
 
     def create(self, key: str, *args, **kwargs) -> Any:
         """Create a new object of type ``key``, forwarding all arguments."""

--- a/src/pyrokinetics/file_utils.py
+++ b/src/pyrokinetics/file_utils.py
@@ -17,7 +17,7 @@ __all__ = [
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from textwrap import indent
+from textwrap import dedent, indent
 from typing import Any, ClassVar, Dict, List, NoReturn, Optional, Type
 
 from .typing import PathLike
@@ -163,7 +163,14 @@ class FileReaderFactory(Factory):
                 return super().type(self._infer_file_type(key))
             except (FileNotFoundError, FileInferenceException) as infer_error:
                 c = self._file_type.__name__
-                msg = f"Unable to determine the type of '{c}' from the input '{key}'."
+                msg = dedent(
+                    f"""\
+                    Unable to determine the type of '{c}' from the input '{key}'. If
+                    you supplied a file name, please check the exceptions raised above
+                    from each {c} reader, and try fixing any reported issues. It may
+                    also help to specify the file type explicitly.
+                    """
+                ).replace("\n", " ")
                 _chain_exceptions(RuntimeError(msg), infer_error, key_error)
 
     def _infer_file_type(self, filename: PathLike) -> str:

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -197,8 +197,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             "Q",
             "S",
         ]
-        if not self.verify_expected_keys(filename, expected_keys):
-            raise ValueError(f"Unable to verify {filename} as CGYRO file")
+        self.verify_expected_keys(filename, expected_keys)
 
     def write(self, filename: PathLike, float_format: str = "", local_norm=None):
         # Create directories if they don't exist already
@@ -800,7 +799,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         dirname = Path(dirname)
         for f in self._required_files(dirname).values():
             if not f.path.exists():
-                raise RuntimeError
+                raise RuntimeError(f"Missing the file '{f}'")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -138,8 +138,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         info for Pyrokinetics to work with
         """
         expected_keys = ["general", "geometry", "box"]
-        if not self.verify_expected_keys(filename, expected_keys):
-            raise ValueError(f"Unable to verify {filename} as GENE file")
+        self.verify_expected_keys(filename, expected_keys)
 
     def write(self, filename: PathLike, float_format: str = "", local_norm=None):
         """

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -107,8 +107,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             "species_knobs",
             "kt_grids_knobs",
         ]
-        if not self.verify_expected_keys(filename, expected_keys):
-            raise ValueError(f"Unable to verify {filename} as GS2 file")
+        self.verify_expected_keys(filename, expected_keys)
 
     def write(self, filename: PathLike, float_format: str = "", local_norm=None):
         if local_norm is None:
@@ -675,19 +674,23 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
             data = xr.open_dataset(filename)
         except RuntimeWarning:
             warnings.resetwarnings()
-            raise RuntimeError
+            raise RuntimeError("Error occurred reading GS2 output file")
         warnings.resetwarnings()
 
         if "software_name" in data.attrs:
             if data.attrs["software_name"] != "GS2":
-                raise RuntimeError
+                raise RuntimeError(
+                    f"file '{filename}' has wrong 'software_name' for a GS2 file"
+                )
         elif "code_info" in data.data_vars:
             if data["code_info"].long_name != "GS2":
-                raise RuntimeError
+                raise RuntimeError(
+                    f"file '{filename}' has wrong 'code_info' for a GS2 file"
+                )
         elif "gs2_help" in data.attrs.keys():
             pass
         else:
-            raise RuntimeError
+            raise RuntimeError(f"file '{filename}' missing expected GS2 attributes")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -139,8 +139,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         """
 
         expected_keys = ["rmin_loc", "rmaj_loc", "nky"]
-        if not self.verify_expected_keys(filename, expected_keys):
-            raise ValueError(f"Unable to verify {filename} as TGLF file")
+        self.verify_expected_keys(filename, expected_keys)
 
     def write(self, filename: PathLike, float_format: str = "", local_norm=None):
         """
@@ -599,7 +598,7 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
         dirname = Path(dirname)
         for f in self._required_files(dirname).values():
             if not f.path.exists():
-                raise RuntimeError
+                raise RuntimeError(f"Couldn't find TGLF file '{f}'")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/kinetics/jetto.py
+++ b/src/pyrokinetics/kinetics/jetto.py
@@ -181,11 +181,11 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
         except Exception as e:
             if "not found. Abort" in str(e):
                 raise FileNotFoundError(
-                    f"KineticsReaderJETTO could not find {filename}"
+                    f"KineticsReaderJETTO could not find '{filename}'"
                 ) from e
             elif "Extention of file" in str(e):
                 raise ValueError(
-                    f"Extention of file {filename} not in allowed list. Abort."
+                    f"Extention of file '{filename}' not in allowed list. Abort."
                 )
             else:
                 raise e
@@ -196,6 +196,7 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
             # Failing this, check for expected data_vars
             var_names = ["PSI", "TIME", "TE", "TI", "NE", "VTOR"]
             if not np.all(np.isin(var_names, list(data.keys()))):
+                var_str = "', '".join(var_names)
                 raise ValueError(
-                    f"KineticsReaderJETTO was provided an invalid JETTO file: {filename}"
+                    f"Invalid JETTO file: '{filename}'. Need the vars '{var_str}'."
                 )

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -237,6 +237,6 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
         with open(filename) as f:
             header = f.readline().split()
         if not re.match(r"\d*", header[0]):
-            raise ValueError("pFile header starts with an int")
+            raise ValueError("pFile header should start with an int")
         if not header[1] == "psinorm":
             raise ValueError("pFile first column name should be 'psinorm'")

--- a/src/pyrokinetics/kinetics/scene.py
+++ b/src/pyrokinetics/kinetics/scene.py
@@ -114,9 +114,11 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
                 raise ValueError
         except (AttributeError, ValueError):
             # Failing this, check for expected variables
-            if not np.all(np.isin(["Psi", "TGLF_RMIN", "Te", "Ne"], data.data_vars)):
+            var_names = ["Psi", "TGLF_RMIN", "Te", "Ne"]
+            if not np.all(np.isin(var_names, data.data_vars)):
+                var_str = "', '".join(var_names)
                 raise ValueError(
-                    f"KineticsReaderSCENE was provided an invalid NetCDF: {filename}"
+                    f"'{filename}' not a valid SCENE file: need the vars '{var_str}'"
                 )
         finally:
             data.close()


### PR DESCRIPTION
An issue raised in the [JOSS paper review](https://github.com/openjournals/joss-reviews/issues/5866#issuecomment-1766842546) was that Pyrokinetics failed to read a GS2 input file and returned a fairly useless error message. This PR tries to solve this issue by:

- Making sure each file reader raises useful messages when they fail to verify a file type.
- Retain all raised exceptions and return them at the end in a sensible order
- Add some hints for how to solve the problem

---

Trying the following code block:

```python
from pyrokinetics import Pyro
Pyro(gk_file="pyproject.toml")
```

Old version:

```
Traceback (most recent call last):
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 37, in type
    return self._registered_types[key]
KeyError: 'pyproject.toml'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 128, in type
    return super().type(key)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 39, in type
    raise KeyError(
KeyError: "'pyproject.toml' is not registered with FileReader factory"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/pyro.py", line 174, in __init__
    self.read_gk_file(gk_file, gk_code)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/pyro.py", line 852, in read_gk_file
    gk_input = read_gk_input(gk_file, file_type=gk_code)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/gk_code/gk_input.py", line 221, in read_gk_input
    gk_input = GKInput._factory(file_type if file_type is not None else path)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 66, in __call__
    return self.create(key, *args, **kwargs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 45, in create
    return self.type(key)(*args, **kwargs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 130, in type
    return super().type(self._infer_file_type(key))
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 145, in _infer_file_type
    raise KeyError(err_msg)
KeyError: "'pyproject.toml' is neither a registered key nor a valid file."
```

New version:

```
Traceback (most recent call last):
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 37, in type
    return self._registered_types[key]
KeyError: 'pyproject.toml'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 136, in _chain_exceptions
    _chain_exceptions(*excs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 140, in _chain_exceptions
    raise exc
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 160, in type
    return super().type(key)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 39, in type
    raise KeyError(
KeyError: "'pyproject.toml' is not recognised as a type of FileReader"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 136, in _chain_exceptions
    _chain_exceptions(*excs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 138, in _chain_exceptions
    raise exc from chain
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 163, in type
    return super().type(self._infer_file_type(key))
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 191, in _infer_file_type
    raise FileInferenceException(excs)
pyrokinetics.file_utils.FileInferenceException: Could not infer file type. The following exceptions were raised:
+ 'CGYRO' raised --> RuntimeError("Couldn't read CGYRO file. Is the format correct?")
+ 'GENE' raised --> ValueError(" Unable to verify pyproject.toml as a GENE file. The following keys are required: 'general', 'geometry', 'box' ")
+ 'GS2' raised --> ValueError(" Unable to verify pyproject.toml as a GS2 file. The following keys are required: 'knobs', 'parameters', 'theta_grid_knobs', 'theta_grid_eik_knobs', 'theta_grid_parameters', 'species_knobs', 'kt_grids_knobs' ")
+ 'TGLF' raised --> ValueError(" Unable to verify pyproject.toml as a TGLF file. The following keys are required: 'rmin_loc', 'rmaj_loc', 'nky' ")
+ '_test' raised --> RuntimeError('First line of file should say Hello world!.')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/pyro.py", line 174, in __init__
    self.read_gk_file(gk_file, gk_code)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/pyro.py", line 852, in read_gk_file
    gk_input = read_gk_input(gk_file, file_type=gk_code)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/gk_code/gk_input.py", line 235, in read_gk_input
    gk_input = GKInput._factory(file_type if file_type is not None else path)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 66, in __call__
    return self.create(key, *args, **kwargs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/factory.py", line 45, in create
    return self.type(key)(*args, **kwargs)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 174, in type
    _chain_exceptions(RuntimeError(msg), infer_error, key_error)
  File "/home/ltp511/workspace/pyrokinetics/src/pyrokinetics/file_utils.py", line 138, in _chain_exceptions
    raise exc from chain
RuntimeError: Unable to determine the type of 'GKInput' from the input 'pyproject.toml'. If you supplied a file name, please check the exceptions raised above from each GKInput reader, and try fixing any reported issues. It may also help to specify the file type explicitly. 
```