### PR TITLE
Update gs2.py to fix calculation of eigenvalues in non-wstar_units runs

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -802,7 +802,7 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         ky = raw_data["ky"].data
 
         # time coords
-        time_divisor = 1 / 2
+        time_divisor = 1
         try:
             if gk_input.data["knobs"]["wstar_units"]:
                 time_divisor = ky[0] / 2


### PR DESCRIPTION
Slightly surprised this wasn't caught in the tests so perhaps there's some motivation to add extra tests?