### PR TITLE
Fix NaN check for arrays and normalise to final finite timeslice in f…

### DIFF
--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -728,7 +728,9 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         # Check for final time slice with finite data
         final_index = np.argwhere(np.isfinite(amplitude))[-1][-1]
         if final_index != amplitude.shape[-1] - 1:
-            warnings.warn("Non-finite data found in fields. Likely to due NaN/Inf in GKoutput data")
+            warnings.warn(
+                "Non-finite data found in fields. Likely to due NaN/Inf in GKoutput data"
+            )
 
         amplitude = amplitude[:, :, final_index]
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1163,9 +1163,9 @@ class Pyro:
                 "eigenvalues" in self.gk_output
                 and "time" in self.gk_output["eigenvalues"].dims
             ):
-                self.gk_output.data[
-                    "growth_rate_tolerance"
-                ] = self.gk_output.get_growth_rate_tolerance()
+                self.gk_output.data["growth_rate_tolerance"] = (
+                    self.gk_output.get_growth_rate_tolerance()
+                )
 
     # ==================================
     # Set properties for file attributes

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1077,6 +1077,7 @@ class Pyro:
         load_fields=True,
         load_fluxes=True,
         load_moments=False,
+        drop_nan=False,
         **kwargs,
     ) -> None:
         """
@@ -1099,6 +1100,8 @@ class Pyro:
             Pyrokinetics will search for the other files in the same directory.
 
             If set to None, infers path from ``gk_file``.
+        drop_nan: bool, default False
+            If NaNs are found in the output then that data is dropped. Off by default
         **kwargs
             Arguments to pass to the ``GKOutputReader``.
 
@@ -1152,6 +1155,17 @@ class Pyro:
             load_moments=load_moments,
             **kwargs,
         )
+
+        if drop_nan:
+            self.gk_output.data = self.gk_output.data.dropna(dim="time")
+            # Calculate growth_rate_tolerance with default inputs
+            if (
+                "eigenvalues" in self.gk_output
+                and "time" in self.gk_output["eigenvalues"].dims
+            ):
+                self.gk_output.data[
+                    "growth_rate_tolerance"
+                ] = self.gk_output.get_growth_rate_tolerance()
 
     # ==================================
     # Set properties for file attributes

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -44,9 +44,14 @@ class PyroQuantity(pint.Quantity):
             return value
         # Special case zero, because that's always fine (except for
         # offset units, but we don't use those)
-        if self == 0.0:
+        if (self == 0.0).all():
             return 0.0 * value.units
-        raise PyroNormalisationError(system, self.units)
+        # If everything is a NaN then conversion failed otherwise some
+        # NaNs exist in the data and we can proceed
+        if np.isnan(value).all():
+            raise PyroNormalisationError(system, self.units)
+        else:
+            return value
 
     def to_base_units(self, system: Optional[str] = None):
         with self._REGISTRY.as_system(system):


### PR DESCRIPTION
…ields

Sometimes where GS2/GENE run linearly they can bounce between two modes with very similar growth rates but won't converge leading to overflows, resulting in NaNs/Inf in the output. This would cause pyro to throw an useless error when trying to change the normalisation to the pyro convention.

This fixes it by 

1. Properly checking if all the converted data is NaN which would mean the conversion has failed and thus an error is raised.
2. In the case where some of the data are NaNs, it just means that the normalisation conversion worked fine, but the source data has NaNs so we can technically proceed
3. We also used renormalise the fields to the final timeslice's amplitude. Now we renormalise to the final _finite_ timeslice and warn the user if this not the actual final timeslice.

This means you can still load in the data but certain thing like the growth rate/mode frequency won't calculate when the NaNs appear, but are fine before then. See a case below

![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/5d528ce2-9349-4478-a179-a40581320fda)
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/55865abf-5b79-46f4-868e-ce8b1f2c5cea)
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/cf21c805-00cd-4145-ab84-e57ccc5b6753)
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/9679adbe-256a-41d7-888f-1e3311a985b8)
![image](https://github.com/pyro-kinetics/pyrokinetics/assets/15210802/4f1d4204-63bd-4417-bca1-fd9975e32526)

[gs2.txt](https://github.com/pyro-kinetics/pyrokinetics/files/14852324/gs2.txt)
