### PR TITLE
Move slow imports within relevant functions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -16,24 +16,28 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
-    - name: Install black
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black
+        pip install black isort
     - name: Version
       run: |
         python --version
         black --version
+        isort --version
     - name: Run black
       run: |
         black src tests
+    - name: Run isort
+      run: |
+        isort src
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "[skip ci] Apply black changes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,10 @@ dependencies = [
     "simplejson >= 3.17.6",
     "gitpython >= 3.1",
     "jetto-tools",
+    "pygacode",
 ]
 
 [project.optional-dependencies]
-gacode = [
-  "pygacode",
-]
 docs = [
     "sphinx >= 5.3",
     "sphinx_autodoc_typehints >= 1.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,12 @@ dependencies = [
     "simplejson >= 3.17.6",
     "gitpython >= 3.1",
     "jetto-tools",
-    "pygacode",
 ]
 
 [project.optional-dependencies]
+gacode = [
+  "pygacode",
+]
 docs = [
     "sphinx >= 5.3",
     "sphinx_autodoc_typehints >= 1.19",
@@ -59,6 +61,11 @@ tests = [
     "pytest >= 3.3.0",
     "pytest-cov",
     "pyrokinetics-plugin-examples == 0.2.1",
+]
+linting = [
+  "black",
+  "isort",
+  "flake8",
 ]
 
 [project.urls]
@@ -106,3 +113,9 @@ source = [
   "src/",
   "*/site-packages",
 ]
+
+[tool.black]
+exclude = "_version.py"
+
+[tool.isort]
+profile = "black"

--- a/src/pyrokinetics/__init__.py
+++ b/src/pyrokinetics/__init__.py
@@ -23,26 +23,18 @@ You should have received a copy of the GNU Lesser General Public License
 along with Pyrokinetics.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from .metadata import __version__
-from .pyro import Pyro
-from .pyroscan import PyroScan
-
-# Location of bundled templates
-from .templates import template_dir, gk_templates, eq_templates, kinetics_templates
-
-# Equilibrium classes
 from .equilibrium import (
     Equilibrium,
     FluxSurface,
     read_equilibrium,
     supported_equilibrium_types,
 )
-
-# Kinetics classes
 from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
-
-# Numerics
+from .metadata import __version__
 from .numerics import Numerics
+from .pyro import Pyro
+from .pyroscan import PyroScan
+from .templates import eq_templates, gk_templates, kinetics_templates, template_dir
 
 __all__ = [
     "__version__",

--- a/src/pyrokinetics/cli/entrypoint.py
+++ b/src/pyrokinetics/cli/entrypoint.py
@@ -1,17 +1,12 @@
 from argparse import ArgumentParser
 from textwrap import dedent
 
-from .convert import (
-    add_arguments as convert_add_arguments,
-    description as convert_description,
-    main as convert_main,
-)
-
-from .generate import (
-    add_arguments as generate_add_arguments,
-    description as generate_description,
-    main as generate_main,
-)
+from .convert import add_arguments as convert_add_arguments
+from .convert import description as convert_description
+from .convert import main as convert_main
+from .generate import add_arguments as generate_add_arguments
+from .generate import description as generate_description
+from .generate import main as generate_main
 
 
 def entrypoint() -> None:

--- a/src/pyrokinetics/constants.py
+++ b/src/pyrokinetics/constants.py
@@ -1,5 +1,6 @@
-from scipy import constants
 import numpy as np
+from scipy import constants
+
 from .units import ureg as units
 
 bk = constants.k

--- a/src/pyrokinetics/databases/__init__.py
+++ b/src/pyrokinetics/databases/__init__.py
@@ -3,6 +3,6 @@ from platform import python_version_tuple
 __all__ = []
 
 if tuple(int(x) for x in python_version_tuple()[:2]) >= (3, 9):
-    from .imas import pyro_to_ids, ids_to_pyro
+    from .imas import ids_to_pyro, pyro_to_ids
 
     __all__.extend(["pyro_to_ids", "ids_to_pyro"])

--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -1,21 +1,27 @@
-import pint
-from typing import Dict
-from datetime import datetime
-from idspy_dictionaries import ids_gyrokinetics as gkids
-from idspy_toolkit import ids_to_hdf5
-import idspy_toolkit as idspy
-from xmltodict import parse as xmltodict, unparse as dicttoxml
-from ast import literal_eval
+from __future__ import annotations
 
-from pyrokinetics import __version__ as pyro_version
-from ..normalisation import convert_dict
-from ..gk_code.gk_output import GKOutput
-from ..pyro import Pyro
+from ast import literal_eval
+from datetime import datetime
+from itertools import product
+from typing import TYPE_CHECKING, Dict
 
 import git
-from itertools import product
+import idspy_toolkit as idspy
 import numpy as np
-from xarray import Dataset
+import pint
+from idspy_dictionaries import ids_gyrokinetics as gkids
+from idspy_toolkit import ids_to_hdf5
+from xmltodict import parse as xmltodict
+from xmltodict import unparse as dicttoxml
+
+from pyrokinetics import __version__ as pyro_version
+
+from ..gk_code.gk_output import GKOutput
+from ..normalisation import convert_dict
+from ..pyro import Pyro
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 imas_pyro_field_names = {
     "phi": "phi_potential",
@@ -580,7 +586,7 @@ def get_eigenmode(
         Bi-normal wavenumber to examine
     nperiod : int
         Number of poloidal turns
-    gk_output : Dataset
+    gk_output : xr.Dataset
         Dataset of gk_output
     time_interval : float
         Final fraction of time over which to average fluxes (ignored if linear)
@@ -622,12 +628,12 @@ def get_eigenmode(
     return eigenmode
 
 
-def get_perturbed(gk_output: Dataset):
+def get_perturbed(gk_output: xr.Dataset):
     """
     Calculates "perturbed" quantities of field to be stored in the Wavevector->Eigenmode IDS
     Parameters
     ----------
-    gk_output : Dataset
+    gk_output : xr.Dataset
         Dataset containing fields for a given kx and ky
 
     Returns
@@ -673,7 +679,7 @@ def get_flux_moments(gk_output: GKOutput, time_interval: float):
     Gets data needed for Wavevector->Eigenmode->Flux_moments
     Parameters
     ----------
-    gk_output : Dataset
+    gk_output : xr.Dataset
         Dataset containing fields for a given kx and ky
     time_interval : float
         Final fraction of time over which to average fluxes

--- a/src/pyrokinetics/dataset_wrapper.py
+++ b/src/pyrokinetics/dataset_wrapper.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 from ast import literal_eval
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, Any, Optional, Mapping
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
+
+import netCDF4 as nc
 
 from .metadata import metadata
 from .typing import PathLike
 from .units import ureg
 
-import netCDF4 as nc
-import pint  # noqa
-import pint_xarray  # noqa
-import xarray as xr
+if TYPE_CHECKING:
+    import xarray as xr
 
 
 class DatasetWrapper:
@@ -42,6 +44,9 @@ class DatasetWrapper:
         attrs: Optional[Dict[str, Any]] = None,
         title: Optional[str] = None,
     ) -> None:
+        import pint_xarray  # noqa
+        import xarray as xr
+
         # Set default title if the user hasn't provided one
         if title is None:
             title = self.__class__.__name__
@@ -197,6 +202,9 @@ class DatasetWrapper:
         RuntimeError
             If the netcdf is for the wrong type of object.
         """
+        import pint_xarray  # noqa
+        import xarray as xr
+
         instance = cls.__new__(cls)
         with xr.open_dataset(Path(path), *args, **kwargs) as dataset:
             if dataset.attrs.get("object_type", cls.__name__) != cls.__name__:

--- a/src/pyrokinetics/diagnostics/__init__.py
+++ b/src/pyrokinetics/diagnostics/__init__.py
@@ -1,6 +1,6 @@
 import numpy as np
-from scipy.interpolate import RectBivariateSpline
 import xrft
+from scipy.interpolate import RectBivariateSpline
 
 from ..pyro import Pyro
 
@@ -74,6 +74,8 @@ class Diagnostics:
         NotImplementedError: if `Pyro.gk_code` is not ``CGYRO``, ``GENE`` or ``GS2``
         RuntimeError: in case of linear simulation
         """
+        import pint_xarray  # noqa
+
         if self.pyro.gk_code not in ["CGYRO", "GS2", "GENE"]:
             raise NotImplementedError(
                 "Poincare map only available for CGYRO, GENE and GS2"

--- a/src/pyrokinetics/equilibrium/__init__.py
+++ b/src/pyrokinetics/equilibrium/__init__.py
@@ -1,3 +1,6 @@
+from ..plugins import register_file_reader_plugins
+from . import geqdsk  # noqa
+from . import transp  # noqa
 from .equilibrium import (
     Equilibrium,
     EquilibriumCOCOSWarning,
@@ -6,13 +9,17 @@ from .equilibrium import (
 )
 from .flux_surface import FluxSurface
 
-# Import each built-in reader to register them with Equilibrium
-from . import geqdsk  # noqa
-from . import transp  # noqa
-from . import gacode  # noqa
+pygacode_found: bool
+try:
+    import pygacode
 
-# Register external plugins with Equilibrium
-from ..plugins import register_file_reader_plugins
+    pygacode_found = True
+    del pygacode
+except ImportError:
+    pygacode_found = False
+
+if pygacode_found:
+    from . import gacode  # noqa
 
 register_file_reader_plugins("equilibrium", Equilibrium)
 

--- a/src/pyrokinetics/equilibrium/__init__.py
+++ b/src/pyrokinetics/equilibrium/__init__.py
@@ -1,7 +1,5 @@
-from ..plugins import register_file_reader_plugins
-from . import gacode  # noqa
-from . import geqdsk  # noqa
-from . import transp  # noqa
+# isort: skip_file
+
 from .equilibrium import (
     Equilibrium,
     EquilibriumCOCOSWarning,
@@ -9,6 +7,13 @@ from .equilibrium import (
     supported_equilibrium_types,
 )
 from .flux_surface import FluxSurface
+
+# Import each module to register the associated readers
+from . import geqdsk  # noqa
+from . import transp  # noqa
+from . import gacode  # noqa
+
+from ..plugins import register_file_reader_plugins
 
 register_file_reader_plugins("equilibrium", Equilibrium)
 

--- a/src/pyrokinetics/equilibrium/__init__.py
+++ b/src/pyrokinetics/equilibrium/__init__.py
@@ -1,4 +1,5 @@
 from ..plugins import register_file_reader_plugins
+from . import gacode  # noqa
 from . import geqdsk  # noqa
 from . import transp  # noqa
 from .equilibrium import (
@@ -8,18 +9,6 @@ from .equilibrium import (
     supported_equilibrium_types,
 )
 from .flux_surface import FluxSurface
-
-pygacode_found: bool
-try:
-    import pygacode
-
-    pygacode_found = True
-    del pygacode
-except ImportError:
-    pygacode_found = False
-
-if pygacode_found:
-    from . import gacode  # noqa
 
 register_file_reader_plugins("equilibrium", Equilibrium)
 

--- a/src/pyrokinetics/equilibrium/equilibrium.py
+++ b/src/pyrokinetics/equilibrium/equilibrium.py
@@ -8,25 +8,24 @@ from __future__ import annotations  # noqa
 import warnings
 from copy import deepcopy
 from textwrap import dedent
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
-import xarray as xr
 from numpy.typing import ArrayLike
 from pyloidal.cocos import cocos_transform, identify_cocos
 
 from pyrokinetics._version import __version__
 from pyrokinetics.dataset_wrapper import DatasetWrapper
-from pyrokinetics.file_utils import (
-    FileReader,
-    ReadableFromFile,
-)
+from pyrokinetics.file_utils import FileReader, ReadableFromFile
 from pyrokinetics.typing import PathLike
-from pyrokinetics.units import ureg as units, UnitSpline, UnitSpline2D
+from pyrokinetics.units import UnitSpline, UnitSpline2D
+from pyrokinetics.units import ureg as units
 
 from .flux_surface import FluxSurface, _flux_surface_contour
 from .utils import eq_units
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 
 class EquilibriumCOCOSWarning(UserWarning):
@@ -888,6 +887,8 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
             If ``quantity`` is not a quantity defined over the :math:`\psi` grid,
             or is not the name of an Equilibrium quantity.
         """
+        import matplotlib.pyplot as plt
+
         if quantity not in self.data_vars:
             raise ValueError(
                 f"Must be provided with a quantity defined on the psi grid."
@@ -968,6 +969,7 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
         plt.Axes
             The Axes object created after plotting.
         """
+        import matplotlib.pyplot as plt
 
         if ax is None:
             _, ax = plt.subplots(1, 1)
@@ -1036,6 +1038,8 @@ class EquilibriumReaderPyro(FileReader, file_type="Pyrokinetics", reads=Equilibr
         return eq
 
     def verify_file_type(self, filename: PathLike) -> None:
+        import xarray as xr
+
         ds = xr.open_dataset(filename)
         if ds.software_name != "Pyrokinetics":
             raise ValueError

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -1,9 +1,8 @@
 from __future__ import annotations  # noqa
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from warnings import warn
 
-import matplotlib.pyplot as plt
 import numpy as np
 from contourpy import contour_generator
 from numpy.typing import ArrayLike
@@ -11,6 +10,9 @@ from numpy.typing import ArrayLike
 from ..dataset_wrapper import DatasetWrapper
 from ..units import ureg as units
 from .utils import eq_units
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 
 @units.wraps(units.meter, [units.m, units.m, units.weber / units.rad] * 2, strict=False)
@@ -375,6 +377,8 @@ class FluxSurface(DatasetWrapper):
             If ``quantity`` is not a quantity defined over the :math:`\theta` grid,
             or is not the name of a FluxSurface quantity.
         """
+        import matplotlib.pyplot as plt
+
         if quantity not in self.data_vars:
             raise ValueError(
                 f"Must be provided with a quantity defined on the theta grid."
@@ -443,6 +447,8 @@ class FluxSurface(DatasetWrapper):
         plt.Axes
             The Axes object created after plotting.
         """
+        import matplotlib.pyplot as plt
+
         x_data = self["R"]
         if x_label is None:
             x_label = f"{x_data.long_name} / ${x_data.data.units:L~}$"

--- a/src/pyrokinetics/equilibrium/gacode.py
+++ b/src/pyrokinetics/equilibrium/gacode.py
@@ -1,13 +1,14 @@
+import subprocess
 from typing import Optional
 
 import numpy as np
-from scipy.interpolate import RBFInterpolator
 from pygacode import expro
-import subprocess
+from scipy.interpolate import RBFInterpolator
 
 from ..file_utils import FileReader
 from ..typing import PathLike
-from ..units import ureg as units, UnitSpline
+from ..units import UnitSpline
+from ..units import ureg as units
 from .equilibrium import Equilibrium
 
 

--- a/src/pyrokinetics/equilibrium/transp.py
+++ b/src/pyrokinetics/equilibrium/transp.py
@@ -8,7 +8,8 @@ from scipy.interpolate import RBFInterpolator
 
 from ..file_utils import FileReader
 from ..typing import PathLike
-from ..units import ureg as units, UnitSpline
+from ..units import UnitSpline
+from ..units import ureg as units
 from .equilibrium import Equilibrium
 
 

--- a/src/pyrokinetics/file_utils.py
+++ b/src/pyrokinetics/file_utils.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from textwrap import dedent, indent
 from typing import Any, ClassVar, Dict, List, NoReturn, Optional, Type
 
-from .typing import PathLike
 from .factory import Factory
+from .typing import PathLike
 
 
 class AbstractFileReader(ABC):

--- a/src/pyrokinetics/gk_code/__init__.py
+++ b/src/pyrokinetics/gk_code/__init__.py
@@ -1,11 +1,10 @@
 from platform import python_version_tuple
 
-from .gk_input import GKInput, read_gk_input, supported_gk_input_types
-from .gk_output import GKOutput, read_gk_output, supported_gk_output_types
-
 # Import built-in input and output readers to register them with GkInput and GkOutput.
 from .cgyro import GKInputCGYRO, GKOutputReaderCGYRO  # noqa
 from .gene import GKInputGENE, GKOutputReaderGENE  # noqa
+from .gk_input import GKInput, read_gk_input, supported_gk_input_types
+from .gk_output import GKOutput, read_gk_output, supported_gk_output_types
 from .gs2 import GKInputGS2, GKOutputReaderGS2  # noqa
 from .tglf import GKInputTGLF, GKOutputReaderTGLF  # noqa
 

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -4,11 +4,10 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
-import pint  # noqa
-import pint_xarray  # noqa
 from cleverdict import CleverDict
 
 from ..constants import pi
+from ..file_utils import FileReader
 from ..local_geometry import (
     LocalGeometry,
     LocalGeometryFourierCGYRO,
@@ -22,7 +21,6 @@ from ..local_species import LocalSpecies
 from ..normalisation import SimulationNormalisation as Normalisation
 from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
-from ..file_utils import FileReader
 from ..templates import gk_templates
 from ..typing import PathLike
 from .gk_input import GKInput

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -14,6 +14,7 @@ import pint
 from cleverdict import CleverDict
 
 from ..constants import deuterium_mass, electron_mass, pi
+from ..file_utils import FileReader
 from ..local_geometry import (
     LocalGeometry,
     LocalGeometryMiller,
@@ -25,7 +26,6 @@ from ..local_species import LocalSpecies
 from ..normalisation import SimulationNormalisation as Normalisation
 from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
-from ..file_utils import FileReader
 from ..templates import gk_templates
 from ..typing import PathLike
 from .gk_input import GKInput

--- a/src/pyrokinetics/gk_code/gk_input.py
+++ b/src/pyrokinetics/gk_code/gk_input.py
@@ -7,11 +7,11 @@ from typing import Any, Dict, List, Optional
 import f90nml
 import numpy as np
 
+from ..file_utils import AbstractFileReader, ReadableFromFile
 from ..local_geometry import LocalGeometry
 from ..local_species import LocalSpecies
 from ..normalisation import SimulationNormalisation as Normalisation
 from ..numerics import Numerics
-from ..file_utils import AbstractFileReader, ReadableFromFile
 from ..typing import PathLike
 
 # Monkeypatch on f90nml Namelists to autoconvert numpy scalar arrays to their

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import dataclasses
 from abc import abstractmethod
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Generator,
@@ -13,14 +16,16 @@ from typing import (
 
 import numpy as np
 import pint
-import xarray as xr
 from numpy.typing import ArrayLike
 
 from ..dataset_wrapper import DatasetWrapper
-from ..normalisation import ConventionNormalisation, SimulationNormalisation
 from ..file_utils import ReadableFromFile
+from ..normalisation import ConventionNormalisation, SimulationNormalisation
 from ..typing import PathLike
 from ..units import ureg as units
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 
 @dataclasses.dataclass
@@ -764,6 +769,9 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
 
     def to_netcdf(self, *args, **kwargs) -> None:
         """Writes self.data to disk. Forwards all args to xarray.Dataset.to_netcdf."""
+        import pint_xarray  # noqa
+        import xarray as xr
+
         data = self.data.expand_dims("ReIm", axis=-1)  # Add ReIm axis at the end
         data = xr.concat([data.real, data.imag], dim="ReIm")
 

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1,26 +1,30 @@
+from __future__ import annotations
+
 import warnings
 from copy import copy
 from itertools import product
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
-import numpy as np
-import xarray as xr
-from cleverdict import CleverDict
 import f90nml
+import numpy as np
 import pint
+from cleverdict import CleverDict
 
 from ..constants import pi, sqrt2
+from ..file_utils import FileReader
 from ..local_geometry import LocalGeometry, LocalGeometryMiller, default_miller_inputs
 from ..local_species import LocalSpecies
 from ..normalisation import SimulationNormalisation as Normalisation
 from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
-from ..file_utils import FileReader
 from ..templates import gk_templates
 from ..typing import PathLike
 from .gk_input import GKInput
 from .gk_output import Coords, Eigenvalues, Fields, Fluxes, GKOutput, Moments
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 
 class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
@@ -729,6 +733,8 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         )
 
     def verify_file_type(self, filename: PathLike):
+        import xarray as xr
+
         try:
             warnings.filterwarnings("error")
             data = xr.open_dataset(filename)
@@ -762,6 +768,8 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
 
     @staticmethod
     def _get_raw_data(filename: PathLike) -> Tuple[xr.Dataset, GKInputGS2, str]:
+        import xarray as xr
+
         raw_data = xr.open_dataset(filename)
         # Read input file from netcdf, store as GKInputGS2
         input_file = raw_data["input_file"]

--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -1,20 +1,17 @@
-import numpy as np
-import pint  # noqa
-import pint_xarray  # noqa
-from typing import Tuple, Dict, Any, Optional
-from pathlib import Path
-import xarray as xr
 from ast import literal_eval
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
 from h5py import is_hdf5
 from idspy_dictionaries import ids_gyrokinetics
 from xmltodict import parse as xmltodict
 
-from .gk_output import GKOutput, Coords, Fields, Fluxes, Moments, Eigenvalues
-from . import GKInput
-from ..typing import PathLike
-
 from ..file_utils import FileReader
 from ..normalisation import SimulationNormalisation, ureg
+from ..typing import PathLike
+from . import GKInput
+from .gk_output import Coords, Eigenvalues, Fields, Fluxes, GKOutput, Moments
 
 
 class IDSFile:
@@ -278,6 +275,9 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
     @staticmethod
     def to_netcdf(self, *args, **kwargs) -> None:
         """Writes self.data to disk. Forwards all args to xarray.Dataset.to_netcdf."""
+        import pint_xarray  # noqa
+        import xarray as xr
+
         data = self.data.expand_dims("ReIm", axis=-1)  # Add ReIm axis at the end
         data = xr.concat([data.real, data.imag], dim="ReIm")
 
@@ -317,6 +317,9 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
             which need to do more than this should override this method with their
             own implementation.
         """
+        import pint_xarray  # noqa
+        import xarray as xr
+
         instance = GKOutput.__new__(GKOutput)
 
         with xr.open_dataset(Path(path), *args, **kwargs) as dataset:

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -5,6 +5,7 @@ import numpy as np
 from cleverdict import CleverDict
 
 from ..constants import pi
+from ..file_utils import FileReader
 from ..local_geometry import (
     LocalGeometry,
     LocalGeometryMiller,
@@ -17,7 +18,6 @@ from ..normalisation import SimulationNormalisation
 from ..normalisation import SimulationNormalisation as Normalisation
 from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
-from ..file_utils import FileReader
 from ..templates import gk_templates
 from ..typing import PathLike
 from .gk_input import GKInput
@@ -855,10 +855,10 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
         an eigenvalue file.
 
         Args:
-            data (xr.Dataset): The dataset to be modified.
+            data: The Xarray dataset to be modified.
             dirname (PathLike): Directory containing TGLF output files.
         Returns:
-            xr.Dataset: The modified dataset which was passed to 'data'.
+            Xarray.Dataset: The modified dataset which was passed to 'data'.
         """
 
         results = {}

--- a/src/pyrokinetics/kinetics/__init__.py
+++ b/src/pyrokinetics/kinetics/__init__.py
@@ -1,21 +1,10 @@
 from ..plugins import register_file_reader_plugins
+from .gacode import KineticsReaderGACODE
 from .jetto import KineticsReaderJETTO  # noqa
 from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
 from .pfile import KineticsReaderpFile  # noqa
 from .scene import KineticsReaderSCENE  # noqa
 from .transp import KineticsReaderTRANSP  # noqa
-
-pygacode_found: bool
-try:
-    import pygacode
-
-    pygacode_found = True
-    del pygacode
-except ImportError:
-    pygacode_found = False
-
-if pygacode_found:
-    from .gacode import KineticsReaderGACODE  # noqa
 
 register_file_reader_plugins("kinetics", Kinetics)
 

--- a/src/pyrokinetics/kinetics/__init__.py
+++ b/src/pyrokinetics/kinetics/__init__.py
@@ -1,10 +1,15 @@
-from ..plugins import register_file_reader_plugins
-from .gacode import KineticsReaderGACODE
-from .jetto import KineticsReaderJETTO  # noqa
+# isort: skip_file
+
 from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
-from .pfile import KineticsReaderpFile  # noqa
+
+# Import each module to register the associated readers
 from .scene import KineticsReaderSCENE  # noqa
 from .transp import KineticsReaderTRANSP  # noqa
+from .pfile import KineticsReaderpFile  # noqa
+from .jetto import KineticsReaderJETTO  # noqa
+from .gacode import KineticsReaderGACODE  # noqa
+
+from ..plugins import register_file_reader_plugins
 
 register_file_reader_plugins("kinetics", Kinetics)
 

--- a/src/pyrokinetics/kinetics/__init__.py
+++ b/src/pyrokinetics/kinetics/__init__.py
@@ -1,14 +1,21 @@
-from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
-
-# Import each built-in reader to register them with Kinetics
-from .scene import KineticsReaderSCENE  # noqa
-from .jetto import KineticsReaderJETTO  # noqa
-from .transp import KineticsReaderTRANSP  # noqa
-from .pfile import KineticsReaderpFile  # noqa
-from .gacode import KineticsReaderGACODE  # noqa
-
-# Register external plugins with Kinetics
 from ..plugins import register_file_reader_plugins
+from .jetto import KineticsReaderJETTO  # noqa
+from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
+from .pfile import KineticsReaderpFile  # noqa
+from .scene import KineticsReaderSCENE  # noqa
+from .transp import KineticsReaderTRANSP  # noqa
+
+pygacode_found: bool
+try:
+    import pygacode
+
+    pygacode_found = True
+    del pygacode
+except ImportError:
+    pygacode_found = False
+
+if pygacode_found:
+    from .gacode import KineticsReaderGACODE  # noqa
 
 register_file_reader_plugins("kinetics", Kinetics)
 

--- a/src/pyrokinetics/kinetics/gacode.py
+++ b/src/pyrokinetics/kinetics/gacode.py
@@ -1,13 +1,15 @@
-from ..typing import PathLike
-from .kinetics import Kinetics
-from ..species import Species
-from ..constants import electron_mass, deuterium_mass
-from ..file_utils import FileReader
+import subprocess
 
 import numpy as np
-from ..units import ureg as units, UnitSpline
 from pygacode import expro
-import subprocess
+
+from ..constants import deuterium_mass, electron_mass
+from ..file_utils import FileReader
+from ..species import Species
+from ..typing import PathLike
+from ..units import UnitSpline
+from ..units import ureg as units
+from .kinetics import Kinetics
 
 
 class KineticsReaderGACODE(FileReader, file_type="GACODE", reads=Kinetics):

--- a/src/pyrokinetics/kinetics/jetto.py
+++ b/src/pyrokinetics/kinetics/jetto.py
@@ -1,11 +1,12 @@
-from ..typing import PathLike
-from .kinetics import Kinetics
-from ..species import Species
-from ..constants import electron_mass, hydrogen_mass, deuterium_mass, electron_charge
-from ..units import ureg as units, UnitSpline
-from ..file_utils import FileReader
 import numpy as np
-from jetto_tools.binary import read_binary_file
+
+from ..constants import deuterium_mass, electron_charge, electron_mass, hydrogen_mass
+from ..file_utils import FileReader
+from ..species import Species
+from ..typing import PathLike
+from ..units import UnitSpline
+from ..units import ureg as units
+from .kinetics import Kinetics
 
 
 class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
@@ -15,6 +16,8 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
         """
         Reads in JETTO profiles NetCDF file
         """
+        from jetto_tools.binary import read_binary_file
+
         # Open data file, get generic data
         try:
             kinetics_data = read_binary_file(filename)
@@ -174,6 +177,8 @@ class KineticsReaderJETTO(FileReader, file_type="JETTO", reads=Kinetics):
 
     def verify_file_type(self, filename: PathLike) -> None:
         """Quickly verify that we're looking at a JETTO file without processing"""
+        from jetto_tools.binary import read_binary_file
+
         # Try opening data file
         # If it doesn't exist or isn't netcdf, this will fail
         try:

--- a/src/pyrokinetics/kinetics/kinetics.py
+++ b/src/pyrokinetics/kinetics/kinetics.py
@@ -1,8 +1,9 @@
 from typing import List, Optional
+
 from cleverdict import CleverDict
 
-from ..typing import PathLike
 from ..file_utils import ReadableFromFile
+from ..typing import PathLike
 
 
 class Kinetics(ReadableFromFile):

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -3,19 +3,22 @@ Reads in an Osborne pFile: https://omfit.io/_modules/omfit_classes/omfit_osborne
 
 
 """
-from ..typing import PathLike
-from .kinetics import Kinetics
-from ..species import Species
-from ..constants import electron_mass, deuterium_mass
-from pyrokinetics.equilibrium.equilibrium import read_equilibrium
-from ..units import ureg as units, UnitSpline
-from ..file_utils import FileReader
+import re
+from contextlib import redirect_stdout
+from textwrap import dedent
 
 import numpy as np
-import re
-from textwrap import dedent
-from contextlib import redirect_stdout
 from freeqdsk import peqdsk
+
+from pyrokinetics.equilibrium.equilibrium import read_equilibrium
+
+from ..constants import deuterium_mass, electron_mass
+from ..file_utils import FileReader
+from ..species import Species
+from ..typing import PathLike
+from ..units import UnitSpline
+from ..units import ureg as units
+from .kinetics import Kinetics
 
 
 def ion_species_selector(nucleons, charge):

--- a/src/pyrokinetics/kinetics/scene.py
+++ b/src/pyrokinetics/kinetics/scene.py
@@ -1,17 +1,20 @@
-from ..typing import PathLike
-from .kinetics import Kinetics
-from ..species import Species
-from ..constants import electron_mass, deuterium_mass
-from ..file_utils import FileReader
-
 import numpy as np
-import xarray as xr
-from ..units import ureg as units, UnitSpline
+
+from ..constants import deuterium_mass, electron_mass
+from ..file_utils import FileReader
+from ..species import Species
+from ..typing import PathLike
+from ..units import UnitSpline
+from ..units import ureg as units
+from .kinetics import Kinetics
 
 
 class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
     def read_from_file(self, filename: PathLike) -> Kinetics:
         """Reads NetCDF file from SCENE code. Assumes 3 species: e, D, T"""
+        import pint_xarray  # noqa
+        import xarray as xr
+
         # Open data file, get generic data
         with xr.open_dataset(filename) as kinetics_data:
             psi = kinetics_data["Psi"][::-1]
@@ -95,6 +98,8 @@ class KineticsReaderSCENE(FileReader, file_type="SCENE", reads=Kinetics):
 
     def verify_file_type(self, filename: PathLike) -> None:
         """Quickly verify that we're looking at a SCENE file without processing"""
+        import xarray as xr
+
         # Try opening data file
         # If it doesn't exist or isn't netcdf, this will fail
         try:

--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -1,13 +1,14 @@
-from ..typing import PathLike
-from .kinetics import Kinetics
-from ..species import Species
-from ..constants import electron_mass, hydrogen_mass, deuterium_mass
-from ..file_utils import FileReader
-
 # Can't use xarray, as TRANSP has a variable called X which itself has a dimension called X
 import netCDF4 as nc
 import numpy as np
-from ..units import ureg as units, UnitSpline
+
+from ..constants import deuterium_mass, electron_mass, hydrogen_mass
+from ..file_utils import FileReader
+from ..species import Species
+from ..typing import PathLike
+from ..units import UnitSpline
+from ..units import ureg as units
+from .kinetics import Kinetics
 
 
 class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):

--- a/src/pyrokinetics/local_geometry/__init__.py
+++ b/src/pyrokinetics/local_geometry/__init__.py
@@ -1,10 +1,10 @@
-from .local_geometry import LocalGeometry, local_geometry_factory
-from .miller_turnbull import LocalGeometryMillerTurnbull, default_miller_turnbull_inputs
-from .miller import LocalGeometryMiller, default_miller_inputs
-from .fourier_gene import LocalGeometryFourierGENE, default_fourier_gene_inputs
 from .fourier_cgyro import LocalGeometryFourierCGYRO, default_fourier_cgyro_inputs
-from .mxh import LocalGeometryMXH, default_mxh_inputs
+from .fourier_gene import LocalGeometryFourierGENE, default_fourier_gene_inputs
+from .local_geometry import LocalGeometry, local_geometry_factory
 from .metric import MetricTerms
+from .miller import LocalGeometryMiller, default_miller_inputs
+from .miller_turnbull import LocalGeometryMillerTurnbull, default_miller_turnbull_inputs
+from .mxh import LocalGeometryMXH, default_mxh_inputs
 
 # Register LocalGeometry objects with factory
 local_geometry_factory["MillerTurnbull"] = LocalGeometryMillerTurnbull

--- a/src/pyrokinetics/local_geometry/fourier_cgyro.py
+++ b/src/pyrokinetics/local_geometry/fourier_cgyro.py
@@ -1,11 +1,12 @@
-import numpy as np
 from typing import Tuple
-from scipy.optimize import least_squares  # type: ignore
+
+import numpy as np
 from scipy.integrate import simpson
+from scipy.optimize import least_squares  # type: ignore
+
 from ..constants import pi
-from .local_geometry import LocalGeometry
 from ..typing import ArrayLike
-from .local_geometry import default_inputs
+from .local_geometry import LocalGeometry, default_inputs
 
 
 def default_fourier_cgyro_inputs():

--- a/src/pyrokinetics/local_geometry/fourier_gene.py
+++ b/src/pyrokinetics/local_geometry/fourier_gene.py
@@ -1,10 +1,11 @@
-import numpy as np
 from typing import Tuple
-from scipy.optimize import least_squares  # type: ignore
+
+import numpy as np
 from scipy.integrate import simpson
-from .local_geometry import LocalGeometry
+from scipy.optimize import least_squares  # type: ignore
+
 from ..typing import ArrayLike
-from .local_geometry import default_inputs
+from .local_geometry import LocalGeometry, default_inputs
 
 
 def default_fourier_gene_inputs():

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -1,11 +1,17 @@
-from ..decorators import not_implemented
-from ..factory import Factory
-from ..constants import pi
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
 import numpy as np
-from typing import Tuple, Dict, Any, Optional
-from ..typing import ArrayLike
+
+from ..constants import pi
+from ..decorators import not_implemented
 from ..equilibrium import Equilibrium
-import matplotlib.pyplot as plt
+from ..factory import Factory
+from ..typing import ArrayLike
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 
 def default_inputs():
@@ -492,6 +498,8 @@ class LocalGeometry:
     def plot_equilibrium_to_local_geometry_fit(
         self, axes: Optional[Tuple[plt.Axes, plt.Axes]] = None, show_fit=False
     ):
+        import matplotlib.pyplot as plt
+
         # Get flux surface and b_poloidal
         R_fit, Z_fit = self.get_flux_surface(theta=self.theta, normalised=False)
 

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -1,7 +1,8 @@
 import numpy as np
-from . import LocalGeometry
 import scipy.integrate as integrate
 from scipy.interpolate import interp1d
+
+from . import LocalGeometry
 
 
 class MetricTerms:  # CleverDict

--- a/src/pyrokinetics/local_geometry/miller.py
+++ b/src/pyrokinetics/local_geometry/miller.py
@@ -1,9 +1,10 @@
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 from scipy.optimize import least_squares  # type: ignore
-from .local_geometry import LocalGeometry
+
 from ..typing import ArrayLike
-from .local_geometry import default_inputs
+from .local_geometry import LocalGeometry, default_inputs
 
 
 def default_miller_inputs():

--- a/src/pyrokinetics/local_geometry/miller_turnbull.py
+++ b/src/pyrokinetics/local_geometry/miller_turnbull.py
@@ -1,10 +1,11 @@
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 from scipy.optimize import least_squares  # type: ignore
+
 from ..constants import pi
-from .local_geometry import LocalGeometry
 from ..typing import ArrayLike
-from .local_geometry import default_inputs
+from .local_geometry import LocalGeometry, default_inputs
 
 
 def default_miller_turnbull_inputs():

--- a/src/pyrokinetics/local_geometry/mxh.py
+++ b/src/pyrokinetics/local_geometry/mxh.py
@@ -1,10 +1,11 @@
-import numpy as np
 from typing import Tuple
-from scipy.optimize import least_squares  # type: ignore
+
+import numpy as np
 from scipy.integrate import simpson
-from .local_geometry import LocalGeometry
+from scipy.optimize import least_squares  # type: ignore
+
 from ..typing import ArrayLike
-from .local_geometry import default_inputs
+from .local_geometry import LocalGeometry, default_inputs
 
 
 def default_mxh_inputs():

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -1,11 +1,13 @@
 import warnings
+from typing import Dict, Optional
 
+import numpy as np
 from cleverdict import CleverDict
+
 from .constants import pi
 from .kinetics import Kinetics
-from .normalisation import ureg, SimulationNormalisation as Normalisation
-import numpy as np
-from typing import Dict, Optional
+from .normalisation import SimulationNormalisation as Normalisation
+from .normalisation import ureg
 
 
 class LocalSpecies(CleverDict):

--- a/src/pyrokinetics/metadata.py
+++ b/src/pyrokinetics/metadata.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from typing import Dict
 
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ModuleNotFoundError:
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 try:
     __version__ = version("pyrokinetics")
 except PackageNotFoundError:

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -128,14 +128,13 @@ normalisations.
 
 
 import copy
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 import pint
 
 from pyrokinetics.kinetics import Kinetics
 from pyrokinetics.local_geometry import LocalGeometry
-from pyrokinetics.units import ureg, PyroNormalisationError, Normalisation
-
+from pyrokinetics.units import Normalisation, PyroNormalisationError, ureg
 
 REFERENCE_CONVENTIONS = {
     "lref": [ureg.lref_major_radius, ureg.lref_minor_radius],

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -11,17 +11,18 @@ the following objects:
 
 """
 
+from __future__ import annotations
 
-from collections import Counter
 import copy
 import warnings
-import xarray as xr
-import numpy as np
-import f90nml
-
+from collections import Counter
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import f90nml
+import numpy as np
+
+from .equilibrium import read_equilibrium, supported_equilibrium_types
 from .gk_code import (
     GKInput,
     GKOutput,
@@ -30,26 +31,26 @@ from .gk_code import (
     supported_gk_input_types,
     supported_gk_output_types,
 )
+from .kinetics import read_kinetics, supported_kinetics_types
 from .local_geometry import (
     LocalGeometry,
-    LocalGeometryMillerTurnbull,
-    LocalGeometryMiller,
-    LocalGeometryMXH,
     LocalGeometryFourierCGYRO,
     LocalGeometryFourierGENE,
-    local_geometry_factory,
+    LocalGeometryMiller,
+    LocalGeometryMillerTurnbull,
+    LocalGeometryMXH,
     MetricTerms,
+    local_geometry_factory,
 )
 from .local_species import LocalSpecies
+from .normalisation import ConventionNormalisation as Normalisation
+from .normalisation import SimulationNormalisation
 from .numerics import Numerics
-from .equilibrium import read_equilibrium, supported_equilibrium_types
-from .kinetics import read_kinetics, supported_kinetics_types
-from .normalisation import (
-    ConventionNormalisation as Normalisation,
-    SimulationNormalisation,
-)
-from .typing import PathLike
 from .templates import gk_templates
+from .typing import PathLike
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 
 class Pyro:

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -1,15 +1,18 @@
-import numpy as np
-from .pyro import Pyro
-from .gk_code import GKInput
-import os
-from contextlib import contextmanager
-from itertools import product
-from functools import reduce
+from __future__ import annotations
+
 import copy
 import json
+import os
 import pathlib
-import xarray as xr
+from contextlib import contextmanager
+from functools import reduce
+from itertools import product
+
+import numpy as np
 import pint
+
+from .gk_code import GKInput
+from .pyro import Pyro
 
 
 class PyroScan:
@@ -276,6 +279,7 @@ class PyroScan:
         -------
         self.gk_output : xarray DataSet of data
         """
+        import xarray as xr
 
         # xarray DataSet to store data
         ds = xr.Dataset(self.parameter_dict)

--- a/src/pyrokinetics/typing.py
+++ b/src/pyrokinetics/typing.py
@@ -1,8 +1,8 @@
-from typing import Union
 from os import PathLike as os_PathLike
-from numpy import integer, floating
-from numpy.typing import ArrayLike  # noqa
+from typing import Union
 
+from numpy import floating, integer
+from numpy.typing import ArrayLike  # noqa
 
 Scalar = Union[float, integer, floating]
 PathLike = Union[os_PathLike, str]

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -2,9 +2,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 import numpy as np
-from xarray import DataArray
 import pint
-
 from numpy.typing import ArrayLike
 from scipy.interpolate import InterpolatedUnivariateSpline, RectBivariateSpline
 
@@ -293,6 +291,8 @@ class UnitSpline:
     """
 
     def __init__(self, x: ArrayLike, y: ArrayLike):
+        from xarray import DataArray
+
         if isinstance(x, DataArray):
             x = x.data
         if isinstance(y, DataArray):

--- a/tests/equilibrium/test_gacode.py
+++ b/tests/equilibrium/test_gacode.py
@@ -9,7 +9,11 @@ from pyrokinetics.equilibrium import (
     EquilibriumCOCOSWarning,
     read_equilibrium,
 )
-from pyrokinetics.equilibrium.gacode import EquilibriumReaderGACODE
+
+try:
+    from pyrokinetics.equilibrium.gacode import EquilibriumReaderGACODE
+except ImportError:
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.fixture

--- a/tests/equilibrium/test_gacode.py
+++ b/tests/equilibrium/test_gacode.py
@@ -9,11 +9,7 @@ from pyrokinetics.equilibrium import (
     EquilibriumCOCOSWarning,
     read_equilibrium,
 )
-
-try:
-    from pyrokinetics.equilibrium.gacode import EquilibriumReaderGACODE
-except ImportError:
-    pytest.skip(allow_module_level=True)
+from pyrokinetics.equilibrium.gacode import EquilibriumReaderGACODE
 
 
 @pytest.fixture

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -5,15 +5,6 @@ from pyrokinetics import template_dir
 import pytest
 import numpy as np
 
-pygacode_found: bool
-try:
-    import pygacode
-
-    pygacode_found = True
-    del pygacode
-except ImportError:
-    pygacode_found = False
-
 tritium_mass = 1.5 * deuterium_mass
 
 
@@ -350,7 +341,6 @@ def test_read_pFile(pfile_file, geqdsk_file, kinetics_type):
     )
 
 
-@pytest.mark.skipif(not pygacode_found, reason="Not running with GACODE features")
 @pytest.mark.parametrize("kinetics_type", ["GACODE", None])
 def test_read_gacode(gacode_file, geqdsk_file, kinetics_type):
     gacode = read_kinetics(gacode_file, kinetics_type)
@@ -400,16 +390,15 @@ def test_read_gacode(gacode_file, geqdsk_file, kinetics_type):
     )
 
 
-_filetype_inference_args = [
-    ("scene.cdf", "SCENE"),
-    ("jetto.jsp", "JETTO"),
-    ("transp.cdf", "TRANSP"),
-]
-if pygacode_found:
-    _filetype_inference_args.append(("input.gacode", "GACODE"))
-
-
-@pytest.mark.parametrize("filename,kinetics_type", _filetype_inference_args)
+@pytest.mark.parametrize(
+    "filename,kinetics_type",
+    [
+        ("scene.cdf", "SCENE"),
+        ("jetto.jsp", "JETTO"),
+        ("transp.cdf", "TRANSP"),
+        ("input.gacode", "GACODE"),
+    ],
+)
 def test_filetype_inference(filename, kinetics_type):
     kinetics = read_kinetics(template_dir.joinpath(filename))
     assert kinetics.kinetics_type == kinetics_type
@@ -428,17 +417,18 @@ def test_bad_kinetics_type(scene_file):
 
 # Compare JETTO and GACODE files with the same Equilibrium
 # Compare only the flux surface at ``psi_n=0.5``.
+@pytest.fixture(scope="module")
 def kin_gacode():
     kin = read_kinetics(template_dir / "input.gacode")
     return kin
 
 
+@pytest.fixture(scope="module")
 def kin_jetto():
     kin = read_kinetics(template_dir / "jetto.jsp", time_index=-1)
     return kin
 
 
-@pytest.mark.skipif(not pygacode_found, reason="Not using GACODE features")
 @pytest.mark.parametrize(
     "attr, unit",
     [

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -8,6 +8,7 @@ import numpy as np
 pygacode_found: bool
 try:
     import pygacode
+
     pygacode_found = True
     del pygacode
 except ImportError:
@@ -398,6 +399,7 @@ def test_read_gacode(gacode_file, geqdsk_file, kinetics_type):
         midpoint_angular_velocity_gradient=1.78730003,
     )
 
+
 _filetype_inference_args = [
     ("scene.cdf", "SCENE"),
     ("jetto.jsp", "JETTO"),
@@ -405,6 +407,7 @@ _filetype_inference_args = [
 ]
 if pygacode_found:
     _filetype_inference_args.append(("input.gacode", "GACODE"))
+
 
 @pytest.mark.parametrize("filename,kinetics_type", _filetype_inference_args)
 def test_filetype_inference(filename, kinetics_type):

--- a/tests/kinetics/test_kinetics_reader_gacode.py
+++ b/tests/kinetics/test_kinetics_reader_gacode.py
@@ -1,7 +1,12 @@
-from pyrokinetics.kinetics import Kinetics, KineticsReaderGACODE
+from pyrokinetics.kinetics import Kinetics
 from pyrokinetics.species import Species
 from pyrokinetics import template_dir
 import pytest
+
+try:
+    from pyrokinetics.kinetics import KineticsReaderGACODE
+except ImportError:
+    pytest.skip(allow_module_level=True)
 
 
 class TestKineticsReaderGACODE:

--- a/tests/kinetics/test_kinetics_reader_gacode.py
+++ b/tests/kinetics/test_kinetics_reader_gacode.py
@@ -1,12 +1,7 @@
-from pyrokinetics.kinetics import Kinetics
+from pyrokinetics.kinetics import Kinetics, KineticsReaderGACODE
 from pyrokinetics.species import Species
 from pyrokinetics import template_dir
 import pytest
-
-try:
-    from pyrokinetics.kinetics import KineticsReaderGACODE
-except ImportError:
-    pytest.skip(allow_module_level=True)
 
 
 class TestKineticsReaderGACODE:


### PR DESCRIPTION
Move slow imports (xarray, matplotlib, jetto-tools) inside the functions that use them. Roughly halves the import time for the project, and the remaining time is almost entirely taken up by units stuff:

![faster_imports](https://github.com/pyro-kinetics/pyrokinetics/assets/14332134/7b8d5ecf-5cf8-4c63-a5e7-51717e15555c)


I found it difficult to parse some of the import sections while I was searching for the right things to edit, so I sorted the import sections with [`isort`](https://pycqa.github.io/isort/index.html) and added it to the autoformatting CI job.

I also found the new GACODE features don't work on my machine. Looks like it can't find Python headers, and I can't immediately figure out what it's trying to do. I moved it to be an optional import.

Resolves Issue https://github.com/pyro-kinetics/pyrokinetics/issues/274.

(Sorry that this changed quite a lot more than I was planning, in hindsight I could have split the changes into 3 separate commits)
