### PR TITLE
Feature/gene trpeps geometry file

### DIFF
--- a/docs/examples/example_imas.py
+++ b/docs/examples/example_imas.py
@@ -123,7 +123,7 @@ def compare_pyro_run_nl(og_pyro, new_pyro, code):
 reference_values = {
     "tref_electron": 1000.0 * units.eV,
     "nref_electron": 1e19 * units.meter ** -3,
-    "lref_minor_radius": 1.5 * units.meter,
+    "lref_major_radius": 3.0 * units.meter,
     "bref_B0": 2.0 * units.tesla,
 }
 

--- a/docs/examples/example_imas.py
+++ b/docs/examples/example_imas.py
@@ -122,7 +122,7 @@ def compare_pyro_run_nl(og_pyro, new_pyro, code):
 
 reference_values = {
     "tref_electron": 1000.0 * units.eV,
-    "nref_electron": 1e19 * units.meter ** -3,
+    "nref_electron": 1e19 * units.meter**-3,
     "lref_major_radius": 3.0 * units.meter,
     "bref_B0": 2.0 * units.tesla,
 }
@@ -221,7 +221,7 @@ ids = pyro_to_ids(
     reference_values=reference_values,
     format="hdf5",
     file_name="cgyro_nl_test.hdf5",
-    time_interval=[0, 1]
+    time_interval=[0, 1],
 )
 
 new_pyro = ids_to_pyro("cgyro_nl_test.hdf5")

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -256,7 +256,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         if original_filename.suffix:
             suffix = original_filename.suffix
         else:
-            filename_split = self.original_filename.split("_")
+            filename_split = original_filename.name.split("_")
             if len(filename_split) > 1:
                 suffix = f"_{filename_split[-1]}"
             else:

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -1193,6 +1193,7 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         input_str = input_str.replace(")", "")
         gk_input = GKInputGENE()
         gk_input.read_str(input_str)
+        gk_input.original_filename = filename
         gk_input._detect_normalisation()
 
         species_names = [species["name"] for species in gk_input.data["species"]]

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -165,6 +165,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         """
 
         # TODO Hacky fix in erroneous brackets from GENE v3.0
+        self.original_filename = filename
         read_str = False
         with open(filename, "r") as f:
             filedata = f.readlines()
@@ -248,6 +249,14 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         Returns local geometry. Delegates to more specific functions
         """
         geometry_type = self.data["geometry"]["magn_geometry"]
+
+        original_filename = Path(self.original_filename)
+        geometry_filename = (original_filename.parent / geometry_type).with_suffix(original_filename.suffix)
+        if geometry_filename.exists():
+            direct_geometry_nml = f90nml.read(geometry_filename)
+        else:
+            direct_geometry_nml = None
+
         if geometry_type == "miller":
             if (
                 self.data["geometry"].get("zeta", 0.0) != 0.0
@@ -304,9 +313,15 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         local_geometry_data["Rmaj"] = self.data["geometry"].get(
             "major_r", 1.0
         ) / self.data["geometry"].get("minor_r", 1.0)
-        local_geometry_data["rho"] = (
-            self.data["geometry"].get("trpeps", 0.0) * local_geometry_data["Rmaj"]
-        )
+
+        if direct_geometry_nml:
+            local_geometry_data["rho"] = (
+                direct_geometry_nml["parameters"]["trpeps"] * local_geometry_data["Rmaj"]
+            )
+        else:
+            local_geometry_data["rho"] = (
+                    self.data["geometry"].get("trpeps", 0.0) * local_geometry_data["Rmaj"]
+            )
 
         # Need to add in factor of rho
         if geometry_type == "miller_mxh":
@@ -392,8 +407,17 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             "external_contr", {"ExBrate": 0.0, "Omega0_tor": 0.0, "pfsrate": 0.0}
         )
 
+        geometry_type = self.data["geometry"]["magn_geometry"]
+        original_filename = Path(self.original_filename)
+        geometry_filename = (original_filename.parent / geometry_type ).with_suffix(original_filename.suffix)
+        if geometry_filename.exists():
+            direct_geometry_nml = f90nml.read(geometry_filename)
+            trpeps = direct_geometry_nml["parameters"]["trpeps"]
+        else:
+            trpeps = self.data["geometry"].get("trpeps", 0.0)
+
         rho = (
-            self.data["geometry"].get("trpeps", 0.0)
+            trpeps
             * self.data["geometry"].get("major_r", 1.0)
             / self.data["geometry"].get("minor_r", 1.0)
         )
@@ -1091,8 +1115,8 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         return files
 
     @staticmethod
-    def _get_gene_mom_files(
-        filename: PathLike, files: Dict, species_names
+    def _get_gene_mom_geo_files(
+        filename: PathLike, files: Dict, species_names, geometry_type
     ) -> Dict[str, Path]:
         """
         Given a directory name, looks for the files filename/parameters_0000,
@@ -1101,7 +1125,7 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         looks up the rest of the files in the same directory.
         """
         filename = Path(filename)
-        prefixes = [f"mom_{species_name}" for species_name in species_names]
+        prefixes = [f"mom_{species_name}" for species_name in species_names] + [geometry_type]
         if filename.is_dir():
             # If given a dir name, looks for dir/parameters_0000
             dirname = filename
@@ -1165,7 +1189,8 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         gk_input._detect_normalisation()
 
         species_names = [species["name"] for species in gk_input.data["species"]]
-        files = cls._get_gene_mom_files(filename, files, species_names)
+        geometry_type = gk_input.data["geometry"]["magn_geometry"]
+        files = cls._get_gene_mom_geo_files(filename, files, species_names, geometry_type)
         # Defer processing field and flux data until their respective functions
         # Simply return files in place of raw data
         return files, gk_input, input_str

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -251,7 +251,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         geometry_type = self.data["geometry"]["magn_geometry"]
 
         original_filename = Path(self.original_filename)
-        geometry_filename = (original_filename.parent / geometry_type).with_suffix(original_filename.suffix)
+        geometry_filename = (original_filename.parent / geometry_type).with_suffix(
+            original_filename.suffix
+        )
         if geometry_filename.exists():
             direct_geometry_nml = f90nml.read(geometry_filename)
         else:
@@ -316,11 +318,12 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         if direct_geometry_nml:
             local_geometry_data["rho"] = (
-                direct_geometry_nml["parameters"]["trpeps"] * local_geometry_data["Rmaj"]
+                direct_geometry_nml["parameters"]["trpeps"]
+                * local_geometry_data["Rmaj"]
             )
         else:
             local_geometry_data["rho"] = (
-                    self.data["geometry"].get("trpeps", 0.0) * local_geometry_data["Rmaj"]
+                self.data["geometry"].get("trpeps", 0.0) * local_geometry_data["Rmaj"]
             )
 
         # Need to add in factor of rho
@@ -409,7 +412,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         geometry_type = self.data["geometry"]["magn_geometry"]
         original_filename = Path(self.original_filename)
-        geometry_filename = (original_filename.parent / geometry_type ).with_suffix(original_filename.suffix)
+        geometry_filename = (original_filename.parent / geometry_type).with_suffix(
+            original_filename.suffix
+        )
         if geometry_filename.exists():
             direct_geometry_nml = f90nml.read(geometry_filename)
             trpeps = direct_geometry_nml["parameters"]["trpeps"]
@@ -1125,7 +1130,9 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         looks up the rest of the files in the same directory.
         """
         filename = Path(filename)
-        prefixes = [f"mom_{species_name}" for species_name in species_names] + [geometry_type]
+        prefixes = [f"mom_{species_name}" for species_name in species_names] + [
+            geometry_type
+        ]
         if filename.is_dir():
             # If given a dir name, looks for dir/parameters_0000
             dirname = filename
@@ -1190,7 +1197,9 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
 
         species_names = [species["name"] for species in gk_input.data["species"]]
         geometry_type = gk_input.data["geometry"]["magn_geometry"]
-        files = cls._get_gene_mom_geo_files(filename, files, species_names, geometry_type)
+        files = cls._get_gene_mom_geo_files(
+            filename, files, species_names, geometry_type
+        )
         # Defer processing field and flux data until their respective functions
         # Simply return files in place of raw data
         return files, gk_input, input_str

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -590,12 +590,12 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         norms = {}
 
-        if "minor_r" in self.data["geometry"]:
-            lref_scale = self.data["geometry"]["minor_r"]
-            lref_key = "minor_radius"
-        elif "major_R" in self.data["geometry"]:
+        if "major_R" in self.data["geometry"]:
             lref_scale = self.data["geometry"]["major_R"]
             lref_key = "major_radius"
+        elif "minor_r" in self.data["geometry"]:
+            lref_scale = self.data["geometry"]["minor_r"]
+            lref_key = "minor_radius"
 
         norms["tref_electron"] = self.data["units"]["Tref"] * local_norm.units.keV
         norms["nref_electron"] = (
@@ -603,7 +603,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         )
         norms["bref_B0"] = self.data["units"]["Bref"] * local_norm.units.tesla
         norms[f"lref_{lref_key}"] = (
-            self.data["units"]["lref"] * local_norm.units.meter / lref_scale
+            self.data["units"]["lref"] * local_norm.units.meter * lref_scale
         )
 
         return norms

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -251,9 +251,19 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         geometry_type = self.data["geometry"]["magn_geometry"]
 
         original_filename = Path(self.original_filename)
-        geometry_filename = (original_filename.parent / geometry_type).with_suffix(
-            original_filename.suffix
-        )
+        prefix = original_filename.parent / geometry_type
+
+        if original_filename.suffix:
+            suffix = original_filename.suffix
+        else:
+            filename_split = self.original_filename.split("_")
+            if len(filename_split) > 1:
+                suffix = f"_{filename_split[-1]}"
+            else:
+                suffix = ""
+
+        geometry_filename = Path(f"{str(prefix)}{suffix}")
+
         if geometry_filename.exists():
             direct_geometry_nml = f90nml.read(geometry_filename)
         else:

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -806,12 +806,12 @@ class SimulationNormalisation(Normalisation):
                 )
         elif lref_minor_radius:
             lref_major_radius = lref_minor_radius * pyro.local_geometry.Rmaj.to(
-                self.pyrokinetics.lref, self.context
-            )
+                self.gene.lref, self.context
+            ).m
         elif lref_major_radius:
             lref_minor_radius = lref_major_radius / pyro.local_geometry.Rmaj.to(
-                self.gene.lref
-            )
+                self.pyrokinetics.lref, self.context
+            ).m
 
         self.define(f"lref_minor_radius_{self.name} = {lref_minor_radius}", units=True)
         self.define(f"lref_major_radius_{self.name} = {lref_major_radius}", units=True)

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -805,13 +805,15 @@ class SimulationNormalisation(Normalisation):
                     "Specified major radius and minor radius do not match, please check the data"
                 )
         elif lref_minor_radius:
-            lref_major_radius = lref_minor_radius * pyro.local_geometry.Rmaj.to(
-                self.gene.lref, self.context
-            ).m
+            lref_major_radius = (
+                lref_minor_radius
+                * pyro.local_geometry.Rmaj.to(self.gene.lref, self.context).m
+            )
         elif lref_major_radius:
-            lref_minor_radius = lref_major_radius / pyro.local_geometry.Rmaj.to(
-                self.pyrokinetics.lref, self.context
-            ).m
+            lref_minor_radius = (
+                lref_major_radius
+                / pyro.local_geometry.Rmaj.to(self.pyrokinetics.lref, self.context).m
+            )
 
         self.define(f"lref_minor_radius_{self.name} = {lref_minor_radius}", units=True)
         self.define(f"lref_major_radius_{self.name} = {lref_major_radius}", units=True)


### PR DESCRIPTION
Adds ability to read in `trpeps` from the geometry output file (`miller.dat`, `circular.dat`, `tracer_efit.dat`). 

It seems that when using `tracer_efit` geometry `trpeps` isn't written in the `parameters.dat` file (this seems like a bug tbh) so it needs to be read in from `magn_geometry` file. This adds that in.

Note this currently looks for files with the same extension as the input file so if you do 
`pyro = Pyro(gk_file="parameters")`

It would look for a file called `tracer_efit`, which won't exist.

If you do `pyro = Pyro(gk_file="parameters.dat")`, it will look for `tracer_efit.dat`. Basically this only really works if you specify the extension. We could search for the geometry file so it would work for just `parameters` if need be, so let me know if anyone would prefer that.