### PR TITLE
Bugfix/eigenvalues units

### DIFF
--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -329,10 +329,10 @@ class Eigenvalues(GKOutputArgs):
     non-optional.
     """
 
-    #: Units of ``[lref / vref]``.
+    #: Units of ``[vref / lref]``.
     growth_rate: ArrayLike
 
-    #: Units of ``[lref / vref]``.
+    #: Units of ``[vref / lref]``.
     mode_frequency: ArrayLike
 
     _has_normalised_units: ClassVar[Tuple[str, ...]] = ("growth_rate", "mode_frequency")
@@ -343,7 +343,7 @@ class Eigenvalues(GKOutputArgs):
 
     def units(self, name: str, c: ConventionNormalisation) -> pint.Unit:
         """Return units for a given convention"""
-        return c.lref / c.vref
+        return c.vref / c.lref
 
     def __post_init__(self, dims):
         self._set_and_check_dims(dims)

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -8,6 +8,7 @@ import xarray as xr
 import numpy as np
 import pytest
 from types import SimpleNamespace as basic_object
+import netCDF4 as nc
 
 
 @pytest.fixture(scope="module")
@@ -81,6 +82,36 @@ def test_infer_path_from_input_file_gs2():
     input_path = Path("dir/to/input_file.in")
     output_path = GKOutputReaderGS2.infer_path_from_input_file(input_path)
     assert output_path == Path("dir/to/input_file.out.nc")
+
+
+def test_gs2_read_omega_file(tmp_path):
+    """Can we match growth rate/frequency from netCDF file"""
+
+    path = template_dir / "outputs" / "GS2_linear"
+    pyro = Pyro(gk_file=path / "gs2.in", name="test_gk_output_gs2")
+    pyro.load_gk_output()
+
+    netcdf_data = nc.Dataset(template_dir / "outputs" / "GS2_linear" / "gs2.out.nc")
+
+    cdf_mode_freq = netcdf_data["omega"][-1, 0, 0, 0]
+    cdf_gamma = netcdf_data["omega"][-1, 0, 0, 1]
+
+    assert np.isclose(
+        pyro.gk_output.data["growth_rate"]
+        .isel(time=-1, ky=0, kx=0)
+        .data.to(pyro.norms.gs2)
+        .m,
+        cdf_gamma,
+        rtol=0.1,
+    )
+    assert np.isclose(
+        pyro.gk_output.data["mode_frequency"]
+        .isel(time=-1, ky=0, kx=0)
+        .data.to(pyro.norms.gs2)
+        .m,
+        cdf_mode_freq,
+        rtol=0.1,
+    )
 
 
 # Golden answer tests

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -91,10 +91,9 @@ def test_gs2_read_omega_file(tmp_path):
     pyro = Pyro(gk_file=path / "gs2.in", name="test_gk_output_gs2")
     pyro.load_gk_output()
 
-    netcdf_data = nc.Dataset(template_dir / "outputs" / "GS2_linear" / "gs2.out.nc")
-
-    cdf_mode_freq = netcdf_data["omega"][-1, 0, 0, 0]
-    cdf_gamma = netcdf_data["omega"][-1, 0, 0, 1]
+    with nc.Dataset(path / "gs2.out.nc") as netcdf_data:
+        cdf_mode_freq = netcdf_data["omega"][-1, 0, 0, 0]
+        cdf_gamma = netcdf_data["omega"][-1, 0, 0, 1]
 
     assert np.isclose(
         pyro.gk_output.data["growth_rate"]


### PR DESCRIPTION
How this slipped through the cracks I have no idea (though I do outline how below). The growth rate and frequency had inverted units 😱 

Essentially we normally calculate the eigenvalues directly from the fields and in doing so we dropped the units during the calculation (because `phi` `apar` and `bpar` have different units) and then apply the units back on afterwards. So the actual value of the growth rate and frequency was technically correct but if we were to convert the output to a different convention then it would convert the wrong way. But as long as you didn't want to convert the units to a different normalisation you would be fine.

However, this bug is particularly bad when you would not be able to get the eigenvalues from the fields so would read from the gk output directly. In that case it reads in the eigenvalues, applies the code's local convention and then tries to convert it to the pyro convention and that would fail to give you the correct value.

In #325 we created the option to specify the Convention of the outputs in Pyro for GKW so this becomes even more likely to be an issue and in #301 we actually need to convert from pyro to GKW convention.

The fix is straightforward and a test has been included to directly compare to the GS2 output omega. The tolerance is reasonably high due to the fact that this run has not converged but before they would be different by a factor ~4
