### PR TITLE
Set qref to pint elementary_charge and mref  to scipy constant in uni…

### DIFF
--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -5,6 +5,7 @@ import numpy as np
 import pint
 from numpy.typing import ArrayLike
 from scipy.interpolate import InterpolatedUnivariateSpline, RectBivariateSpline
+from scipy.constants import physical_constants
 
 
 class PyroNormalisationError(Exception):
@@ -127,12 +128,11 @@ class PyroUnitRegistry(pint.UnitRegistry):
 
         self._on_redefinition = "ignore"
 
-        self.define("elementary_charge = 1.602176634e−19 coulomb")
         self.define("qref = elementary_charge")
 
-        # IMAS normalises to the actual deuterium mass, so lets add that
+        # IMAS normalises to the actual deuterium mass, so let's add that
         # as a constant
-        self.define("deuterium_mass = 3.3435837724e-27 kg")
+        self.define(f"deuterium_mass = {physical_constants['deuteron mass'][0]} kg")
 
         # We can immediately define reference masses in physical units.
         # WARNING: This might need refactoring to use a [mref] dimension

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -132,7 +132,9 @@ class PyroUnitRegistry(pint.UnitRegistry):
 
         # IMAS normalises to the actual deuterium mass, so let's add that
         # as a constant
-        self.define(f"deuterium_mass = {physical_constants['deuteron mass'][0]} kg")
+        self.define(
+            f"deuterium_mass = {physical_constants['deuteron mass'][0]} {physical_constants['deuteron mass'][1]}"
+        )
 
         # We can immediately define reference masses in physical units.
         # WARNING: This might need refactoring to use a [mref] dimension

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -4,8 +4,8 @@ from typing import Optional
 import numpy as np
 import pint
 from numpy.typing import ArrayLike
-from scipy.interpolate import InterpolatedUnivariateSpline, RectBivariateSpline
 from scipy.constants import physical_constants
+from scipy.interpolate import InterpolatedUnivariateSpline, RectBivariateSpline
 
 
 class PyroNormalisationError(Exception):


### PR DESCRIPTION
…ts.py

Fix issue in #317 by setting `qref` to pint's pre-defined `elementary_charge` and `deuterium_mass` to the scipy constant