### PR TITLE
Bugfix/gene dpdx pm sign

### DIFF
--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -695,7 +695,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         self.data["geometry"]["amhd"] = (
             -(local_geometry.q**2) * local_geometry.Rmaj * local_geometry.beta_prime
         )
-        self.data["geometry"]["dpdx_pm"] = local_geometry.beta_prime
+        self.data["geometry"]["dpdx_pm"] = -local_geometry.beta_prime
 
         self.data["geometry"]["trpeps"] = local_geometry.rho / local_geometry.Rmaj
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -286,7 +286,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         elif dpdx == -2:
             local_geometry_data["beta_prime"] = amhd_beta_prime
         else:
-            local_geometry_data["beta_prime"] = dpdx
+            local_geometry_data["beta_prime"] = -dpdx
 
         if not np.isclose(local_geometry_data["beta_prime"], amhd_beta_prime):
             warnings.warn(


### PR DESCRIPTION
`dpdx_pm = -beta_prime` in GENE, minus sign was missing. Warning comes up but no errors occur because of it so it passed the testing.

`UserWarning: GENE dpdx_pm = 0.5045 not set consistently with amhd = -0.5045000005976776 - drifts may not behave as expected`

This fixes that