### PR TITLE
Bugfix: Pin `idspy-dictionaries` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pint-xarray ~= 0.3",
     "contourpy ~= 1.0",
     "xrft >= 1.0.0",
-    "idspy-dictionaries >= 34000.2.0",
+    "idspy-dictionaries == 34000.2.0",
     "idspy-toolkit == 0.6.5",
     "pyloidal ~= 0.2.0",
     "xmltodict ~= 0.13.0",


### PR DESCRIPTION
In PR https://github.com/pyro-kinetics/pyrokinetics/pull/357, all tests passed following the final push (https://github.com/pyro-kinetics/pyrokinetics/actions/runs/9372068998/job/25802746935). They then failed during the merge (https://github.com/pyro-kinetics/pyrokinetics/actions/runs/9415332642/job/25936125182), as `idspy-dictionaries` released a new version which is incompatible with our existing test data.

I'm not sure how to fix this one, but given our version of `idspy-toolkit` is pinned, the easiest solution was to pin `idspy-dictionaries` to the previous version. Perhaps we could raise an issue and come up with a longer term solution later?