### PR TITLE
Add correct mass factor in rhoref scaling

### DIFF
--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -439,7 +439,7 @@ class SimulationNormalisation(Normalisation):
         )
 
         vref_multiplier = (md / te) ** 0.5
-        rho_ref_multiplier = vref_multiplier * rgeo_rmaj
+        rho_ref_multiplier = vref_multiplier * rgeo_rmaj / md
 
         if te != 1.0 or md != 1.0:
             vref_base = f"vref_{convention_dict['vref']}"

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -622,7 +622,7 @@ def test_non_standard_normalisation_mass(gk_code, geometry_sim_units):
 
             norm.set_ref_ratios(local_geometry=geometry_sim_units)
             assert np.isclose(
-                mass_md**-0.5 * norm.nonstandard.rhoref,
+                mass_md**0.5 * norm.nonstandard.rhoref,
                 (1.0 * getattr(norm, gk_code.lower()).rhoref).to(
                     norm.nonstandard.rhoref, norm.context
                 ),


### PR DESCRIPTION
`rhoref` scaling was missing a factor mass when defining a custom `rhoref`. 

$\rho_{ref} = \frac{m_{ref}v_{ref}}{B_{ref}q_{ref}}$