### PR TITLE
Definition of inverse_lp was reverted accidentally when adding GKW. T…

### DIFF
--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -191,9 +191,10 @@ class LocalSpecies(CleverDict):
 
         self["pressure"] = pressure
 
-        if hasattr(inverse_lp, "magnitude"):
-            # Cancel out units from pressure
-            inverse_lp = inverse_lp.magnitude * species["inverse_lt"].units
+        if pressure != 0.0:
+            inverse_lp = inverse_lp / pressure * species["inverse_lt"].units
+        else:
+            inverse_lp = 0.0
 
         self["inverse_lp"] = inverse_lp
 

--- a/tests/gk_code/test_gk_input_cgyro.py
+++ b/tests/gk_code/test_gk_input_cgyro.py
@@ -1,5 +1,5 @@
 from pyrokinetics.gk_code import GKInputCGYRO
-from pyrokinetics import template_dir
+from pyrokinetics import template_dir, Pyro
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
@@ -108,3 +108,13 @@ def test_write(tmp_path, cgyro):
     assert local_species.nspec == new_local_species.nspec
     new_numerics = cgyro_reader.get_numerics()
     assert numerics.delta_time == new_numerics.delta_time
+
+
+def test_beta_star_scale(tmp_path):
+    pyro = Pyro(gk_file=template_dir / "input.gs2")
+
+    pyro.gk_code = "CGYRO"
+
+    pyro.write_gk_file(tmp_path / "input.cgyro")
+
+    assert pyro.gk_input.data["BETA_STAR_SCALE"] == 1.0


### PR DESCRIPTION
…est added to check it is correct using beta_star_scale in CGYRO

Accidentally reverted `local_species.inverse_lp` to its previous (wrong) definition without the pressure in 706af8d41cc6d1d7ba0ddd02d4d260102eac2ba3 so we revert and as a quick test by looking at `beta_star_scale` in CGYRO which should be 1 when converting from the GS2 template file.