### PR TITLE
Bugfix/docker publishing issues

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -2,13 +2,13 @@ name: Publish Docker Image
 
 on:
   workflow_dispatch:
+  push:
   release:
     types: [published]
 
 jobs:
   publish-docker:
     runs-on: ubuntu-latest
-
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -29,7 +29,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}
+          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '0.0.1' }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -32,3 +32,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ RUN apt-get update
 RUN apt-get -y install gfortran && apt-get clean
 
 COPY ./ /pyrokinetics
-RUN cd /pyrokinetics && git describe --tags > VERSION
-RUN cd /pyrokinetics && pip install --no-cache-dir . && rm -rf .git
+COPY ./.git /pyrokinetics/.git
+WORKDIR /pyrokinetics
+RUN git describe --tags > VERSION
+RUN pip install --no-cache-dir .[tests]
 
 CMD [ "ipython" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ from python:3.11
 RUN apt-get update
 RUN apt-get -y install gfortran && apt-get clean
 
-COPY ./ /pyrokinetics
-COPY ./.git /pyrokinetics/.git
+COPY . /pyrokinetics
 WORKDIR /pyrokinetics
 RUN git describe --tags > VERSION
 RUN pip install --no-cache-dir .[tests]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get -y install gfortran && apt-get clean
 
 COPY . /pyrokinetics
 WORKDIR /pyrokinetics
-RUN git describe --tags > VERSION
 RUN pip install --no-cache-dir .[tests]
 
 CMD [ "ipython" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get -y install gfortran && apt-get clean
 
 COPY . /pyrokinetics
 WORKDIR /pyrokinetics
+
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
 RUN pip install --no-cache-dir .[tests]
 
 CMD [ "ipython" ]


### PR DESCRIPTION
Fixes for the Docker publishing workflow.

[docker/build-push-action](https://github.com/docker/build-push-action) does not make use of the project's working directory, but instead gets its own copy of the project via the [build command](https://docs.docker.com/engine/reference/commandline/build/#git-repositories). To minimise the size of the resulting image, this does not copy across the full commit history in `.git`, with the side-effect that `setuptools-scm` can't figure out the Git tags at build time.

This fix sets the `ARG` `SETUPTOOLS_SCM_PRETEND_VERSION`, which overrides the local version in the Docker file if set like so:

```bash
$ docker build . --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=v0.6.0 -t pyrokinetics
```

If building locally and the `--build-arg` is excluded, `setuptools-scm` will grab the version from the Git tags as usual. In the CI job, the build arg is set using `${{ github.ref_name }}`, and on new releases this will be set to the release tag.

Also contains some edits to the `Dockerfile`  that I made while trying to find alternative solutions. I think it's a little easier to read now, so I left the changes in.

I wasn't able to verify that this definitely works, as `${{ github.ref_name }}` resolved to my branch name in testing, and we'll need to make a new release to be sure.