### PR TITLE
Update GS2 reader for next

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -711,7 +711,10 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         else:
             # Old diagnostics (and eventually the single merged diagnostics)
             # input file stored as array of bytes
-            input_str = "\n".join((line.decode("utf-8") for line in input_file.data))
+            if isinstance(input_file.data[0], np.ndarray):
+                input_str = "\n".join(("".join(np.char.decode(line)).strip() for line in input_file.data))
+            else:
+                input_str = "\n".join((line.decode("utf-8") for line in input_file.data))
         gk_input = GKInputGS2()
         gk_input.read_str(input_str)
         return raw_data, gk_input, input_str
@@ -742,9 +745,9 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
 
         # energy coords
         try:
-            energy = raw_data["energy"].data  # new diagnostics
+            energy = raw_data["egrid"].data  # new diagnostics
         except KeyError:
-            energy = raw_data["egrid"].data  # old diagnostics
+            energy = raw_data["energy"].data  # old diagnostics
 
         # pitch coords
         pitch = raw_data["lambda"].data

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -749,9 +749,9 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
 
         # energy coords
         try:
-            energy = raw_data["egrid"].data  # new diagnostics
+            energy = raw_data["egrid"].data
         except KeyError:
-            energy = raw_data["energy"].data  # old diagnostics
+            energy = raw_data["energy"].data
 
         # pitch coords
         pitch = raw_data["lambda"].data

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -712,9 +712,13 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
             # Old diagnostics (and eventually the single merged diagnostics)
             # input file stored as array of bytes
             if isinstance(input_file.data[0], np.ndarray):
-                input_str = "\n".join(("".join(np.char.decode(line)).strip() for line in input_file.data))
+                input_str = "\n".join(
+                    ("".join(np.char.decode(line)).strip() for line in input_file.data)
+                )
             else:
-                input_str = "\n".join((line.decode("utf-8") for line in input_file.data))
+                input_str = "\n".join(
+                    (line.decode("utf-8") for line in input_file.data)
+                )
         gk_input = GKInputGS2()
         gk_input.read_str(input_str)
         return raw_data, gk_input, input_str


### PR DESCRIPTION
Fixes #268 

Update default source of `energy` grid in GS2. Note this isn't actually used for anything right now so it sort of pointless really.

Also update reader of new input file format. A simple check on the data type will allow for the new and older formats to both work.