### PR TITLE
Replace "parameters" with "knobs" in GS2

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -331,9 +331,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
         if mxh.B0 is not None:
-            mxh.beta_prime = (
-                -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
-            )
+            mxh.beta_prime = -local_species.inverse_lp.m * beta_prime_scale / mxh.B0**2
         else:
             mxh.beta_prime = 0.0
 
@@ -782,21 +780,29 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 field=coords["field"],
             ).with_units(convention),
             norm=norm,
-            fields=Fields(**fields, dims=field_dims).with_units(convention)
-            if fields
-            else None,
-            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
-            if fluxes
-            else None,
-            moments=Moments(**moments, dims=moment_dims).with_units(convention)
-            if moments
-            else None,
-            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
-            if eigenvalues
-            else None,
-            eigenfunctions=None
-            if eigenfunctions is None
-            else Eigenfunctions(eigenfunctions),
+            fields=(
+                Fields(**fields, dims=field_dims).with_units(convention)
+                if fields
+                else None
+            ),
+            fluxes=(
+                Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+                if fluxes
+                else None
+            ),
+            moments=(
+                Moments(**moments, dims=moment_dims).with_units(convention)
+                if moments
+                else None
+            ),
+            eigenvalues=(
+                Eigenvalues(**eigenvalues).with_units(convention)
+                if eigenvalues
+                else None
+            ),
+            eigenfunctions=(
+                None if eigenfunctions is None else Eigenfunctions(eigenfunctions)
+            ),
             linear=coords["linear"],
             gk_code="CGYRO",
             input_file=input_str,

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -802,18 +802,26 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
                 field=coords["field"],
             ).with_units(convention),
             norm=norm,
-            fields=Fields(**fields, dims=field_dims).with_units(convention)
-            if fields
-            else None,
-            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
-            if fluxes
-            else None,
-            moments=Moments(**moments, dims=moment_dims).with_units(convention)
-            if moments
-            else None,
-            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
-            if eigenvalues
-            else None,
+            fields=(
+                Fields(**fields, dims=field_dims).with_units(convention)
+                if fields
+                else None
+            ),
+            fluxes=(
+                Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+                if fluxes
+                else None
+            ),
+            moments=(
+                Moments(**moments, dims=moment_dims).with_units(convention)
+                if moments
+                else None
+            ),
+            eigenvalues=(
+                Eigenvalues(**eigenvalues).with_units(convention)
+                if eigenvalues
+                else None
+            ),
             linear=coords["linear"],
             gk_code="GENE",
             input_file=input_str,
@@ -1254,11 +1262,11 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
                             raw_moment = np.frombuffer(
                                 binary_moment, dtype=np.complex128
                             )
-                            sliced_moment[
-                                i_sp, i_moment, :, :, :, i_time
-                            ] = raw_moment.reshape(
-                                (nx, nky, nz),
-                                order="F",
+                            sliced_moment[i_sp, i_moment, :, :, :, i_time] = (
+                                raw_moment.reshape(
+                                    (nx, nky, nz),
+                                    order="F",
+                                )
                             )
                             file.seek(int_size, 1)
                         if i_time < ntime - 1:

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -666,6 +666,16 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
         return ne, Te
 
+    def _get_beta(self):
+        """
+        Small helper to wrap up logic required to get beta from the input
+        consistent with logic across versions of GS2.
+        """
+        has_parameters = "parameters" in self.data.keys()
+        beta_default = 0.0
+        if has_parameters:
+            beta_default = self.data["parameters"].get("beta", 0.0)
+        return self.data["knobs"].get("beta", beta_default)
 
 class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
     def read_from_file(
@@ -759,17 +769,6 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
             pass
         else:
             raise RuntimeError(f"file '{filename}' missing expected GS2 attributes")
-
-    def _get_beta(self):
-        """
-        Small helper to wrap up logic required to get beta from the input
-        consistent with logic across versions of GS2.
-        """
-        has_parameters = "parameters" in self.data.keys()
-        beta_default = 0.0
-        if has_parameters:
-            beta_default = self.data["parameters"].get("beta", 0.0)
-        return self.data["knobs"].get("beta", beta_default)
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -677,6 +677,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             beta_default = self.data["parameters"].get("beta", 0.0)
         return self.data["knobs"].get("beta", beta_default)
 
+
 class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
     def read_from_file(
         self,

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -200,12 +200,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         r_geo = self.data["theta_grid_parameters"].get("r_geo", miller_data["Rmaj"])
 
         ne_norm, Te_norm = self.get_ne_te_normalisation()
-        beta = (
-            self._get_beta()
-            * (miller_data["Rmaj"] / r_geo) ** 2
-            * ne_norm
-            * Te_norm
-        )
+        beta = self._get_beta() * (miller_data["Rmaj"] / r_geo) ** 2 * ne_norm * Te_norm
         miller_data["beta_prime"] *= (miller_data["Rmaj"] / r_geo) ** 2
 
         # Assume pref*8pi*1e-7 = 1.0
@@ -713,18 +708,26 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
                 field=coords["field"],
             ).with_units(convention),
             norm=norm,
-            fields=Fields(**fields, dims=field_dims).with_units(convention)
-            if fields
-            else None,
-            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
-            if fluxes
-            else None,
-            moments=Moments(**moments, dims=moment_dims).with_units(convention)
-            if moments
-            else None,
-            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
-            if eigenvalues
-            else None,
+            fields=(
+                Fields(**fields, dims=field_dims).with_units(convention)
+                if fields
+                else None
+            ),
+            fluxes=(
+                Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+                if fluxes
+                else None
+            ),
+            moments=(
+                Moments(**moments, dims=moment_dims).with_units(convention)
+                if moments
+                else None
+            ),
+            eigenvalues=(
+                Eigenvalues(**eigenvalues).with_units(convention)
+                if eigenvalues
+                else None
+            ),
             linear=coords["linear"],
             gk_code="GS2",
             input_file=input_str,

--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -65,18 +65,26 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                 species=coords["species"],
             ).with_units(convention),
             norm=norm,
-            fields=Fields(**fields, dims=field_dims).with_units(convention)
-            if fields
-            else None,
-            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
-            if fluxes
-            else None,
-            moments=Moments(**moments, dims=moment_dims).with_units(convention)
-            if moments
-            else None,
-            eigenvalues=Eigenvalues(**eigenvalues).with_units(convention)
-            if eigenvalues
-            else None,
+            fields=(
+                Fields(**fields, dims=field_dims).with_units(convention)
+                if fields
+                else None
+            ),
+            fluxes=(
+                Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+                if fluxes
+                else None
+            ),
+            moments=(
+                Moments(**moments, dims=moment_dims).with_units(convention)
+                if moments
+                else None
+            ),
+            eigenvalues=(
+                Eigenvalues(**eigenvalues).with_units(convention)
+                if eigenvalues
+                else None
+            ),
             linear=coords["linear"],
             gk_code=coords["gk_code"],
             normalise_flux_moment=False,

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -572,23 +572,31 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
                 field=coords["field"],
             ).with_units(convention),
             norm=norm,
-            fields=Fields(**fields, dims=field_dims).with_units(convention)
-            if fields
-            else None,
-            fluxes=Fluxes(**fluxes, dims=flux_dims).with_units(convention)
-            if fluxes
-            else None,
-            moments=Moments(**moments, dims=moment_dims).with_units(convention)
-            if moments
-            else None,
-            eigenvalues=Eigenvalues(**eigenvalues, dims=eigenvalues_dims).with_units(
-                convention
-            )
-            if eigenvalues
-            else None,
-            eigenfunctions=None
-            if eigenfunctions is None
-            else Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims),
+            fields=(
+                Fields(**fields, dims=field_dims).with_units(convention)
+                if fields
+                else None
+            ),
+            fluxes=(
+                Fluxes(**fluxes, dims=flux_dims).with_units(convention)
+                if fluxes
+                else None
+            ),
+            moments=(
+                Moments(**moments, dims=moment_dims).with_units(convention)
+                if moments
+                else None
+            ),
+            eigenvalues=(
+                Eigenvalues(**eigenvalues, dims=eigenvalues_dims).with_units(convention)
+                if eigenvalues
+                else None
+            ),
+            eigenfunctions=(
+                None
+                if eigenfunctions is None
+                else Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims)
+            ),
             linear=coords["linear"],
             gk_code="TGLF",
             input_file=input_str,

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -3,6 +3,7 @@ Reads in an Osborne pFile: https://omfit.io/_modules/omfit_classes/omfit_osborne
 
 
 """
+
 import re
 from contextlib import redirect_stdout
 from textwrap import dedent

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -491,9 +491,7 @@ class MetricTerms:  # CleverDict
             - self.dg_theta_theta_dr
             - (g_r_theta * self.dJacobian_dtheta / self.Jacobian)
         )
-        term3 = (
-            (self.mu0dPdr / (self.dpsidr**2)) * (self.Jacobian**3) / g_theta_theta
-        )
+        term3 = (self.mu0dPdr / (self.dpsidr**2)) * (self.Jacobian**3) / g_theta_theta
         term4 = (
             (self.B_zeta * self.dB_zeta_dr / (self.dpsidr**2))
             * (self.Jacobian**3)
@@ -685,9 +683,9 @@ class MetricTerms:  # CleverDict
         self._field_aligned_covariant_metric[0, 1] = -self.dalpha_dr * g_zeta_zeta
 
         # tilde{g}_alpha_r
-        self._field_aligned_covariant_metric[
-            1, 0
-        ] = self._field_aligned_covariant_metric[0, 1]
+        self._field_aligned_covariant_metric[1, 0] = (
+            self._field_aligned_covariant_metric[0, 1]
+        )
 
         # tilde{g}_r_theta: eq 27
         self._field_aligned_covariant_metric[0, 2] = (
@@ -695,9 +693,9 @@ class MetricTerms:  # CleverDict
         )
 
         # tilde{g}_theta_r
-        self._field_aligned_covariant_metric[
-            2, 0
-        ] = self._field_aligned_covariant_metric[0, 2]
+        self._field_aligned_covariant_metric[2, 0] = (
+            self._field_aligned_covariant_metric[0, 2]
+        )
 
         # tilde{g}_alpha_alpha: eq 28
         self._field_aligned_covariant_metric[1, 1] = g_zeta_zeta
@@ -706,9 +704,9 @@ class MetricTerms:  # CleverDict
         self._field_aligned_covariant_metric[1, 2] = -self.dalpha_dtheta * g_zeta_zeta
 
         # tilde{g}_theta_alpha
-        self._field_aligned_covariant_metric[
-            2, 1
-        ] = self._field_aligned_covariant_metric[1, 2]
+        self._field_aligned_covariant_metric[2, 1] = (
+            self._field_aligned_covariant_metric[1, 2]
+        )
 
         # tilde{g}_theta_theta: eq 30
         self._field_aligned_covariant_metric[2, 2] = (
@@ -735,9 +733,9 @@ class MetricTerms:  # CleverDict
         # tilde{g}^r^theta: eq 34
         self._field_aligned_contravariant_metric[0, 2] = gcont_r_theta
         # tilde{g}^theta^r
-        self._field_aligned_contravariant_metric[
-            2, 0
-        ] = self._field_aligned_contravariant_metric[0, 2]
+        self._field_aligned_contravariant_metric[2, 0] = (
+            self._field_aligned_contravariant_metric[0, 2]
+        )
 
         # tilde{g}^theta^theta: eq 35
         self._field_aligned_contravariant_metric[2, 2] = gcont_theta_theta
@@ -747,18 +745,18 @@ class MetricTerms:  # CleverDict
             self.dalpha_dr * gcont_r_r + self.dalpha_dtheta * gcont_r_theta
         )
         # tilde{g}^alpha^r
-        self._field_aligned_contravariant_metric[
-            1, 0
-        ] = self._field_aligned_contravariant_metric[1, 2]
+        self._field_aligned_contravariant_metric[1, 0] = (
+            self._field_aligned_contravariant_metric[1, 2]
+        )
 
         # tilde{g}^theta^alpha: eq 36
         self._field_aligned_contravariant_metric[2, 1] = (
             self.dalpha_dr * gcont_r_theta + self.dalpha_dtheta * gcont_theta_theta
         )
         # tilde{g}^alpha^theta
-        self._field_aligned_contravariant_metric[
-            1, 2
-        ] = self._field_aligned_contravariant_metric[2, 1]
+        self._field_aligned_contravariant_metric[1, 2] = (
+            self._field_aligned_contravariant_metric[2, 1]
+        )
 
         # tilde{g}^alpha^alpha: eq 33
         self._field_aligned_contravariant_metric[1, 1] = (

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -126,7 +126,6 @@ normalisations.
 
 """
 
-
 import copy
 from typing import Dict, Optional
 

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -85,9 +85,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[
-                    species
-                ].inverse_ln = pyro.local_species.electron.inverse_ln
+                pyro.local_species[species].inverse_ln = (
+                    pyro.local_species.electron.inverse_ln
+                )
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)


### PR DESCRIPTION
The parameters namelist in GS2 has been deprecated for a while and v8.2 will be removing this. Currently we attempt to get/set beta and zeff using parameters. This commit changes that.

We could probably add a helper similar to `_get_beta` for zeff as well. Probably not much work to add something like

~~~~python
def _get_knobs_parameters(self, var, default = 0.0):
      has_parameters = "parameters" in self.data.keys()
      local_default = default
      if has_parameters:
               local_default = self.data["parameters"].get(var, local_default)
      return self.data["knobs"].get(var, local_default)
~~~~

It would even be possible to take a list of namelist to search in order if we wanted to generalise further (but likely no need).