### PR TITLE
Add units to eigenfunctions when loaded manually

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -956,7 +956,9 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 else None
             ),
             eigenfunctions=(
-                None if eigenfunctions is None else Eigenfunctions(eigenfunctions)
+                None
+                if eigenfunctions is None
+                else Eigenfunctions(eigenfunctions).with_units(convention)
             ),
             linear=coords["linear"],
             gk_code="CGYRO",

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -359,6 +359,8 @@ class Eigenfunctions(GKOutputArgs):
     #: The dimensionality of the eigenfunctions. Should match ``data``.
     dims: dataclasses.InitVar[Tuple[str, ...]] = ("field", "theta", "kx", "ky", "time")
 
+    _has_normalised_units: ClassVar[Tuple[str, ...]] = ("eigenfunctions",)
+
     def units(self, name: str, c: ConventionNormalisation) -> pint.Unit:
         """Return units for a given convention"""
         return units.dimensionless

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -882,7 +882,9 @@ class GKOutputReaderGKW(FileReader, file_type="GKW", reads=GKOutput):
             eigenfunctions=(
                 None
                 if eigenfunctions is None
-                else Eigenfunctions(eigenfunctions, dims=eigenfunction_dims)
+                else Eigenfunctions(eigenfunctions, dims=eigenfunction_dims).with_units(
+                    convention
+                )
             ),
             linear=coords["linear"],
             gk_code="GKW",

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -965,7 +965,9 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
             eigenfunctions=(
                 None
                 if eigenfunctions is None
-                else Eigenfunctions(eigenfunctions, dims=("field", "theta", "kx", "ky"))
+                else Eigenfunctions(
+                    eigenfunctions, dims=("field", "theta", "kx", "ky")
+                ).with_units(convention)
             ),
             linear=coords["linear"],
             gk_code="GS2",

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -709,7 +709,9 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
             eigenfunctions=(
                 None
                 if eigenfunctions is None
-                else Eigenfunctions(eigenfunctions, dims=eigenfunctions_dims)
+                else Eigenfunctions(
+                    eigenfunctions, dims=eigenfunctions_dims
+                ).with_units(convention)
             ),
             linear=coords["linear"],
             gk_code="TGLF",

--- a/tests/gk_code/test_gk_output_reader_cgyro.py
+++ b/tests/gk_code/test_gk_output_reader_cgyro.py
@@ -167,4 +167,5 @@ def test_amplitude(load_fields):
     amplitude = np.sqrt(
         field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
     )
+    assert hasattr(eigenfunctions.data, "units")
     assert np.isclose(ureg.Quantity(amplitude.data).magnitude, 1.0)

--- a/tests/gk_code/test_gk_output_reader_gene.py
+++ b/tests/gk_code/test_gk_output_reader_gene.py
@@ -192,6 +192,7 @@ def test_amplitude(load_fields):
     amplitude = np.sqrt(
         field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
     )
+    assert hasattr(eigenfunctions.data, "units")
     assert np.isclose(ureg.Quantity(amplitude.data).magnitude, 1.0)
 
 

--- a/tests/gk_code/test_gk_output_reader_gkw.py
+++ b/tests/gk_code/test_gk_output_reader_gkw.py
@@ -181,4 +181,5 @@ def test_amplitude(load_fields):
     amplitude = np.sqrt(
         field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
     )
+    assert hasattr(eigenfunctions.data, "units")
     assert np.isclose(ureg.Quantity(amplitude.data).magnitude, 1.0)

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -210,6 +210,7 @@ def test_amplitude(load_fields):
         field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
     )
 
+    assert hasattr(eigenfunctions.data, "units")
     assert np.isclose(amplitude, 1.0)
 
 

--- a/tests/gk_code/test_gk_output_reader_stella.py
+++ b/tests/gk_code/test_gk_output_reader_stella.py
@@ -83,6 +83,32 @@ def test_infer_path_from_input_file_stella():
     assert output_path == Path("dir/to/input_file.out.nc")
 
 
+@pytest.mark.parametrize(
+    "load_fields",
+    [
+        True,
+    ],
+)
+def test_amplitude(load_fields):
+
+    path = template_dir / "outputs" / "STELLA_linear"
+
+    pyro = Pyro(gk_file=path / "stella.in")
+
+    pyro.load_gk_output(load_fields=load_fields)
+    eigenfunctions = pyro.gk_output.data["eigenfunctions"].isel(
+        time=-1, missing_dims="ignore"
+    )
+    field_squared = np.abs(eigenfunctions) ** 2
+
+    amplitude = np.sqrt(
+        field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
+    )
+
+    assert hasattr(eigenfunctions.data, "units")
+    assert np.isclose(amplitude, 1.0)
+
+
 def test_stella_read_omega_file(tmp_path):
     """Can we match growth rate/frequency from netCDF file"""
 

--- a/tests/gk_code/test_gk_output_reader_tglf.py
+++ b/tests/gk_code/test_gk_output_reader_tglf.py
@@ -6,6 +6,7 @@ import pytest
 from pyrokinetics import Pyro, template_dir
 from pyrokinetics.gk_code import GKOutputReaderTGLF
 from pyrokinetics.gk_code.gk_output import GKOutput
+from pyrokinetics.units import ureg
 
 # TODO mock output tests, similar to GS2
 
@@ -167,4 +168,5 @@ def test_amplitude(load_fields):
         field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
     )
 
-    assert np.isclose(amplitude, 1.0)
+    assert hasattr(eigenfunctions.data, "units")
+    assert np.isclose(ureg.Quantity(amplitude.data).magnitude, 1.0)


### PR DESCRIPTION
When loading in eigenfunctions manually (when the 4D fields are not available) units were not being added which made it fail when creating an IDS. That has been fixed now and tests have been added.

Fixes #360 