### PR TITLE
Update publishing workflow

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: docs/joss/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m twine check dist/*
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -41,7 +41,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download distribution packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -1,28 +1,49 @@
-name: Upload Python Package
+name: Build/publish Python Package
 
-on:
-  release:
-    types: [published]
+on: push
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build twine
       - name: Build package
-        run: python -m build --sdist --wheel
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: |
+          python -m build --sdist --wheel
+      - name: Check package
+        run: |
+          python -m twine check dist/*
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_DEPLOYMENT_TOKEN }}
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyrokinetics
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pytest --cov=pyrokinetics --cov-report=xml --cov-report=term -vv ./tests
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('coverage-python-{0}', matrix.python-version) }}
         path: coverage.xml
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download coverage report
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: "coverage-python-3.10"
         path: coverage.xml


### PR DESCRIPTION
In advance of our imminent next release (Issue https://github.com/pyro-kinetics/pyrokinetics/issues/316), I've updated the PyPI publishing workflow to meet the new standards. The previous method of storing PyPI usernames and passwords with GitHub secrets is now obsolete, and PyPI now prefers to use 'trusted publishers' -- [this page](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) explains how to configure everything. I think @bpatel2107 or @ZedThree will have to configure things on the PyPI side.

Things changed in this update:
- Now builds a distribution on every push
- Calls `twine check` to ensure the packages are being built correctly
- Uploads built packages as an artefact which can be downloaded from the action
- Introduces a second job which publishes on new releases
- Publishing _will not work anymore_ unless trusted publishers are set up