### PR TITLE
Docker workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/pyro-kinetics/pyrokinetics
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ $ pyro --help
 $ pyro convert --help
 ```
 
+## Docker
+
+Pyrokinetics provides a `Dockerfile` from which you can build and run Docker containers.
+To do so, you must have [Docker](https://docs.docker.com/engine/install/) installed on
+your system. To build a local container:
+
+```bash
+$ docker build . -t pyrokinetics
+```
+
+It can then be run using:
+
+```bash
+$ docker run -it --rm -v ./path/to/local:/mymount pyrokinetics
+```
+
+where:
+
+- `-it` runs an interactive shell.
+- `--rm` deletes the Docker instance after use.
+- `-v ./path/to/local:/mymount` mounts the local directory `./path/to/local` to the
+  directory `/mymount` within the Docker container.
+
+The container runs an IPython interpreter, with Pyrokinetics already installed. Note
+that you will need to `import` Pyrokinetics before it can be used.
+
 ## Code structure 
 
 Pyro object comprised of 


### PR DESCRIPTION
Adds a workflow that publishes a Docker container to GHCR whenever we make a new release. Also adds a small description of how to use the `Dockerfile` in the `README.md`.