### PR TITLE
Replace `setuptools-scm` with `versioningit`, store `__commit__` alongside `__version__`

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,6 +10,11 @@ jobs:
   publish-docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -29,6 +34,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -8,9 +8,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "xmltodict ~= 0.13.0",
     "typing-extensions >= 4.6.0",
     "simplejson >= 3.17.6",
-    "gitpython >= 3.1",
     "jetto-tools",
 ]
 
@@ -76,15 +75,25 @@ pyro = "pyrokinetics.cli:entrypoint"
 [build-system]
 requires = [
     "setuptools >= 65",
-    "setuptools_scm[toml] >= 6.2",
-    "setuptools_scm_git_archive",
-    "wheel >= 0.29.0",
+    "versioningit",
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
-write_to = "src/pyrokinetics/_version.py"
-git_describe_command = "git describe --dirty --tags --long --match v* --first-parent"
+[tool.versioningit]
+next-version = { method = "smallest" }
+
+[tool.versioningit.write]
+file = "src/pyrokinetics/_version.py"
+template = """
+__version__ = "{version}"
+__version_tuple__ = {version_tuple}
+__commit__ = "{revision}""""
+
+# versioningit setup to mimic setuptools-scm versions
+[tool.versioningit.format]
+distance = "{next_version}.dev{distance}+{vcs}{rev}"
+dirty = "{base_version}+d{build_date:%Y%m%d}"
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ pyro = "pyrokinetics.cli:entrypoint"
 [build-system]
 requires = [
     "setuptools >= 65",
+    "setuptools-scm[toml]", # Used to manage package data, not for versioning
     "versioningit",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit]
+vcs = { method = "git", default-tag = "v0.1.0" }
 next-version = { method = "smallest" }
 
 [tool.versioningit.write]

--- a/src/pyrokinetics/__init__.py
+++ b/src/pyrokinetics/__init__.py
@@ -30,7 +30,7 @@ from .equilibrium import (
     supported_equilibrium_types,
 )
 from .kinetics import Kinetics, read_kinetics, supported_kinetics_types
-from .metadata import __version__
+from .metadata import __commit__, __version__
 from .numerics import Numerics
 from .pyro import Pyro
 from .pyroscan import PyroScan

--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -13,7 +13,7 @@ from idspy_toolkit import ids_to_hdf5
 from xmltodict import parse as xmltodict
 from xmltodict import unparse as dicttoxml
 
-from pyrokinetics import __version__, __commit__
+from pyrokinetics import __commit__, __version__
 
 from ..gk_code.gk_output import GKOutput
 from ..normalisation import convert_dict

--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from itertools import product
 from typing import TYPE_CHECKING, Dict
 
-import git
 import idspy_toolkit as idspy
 import numpy as np
 import pint
@@ -14,7 +13,7 @@ from idspy_toolkit import ids_to_hdf5
 from xmltodict import parse as xmltodict
 from xmltodict import unparse as dicttoxml
 
-from pyrokinetics import __version__ as pyro_version
+from pyrokinetics import __version__, __commit__
 
 from ..gk_code.gk_output import GKOutput
 from ..normalisation import convert_dict
@@ -468,12 +467,10 @@ def pyro_to_imas_mapping(
 
     code_eigenmode = {"parameters": xml_gk_input, "output_flag": 0}
 
-    repo = git.Repo(search_parent_directories=True)
-    sha = repo.head.object.hexsha
     code_library = {
         "name": "pyrokinetics",
-        "commit": sha,
-        "version": pyro_version,
+        "commit": __commit__,
+        "version": __version__,
         "repository": "https://github.com/pyro-kinetics/pyrokinetics",
         "parameters": xml_gk_input,
     }

--- a/src/pyrokinetics/metadata.py
+++ b/src/pyrokinetics/metadata.py
@@ -12,9 +12,13 @@ except PackageNotFoundError:
     try:
         from setuptools_scm import get_version
 
-        __version__ = get_version(root="..", relative_to=__file__)
+        __version__ = get_version(root="../..", relative_to=__file__)
     except ImportError:
         __version__ = "0.0.1"
+try:
+    from ._version import __commit__
+except ImportError:
+    __commit__ = "COMMIT_UNKNOWN"
 
 
 # Define UUID and session start as module-level variables.


### PR DESCRIPTION
An attempt to solve Issue https://github.com/pyro-kinetics/pyrokinetics/issues/330

Currently uses `gitpython` to get the commit hash of the project at runtime, but this won't work if you're using a `pip` installed package or working outside the git repo.

This replaces `setuptools-scm` with the alternative [`versioningit`](https://versioningit.readthedocs.io/en/stable/). It's more configurable than `setuptools-scm`, and allows you to set a template for the `_version.py` file. I've configured it to mimic the `setuptools-scm` versioning scheme, and it will also store the full commit hash at build/install.

It may be possible to achieve the same outcome with `setuptools-scm`, but I wasn't able to figure it out from the docs.