### PR TITLE
Bugfix: Slow deepcopies in tests

### DIFF
--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -935,10 +935,7 @@ class ConventionNormalisation(Normalisation):
         self._update_system()
 
     def __deepcopy__(self, memodict):
-        """Overrides deepcopy behaviour to perform regular copy.
-
-        Performing a full deepcopy would duplicate the Pint registry itself, which
-        can lead to significant performance problems."""
+        """Overrides deepcopy behaviour to perform regular copy of the Pint registry."""
         new_obj = object.__new__(type(self))
         for k, v in self.__dict__.items():
             if k == "_registry" or k == "_system":

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -354,23 +354,10 @@ class SimulationNormalisation(Normalisation):
         new_object = SimulationNormalisation("COPY")
         new_object.name = self.name
         new_object.units = self.units
-        new_object._conventions = copy.deepcopy(self._conventions)
+        new_object._conventions = copy.deepcopy(self._conventions, memodict)
         new_object.default_convention = self.default_convention.name
 
-        # This is not clever, should be in ConventionNormalisation.__deepcopy__?
-        for name, convention in self._conventions.items():
-            new_object._conventions[name]._registry = self.units
-            new_object._conventions[name].run_name = convention.run_name
-            new_object._conventions[name].context = convention.context
-            new_object._conventions[name].bref = convention.bref
-            new_object._conventions[name].lref = convention.lref
-            new_object._conventions[name].mref = convention.mref
-            new_object._conventions[name].nref = convention.nref
-            new_object._conventions[name].tref = convention.tref
-            new_object._conventions[name].vref = convention.vref
-            new_object._conventions[name].rhoref = convention.rhoref
-
-            new_object._conventions[name]._update_system()
+        for name in self._conventions:
             setattr(new_object, name, new_object._conventions[name])
 
         new_object._system = self._system
@@ -946,6 +933,23 @@ class ConventionNormalisation(Normalisation):
         self.beta_ref = convention.beta_ref
 
         self._update_system()
+
+    def __deepcopy__(self, memodict):
+        """Overrides deepcopy behaviour to perform regular copy.
+
+        Performing a full deepcopy would duplicate the Pint registry itself, which
+        can lead to significant performance problems."""
+        new_obj = object.__new__(type(self))
+        for k, v in self.__dict__.items():
+            if k == "_registry" or k == "_system":
+                continue
+            new_obj.__dict__[k] = copy.deepcopy(v, memodict)
+        new_obj._registry = self._registry
+        new_obj._system = self._registry.get_system(
+            f"{self.convention.name}_{self.run_name}"
+        )
+        new_obj._update_system()
+        return new_obj
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Fixes Issue https://github.com/pyro-kinetics/pyrokinetics/issues/326

When deepcopying `SimulationNormalisation`, we call the line:

https://github.com/pyro-kinetics/pyrokinetics/blob/3f9f09d96ab890e78852d39d5adb2a395c8a4e62/src/pyrokinetics/normalisation.py#L357

This deep-copies the following dict:

https://github.com/pyro-kinetics/pyrokinetics/blob/3f9f09d96ab890e78852d39d5adb2a395c8a4e62/src/pyrokinetics/normalisation.py#L325-L328

`ConventionNormalisation` does not have a custom `__deepcopy__`, but it does contain the following line in its `__init__`:

https://github.com/pyro-kinetics/pyrokinetics/blob/3f9f09d96ab890e78852d39d5adb2a395c8a4e62/src/pyrokinetics/normalisation.py#L932

This means each deepcopy was duplicating the pint registry 6 times -- once for each `Convention` in `NORMALISATION_CONVENTIONS`. Somehow this was interacting with the routines that rebuild Pint's cache in functions such as `set_lref` (still not sure what's going on there) to cause the tests to run about 5 times slower than before.

This PR adds a custom `__deepcopy__` to `ConventionNormalisation` that avoids deepcopying the Pint registry, and cleans up the `__deepcopy__` in `SimulationNormalisation`.