### PR TITLE
Drop units in directory name when making Pyroscan with pint Quantity

### DIFF
--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -1,5 +1,6 @@
 from pyrokinetics.pyroscan import PyroScan
 from pyrokinetics import Pyro
+from pyrokinetics.units import ureg as units
 
 from pathlib import Path
 import numpy as np
@@ -54,6 +55,17 @@ def test_format_run_name():
     scan = PyroScan(Pyro(gk_code="GS2"), value_separator="|", parameter_separator="@")
 
     assert scan.format_single_run_name({"ky": 0.1, "nx": 55}) == "ky|0.10@nx|55.00"
+
+
+def test_format_run_name_units():
+    scan = PyroScan(Pyro(gk_code="GS2"), value_separator="|", parameter_separator="@")
+
+    assert (
+        scan.format_single_run_name(
+            {"ky": 0.1 * units.rhoref_pyro**-1, "nx": 55 * units.dimensionless}
+        )
+        == "ky|0.10@nx|55.00"
+    )
 
 
 def test_create_single_run():


### PR DESCRIPTION
When creating a `Pyroscan` object the directories being created were including the unit names if they were defined in the scan parameters which made a mess of things . Now we drop the units and a unit test has been added.

```python
from pyrokinetics import Pyro, PyroScan, template_dir
from pyrokinetics.units import ureg as units
import numpy as np

# Equilibrium file
eq_file = template_dir / "test.geqdsk"

# Kinetics data file
kinetics_file = template_dir / "jetto.jsp"

# Load up pyro object
pyro = Pyro(
    eq_file=eq_file,
    eq_type="GEQDSK",
    kinetics_file=kinetics_file,
    kinetics_type="JETTO",
)

# Generate local parameters at psi_n=0.5
pyro.load_local(psi_n=0.5, local_geometry="Miller")

# Change GK code to GS2
pyro.gk_code = "GS2"

# GS2 template input file
template_file = template_dir / "input.gs2"

# Write single input file using my own template
pyro.write_gk_file(file_name="test_jetto.gs2", template_file=template_file)

# Use existing parameter
param_1 = "ky"
values_1 = np.arange(0.1, 0.3, 0.1) * units.rhoref_pyro**-1

# Dictionary of param and values
param_dict = {param_1: values_1}

# Create PyroScan object
pyro_scan = PyroScan(
    pyro,
    param_dict,
    value_fmt=".3f",
    value_separator="_",
    parameter_separator="_",
    file_name="mygs2.in",
    base_directory="test_GS2",
)

pyro_scan.write()

```

Would make the directory `scan/ky_0.1 / rhoref_pyro` which is clearly wrong.

Also added a few `missing_dims="ignore"` in the cases where the `GKOutput` just doesn't have that dimension (usually `time` in linear runs)