### PR TITLE
Bugfix: unit conversions using simulation units

### DIFF
--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -340,7 +340,7 @@ class LocalGeometry:
             attribute = getattr(self, key)
 
             if hasattr(attribute, "units"):
-                new_attr = attribute.to(val)
+                new_attr = attribute.to(val, norms.context)
             elif attribute is not None:
                 new_attr = attribute * val
 

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -97,7 +97,7 @@ class LocalSpecies(CleverDict):
             inverse_lt = species_data.get_norm_temp_gradient(psi_n)
             inverse_ln = species_data.get_norm_dens_gradient(psi_n)
             domega_drho = species_data.get_angular_velocity(psi_n).to(
-                norm.vref / norm.lref
+                norm.vref / norm.lref, norm.context
             ) * species_data.get_norm_ang_vel_gradient(psi_n).to(
                 norm.lref**-1, norm.context
             )
@@ -206,12 +206,16 @@ class LocalSpecies(CleverDict):
 
         for name in self.names:
             species_data = self[name]
-            species_data["mass"] = species_data["mass"].to(norms.mref)
-            species_data["z"] = species_data["z"].to(norms.qref)
-            species_data["dens"] = species_data["dens"].to(norms.nref)
-            species_data["temp"] = species_data["temp"].to(norms.tref)
-            species_data["omega0"] = species_data["omega0"].to(norms.vref / norms.lref)
-            species_data["nu"] = species_data["nu"].to(norms.vref / norms.lref)
+            species_data["mass"] = species_data["mass"].to(norms.mref, norms.context)
+            species_data["z"] = species_data["z"].to(norms.qref, norms.context)
+            species_data["dens"] = species_data["dens"].to(norms.nref, norms.context)
+            species_data["temp"] = species_data["temp"].to(norms.tref, norms.context)
+            species_data["omega0"] = species_data["omega0"].to(
+                norms.vref / norms.lref, norms.context
+            )
+            species_data["nu"] = species_data["nu"].to(
+                norms.vref / norms.lref, norms.context
+            )
 
             # Gradients use lref_minor_radius -> Need to switch to this norms lref using context
             species_data["inverse_lt"] = species_data["inverse_lt"].to(

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -49,13 +49,12 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
         if (self == 0.0).all():
             return 0.0 * value.units
         # If everything is a NaN then conversion failed or data was
-        # all NaN to begin with. Checks is all data is now a NaN
+        # all NaN to begin with. Checks if all data is now a NaN
         # but was not before, otherwise some
         # NaNs exist in the data and we can proceed
         if np.isnan(value).all() and not np.isnan(self).all():
             raise PyroNormalisationError(system, self.units)
-        else:
-            return value
+        return value
 
     def to_base_units(self, system: Optional[str] = None):
         with self._REGISTRY.as_system(system):
@@ -106,8 +105,11 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
     def to(self, other=None, *contexts, **ctx_kwargs):
         """Return Quantity rescaled to other units or normalisation
 
-        Raises `PyroNormalisationError` if value is NaN, as this
-        indicates required physical reference values are missing
+        Raises
+        ------
+        PyroNormalisationError
+            If ``other`` is a :class:`Normalisation` and the value cannot be converted.
+            This indicates required physical reference values are missing
         """
 
         if isinstance(other, Normalisation):

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -11,10 +11,14 @@ def test_normalise():
 
     Rmaj = geometry.Rmaj
     a_minor = geometry.a_minor
+    assert Rmaj.units == norms.units.lref_minor_radius
+    assert a_minor.units == norms.units.lref_minor_radius
 
     # Convert to a different units standard
     # LocalGeometry.normalise() is an in-place operation
     geometry.normalise(norms.gene)
     assert np.isfinite(geometry.Rmaj.magnitude)
     assert np.isfinite(geometry.a_minor.magnitude)
+    assert geometry.Rmaj.units == norms.units.lref_major_radius
+    assert geometry.a_minor.units == norms.units.lref_major_radius
     assert (geometry.Rmaj / geometry.a_minor) == (Rmaj / a_minor)

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+import pyrokinetics as pk
+
+
+def test_normalise():
+    """Test that a local geometry can be renormalised with simulation units."""
+    pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])
+    geometry = pyro.local_geometry
+    norms = pyro.norms
+
+    Rmaj = geometry.Rmaj
+    a_minor = geometry.a_minor
+
+    # Convert to a different units standard
+    # LocalGeometry.normalise() is an in-place operation
+    geometry.normalise(norms.gene)
+    assert np.isfinite(geometry.Rmaj.magnitude)
+    assert np.isfinite(geometry.a_minor.magnitude)
+    assert (geometry.Rmaj / geometry.a_minor) == (Rmaj / a_minor)

--- a/tests/test_local_species.py
+++ b/tests/test_local_species.py
@@ -1,6 +1,7 @@
 import itertools
 from typing import Dict, List
 
+import pyrokinetics as pk
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.normalisation import ureg as units
 
@@ -157,3 +158,20 @@ def test_merge_fuel_impurity(
             simple_local_species["deuterium"].z.magnitude,
             (2.0 / 3 + 6.0 / 27) / (2.0 / 3 + 1.0 / 27),
         )
+
+
+def test_normalisation():
+    """Test that a local species can be renormalised with simulation units."""
+    pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])
+    geometry = pyro.local_geometry
+    species = pyro.local_species
+    norms = pyro.norms
+
+    nu = species["electron"].nu
+    aspect_ratio = (geometry.Rmaj / geometry.a_minor).magnitude
+
+    # Convert to a different units standard
+    # LocalSpecies.normalise() is an in-place operation
+    species.normalise(norms.gene)
+    assert np.isfinite(species["electron"].nu.magnitude)
+    assert species["electron"].nu.magnitude / aspect_ratio == nu.magnitude


### PR DESCRIPTION
I've been experimenting with ways to keep units consistent across many simulations (Issue https://github.com/pyro-kinetics/pyrokinetics/issues/337) while also removing the need to repeatedly rebuild the pint units cache, which is significantly slowing down our tests (Issue https://github.com/pyro-kinetics/pyrokinetics/issues/326). I should have something to show for it shortly, but it's definitely something that should wait until after our next release.

In the process of this work, I found a bug in the `LocalGeometry` normalisation function:

```
>>> import pyrokinetics as pk
>>> pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])
>>> pyro.local_geometry
<class 'pyrokinetics.local_geometry.miller.LocalGeometryMiller'>(
type  = Miller,
psi_n = 0.5 dimensionless
rho = 0.5 lref_minor_radius
Rmaj = 3.0 lref_minor_radius
Z0 = 0.0 lref_minor_radius
a_minor = 1.0 lref_minor_radius
Fpsi = 0.0 bref_B0 * lref_minor_radius
B0 = 14.142135623730951 bref_B0
q = 2.0 dimensionless
shat = 1.0 dimensionless
beta_prime = -0.04 bref_B0 ** 2 / lref_minor_radius
dpsidr = 0.253546276418555 bref_B0 * lref_minor_radius
bt_ccw = 1 dimensionless
ip_ccw = 1 dimensionless
kappa = 1.0 dimensionless
s_kappa = 0.0 dimensionless
delta = 0.0 dimensionless
s_delta = 0.0 dimensionless
shift = 0.0 dimensionless
dZ0dr = 0.0 dimensionless
bunit_over_b0 = 1.01418510567422 dimensionless
>>> pyro.local_geometry.normalise(pyro.norms.gene)
>>> pyro.local_geometry
<class 'pyrokinetics.local_geometry.miller.LocalGeometryMiller'>(
type  = Miller,
psi_n = 0.5 dimensionless
rho = nan lref_major_radius
Rmaj = nan lref_major_radius
Z0 = nan lref_major_radius
a_minor = nan lref_major_radius
Fpsi = nan bref_B0 * lref_major_radius
B0 = 14.142135623730951 bref_B0
q = 2.0 dimensionless
shat = 1.0 dimensionless
beta_prime = nan bref_B0 ** 2 / lref_major_radius
dpsidr = nan bref_B0 * lref_major_radius
bt_ccw = 1 dimensionless
ip_ccw = 1 dimensionless
kappa = 1.0 dimensionless
s_kappa = 0.0 dimensionless
delta = 0.0 dimensionless
s_delta = 0.0 dimensionless
shift = 0.0 dimensionless
dZ0dr = 0.0 dimensionless
bunit_over_b0 = 1.01418510567422 dimensionless
```

All quantities that depend on `lref` are set to `nan` after normalising to a convention that doesn't use `lref_minor_radius`. This PR fixes that so that the aspect ratio is taken into account during the conversion. I've implemented similar fixes for `LocalGeometry` and `LocalSpecies`.