### PR TITLE
Update normalisation.py to allow for the conversion of original base …

### DIFF
--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -430,7 +430,7 @@ class SimulationNormalisation(Normalisation):
         bref_B0_sim_unit = getattr(self.units, bref_B0_sim)
         self.context.add_transformation(
             "[bref]",
-            bref_B0_sim,
+            bref_B0_sim_unit.dimensionality,
             lambda ureg, x: x.to(ureg.bref_B0).m * bref_B0_sim_unit,
         )
 
@@ -481,7 +481,7 @@ class SimulationNormalisation(Normalisation):
 
         self.context.add_transformation(
             "[lref]",
-            self.pyrokinetics.lref,
+            self.pyrokinetics.lref.dimensionality,
             lambda ureg, x: x.to(ureg.lref_minor_radius).m * self.pyrokinetics.lref,
         )
 
@@ -516,7 +516,7 @@ class SimulationNormalisation(Normalisation):
 
         self.context.add_transformation(
             "[rhoref]",
-            self.pyrokinetics.rhoref,
+            self.pyrokinetics.rhoref.dimensionality,
             lambda ureg, x: x.to(ureg.rhoref_pyro).m * self.pyrokinetics.rhoref,
         )
 
@@ -593,12 +593,12 @@ class SimulationNormalisation(Normalisation):
         # Transformations between simulation and physical units
         self.context.add_transformation(
             "[tref]",
-            self.pyrokinetics.tref,
+            self.pyrokinetics.tref.dimensionality,
             lambda ureg, x: x.to(ureg.tref_electron).m * self.pyrokinetics.tref,
         )
         self.context.add_transformation(
             "[nref]",
-            self.pyrokinetics.nref,
+            self.pyrokinetics.nref.dimensionality,
             lambda ureg, x: x.to(ureg.nref_electron).m * self.pyrokinetics.nref,
         )
 
@@ -606,21 +606,21 @@ class SimulationNormalisation(Normalisation):
         # them automatically.
         self.context.add_transformation(
             "[vref]",
-            self.pyrokinetics.vref,
+            self.pyrokinetics.vref.dimensionality,
             lambda ureg, x: x.to(ureg.vref_nrl).m * self.pyrokinetics.vref,
         )
 
     def set_all_references(
         self,
         pyro,
-        tref=None,
-        nref=None,
+        tref_electron=None,
+        nref_electron=None,
         bref_B0=None,
         lref_minor_radius=None,
         lref_major_radius=None,
     ):
-        self.units.define(f"tref_electron_{self.name} = {tref}")
-        self.units.define(f"nref_electron_{self.name} = {nref}")
+        self.units.define(f"tref_electron_{self.name} = {tref_electron}")
+        self.units.define(f"nref_electron_{self.name} = {nref_electron}")
 
         self.units.define(f"mref_deuterium_{self.name} = mref_deuterium")
 
@@ -673,37 +673,37 @@ class SimulationNormalisation(Normalisation):
         # Transformations between simulation and physical units
         self.context.add_transformation(
             "[tref]",
-            self.pyrokinetics.tref,
+            self.pyrokinetics.tref.dimensionality,
             lambda ureg, x: x.to(ureg.tref_electron).m * self.pyrokinetics.tref,
         )
 
         self.context.add_transformation(
             "[lref]",
-            self.pyrokinetics.lref,
+            self.pyrokinetics.lref.dimensionality,
             lambda ureg, x: x.to(ureg.lref_minor_radius).m * self.pyrokinetics.lref,
         )
 
         self.context.add_transformation(
             "[nref]",
-            self.pyrokinetics.nref,
+            self.pyrokinetics.nref.dimensionality,
             lambda ureg, x: x.to(ureg.nref_electron).m * self.pyrokinetics.nref,
         )
 
         self.context.add_transformation(
             "[bref]",
-            self.pyrokinetics.bref,
+            self.pyrokinetics.bref.dimensionality,
             lambda ureg, x: x.to(ureg.bref_B0).m * self.pyrokinetics.bref,
         )
 
         self.context.add_transformation(
             "[vref]",
-            self.pyrokinetics.vref,
+            self.pyrokinetics.vref.dimensionality,
             lambda ureg, x: x.to(ureg.vref_nrl).m * self.pyrokinetics.vref,
         )
 
         self.context.add_transformation(
             "[rhoref]",
-            self.pyrokinetics.rhoref,
+            self.pyrokinetics.rhoref.dimensionality,
             lambda ureg, x: x.to(ureg.rhoref_pyro).m * self.pyrokinetics.rhoref,
         )
 
@@ -836,7 +836,7 @@ class ConventionNormalisation(Normalisation):
         self._update_system()
 
     def set_all_references(self):
-        """Set refernece value manually"""
+        """Set reference value manually"""
         self.tref = getattr(self._registry, f"{self.convention.tref}_{self.run_name}")
         self.mref = getattr(self._registry, f"{self.convention.mref}_{self.run_name}")
         self.nref = getattr(self._registry, f"{self.convention.nref}_{self.run_name}")

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1813,8 +1813,8 @@ class Pyro:
 
         self.norms.set_all_references(
             self,
-            tref=tref_electron,
-            nref=nref_electron,
+            tref_electron=tref_electron,
+            nref_electron=nref_electron,
             bref_B0=bref_B0,
             lref_minor_radius=lref_minor_radius,
         )

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -56,8 +56,12 @@ class PyroQuantity(pint.Quantity):
     def _convert_simulation_units(self, norm):
         """Replace simulation units by their corresponding physical unit"""
         units = dict()
+        if hasattr(norm, "run_name"):
+            name = norm.run_name
+        else:
+            name = norm.name
         for unit, power in self._units.items():
-            if (new_unit := f"{unit}_{norm.name}") in self._REGISTRY:
+            if (new_unit := f"{unit}_{name}") in self._REGISTRY:
                 unit = new_unit
             units[unit] = power
         return self._REGISTRY.Quantity(self._magnitude, pint.util.UnitsContainer(units))

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -108,7 +108,6 @@ def test_set_all_references():
     norm.set_all_references(pyro, **reference_values)
 
     assert np.isclose(1 * norm.tref, reference_values["tref_electron"])
-    assert np.isclose(1 * norm.nref, reference_values["nref_electron"])
     assert np.isclose(1 * norm.lref, reference_values["lref_minor_radius"])
     assert np.isclose(1 * norm.bref, reference_values["bref_B0"])
 
@@ -118,11 +117,18 @@ def test_set_all_references():
     base_bref_B0 = 1 * norm.units.bref_B0
 
     assert np.isclose(base_tref_electron.to(norm), reference_values["tref_electron"])
-    assert np.isclose(base_nref_electron.to(norm), reference_values["nref_electron"])
     assert np.isclose(
         base_lref_minor_radius.to(norm), reference_values["lref_minor_radius"]
     )
     assert np.isclose(base_bref_B0.to(norm), reference_values["bref_B0"])
+
+    # Had to convert density to SI. Not sure why
+    assert np.isclose(
+        (1 * norm.nref).to("meter**-3"), reference_values["nref_electron"]
+    )
+    assert np.isclose(
+        base_nref_electron.to(norm).to("meter**-3"), reference_values["nref_electron"]
+    )
 
 
 def test_normalisation_constructor(geometry, kinetics):

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -59,6 +59,9 @@ def test_set_bref(geometry):
     assert q.to("tesla") == 1.2 * ureg.tesla
     assert q.to(norm.cgyro.bref) == 0.5 * norm.cgyro.bref
 
+    base = 1 * norm.units.bref_B0
+    assert base.to(norm) == q
+
 
 def test_set_lref(geometry):
     norm = SimulationNormalisation("test")
@@ -68,6 +71,9 @@ def test_set_lref(geometry):
     assert q.to("m") == 2.3 * ureg.metres
     assert q.to(norm.gene.lref) == norm.gene.lref / 4.6
 
+    base = 1 * norm.units.lref_minor_radius
+    assert base.to(norm) == q
+
 
 def test_set_kinetic(kinetics):
     norm = SimulationNormalisation("test")
@@ -76,6 +82,49 @@ def test_set_kinetic(kinetics):
     assert np.isclose(1 * norm.tref, 23774277.31113508 * norm.units.kelvin)
     assert np.isclose(1 * norm.nref, 3.98442302e19 / norm.units.metres**3)
     assert np.isclose(1 * norm.mref, 1 * norm.units.deuterium_mass)
+
+    base_tref_electron = 1 * norm.units.tref_electron
+    base_nref_electron = 1 * norm.units.nref_electron
+    base_mref_deuterium = 1 * norm.units.mref_deuterium
+
+    assert np.isclose(
+        base_tref_electron.to(norm), 23774277.31113508 * norm.units.kelvin
+    )
+    assert np.isclose(
+        base_nref_electron.to(norm), 3.98442302e19 / norm.units.metres ** 3
+    )
+    assert np.isclose(base_mref_deuterium.to(norm), 1 * norm.units.deuterium_mass)
+
+
+def test_set_all_references():
+    pyro = pk.Pyro(gk_file=gk_gs2_template)
+    norm = SimulationNormalisation("test")
+
+    reference_values = {
+        "tref_electron": 1000.0 * norm.units.eV,
+        "nref_electron": 1e19 * norm.units.meter ** -3,
+        "lref_minor_radius": 1.5 * norm.units.meter,
+        "bref_B0": 2.0 * norm.units.tesla,
+    }
+
+    norm.set_all_references(pyro, **reference_values)
+
+    assert np.isclose(1 * norm.tref, reference_values["tref_electron"])
+    assert np.isclose(1 * norm.nref, reference_values["nref_electron"])
+    assert np.isclose(1 * norm.lref, reference_values["lref_minor_radius"])
+    assert np.isclose(1 * norm.bref, reference_values["bref_B0"])
+
+    base_tref_electron = 1 * norm.units.tref_electron
+    base_nref_electron = 1 * norm.units.nref_electron
+    base_lref_minor_radius = 1 * norm.units.lref_minor_radius
+    base_bref_B0 = 1 * norm.units.bref_B0
+
+    assert np.isclose(base_tref_electron.to(norm), reference_values["tref_electron"])
+    assert np.isclose(base_nref_electron.to(norm), reference_values["nref_electron"])
+    assert np.isclose(
+        base_lref_minor_radius.to(norm), reference_values["lref_minor_radius"]
+    )
+    assert np.isclose(base_bref_B0.to(norm), reference_values["bref_B0"])
 
 
 def test_normalisation_constructor(geometry, kinetics):

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -90,9 +90,7 @@ def test_set_kinetic(kinetics):
     assert np.isclose(
         base_tref_electron.to(norm), 23774277.31113508 * norm.units.kelvin
     )
-    assert np.isclose(
-        base_nref_electron.to(norm), 3.98442302e19 / norm.units.metres ** 3
-    )
+    assert np.isclose(base_nref_electron.to(norm), 3.98442302e19 / norm.units.metres**3)
     assert np.isclose(base_mref_deuterium.to(norm), 1 * norm.units.deuterium_mass)
 
 
@@ -102,7 +100,7 @@ def test_set_all_references():
 
     reference_values = {
         "tref_electron": 1000.0 * norm.units.eV,
-        "nref_electron": 1e19 * norm.units.meter ** -3,
+        "nref_electron": 1e19 * norm.units.meter**-3,
         "lref_minor_radius": 1.5 * norm.units.meter,
         "bref_B0": 2.0 * norm.units.tesla,
     }


### PR DESCRIPTION
…units

Initially when setting normalising reference values (`lref`, `nref` `tref` etc.), pyro would create a new unit (`lref_minor_radius_input0000`) which it would then be possible to convert to SI units (`meter`). However you could not convert the original base unit `lref_minor_radius`) to the new unit or SI which led to failures when setting the unit and then converting say the output to a different normalisation. This fixes that (had a feeling there was a issue like this for a while but finally figured it out this morning... very sneaky bug).

If you load directly from `Equilibrium`/`Kinetics` then this is not an issue as the base units are set from the get go. This only affects scenarios where the reference values are set later on down the line.

Added tests to check for this.