### PR TITLE
Add check for box_size when no kx is set with a test.

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -791,9 +791,12 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         if numerics.nonlinear:
             self.data["NONLINEAR_FLAG"] = 1
             self.data["N_RADIAL"] = numerics.nkx
-            self.data["BOX_SIZE"] = int(
-                (numerics.ky * 2 * pi * local_geometry.shat / numerics.kx) + 0.1
-            )
+            if numerics.kx == 0.0:
+                self.data["BOX_SIZE"] = 1
+            else:
+                self.data["BOX_SIZE"] = int(
+                    (numerics.ky * 2 * pi * local_geometry.shat / numerics.kx) + 0.1
+                )
         else:
             self.data["NONLINEAR_FLAG"] = 0
             self.data["N_RADIAL"] = numerics.nperiod * 2

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -794,9 +794,12 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             if abs(shat) < 1e-6:
                 self.data["kt_grids_box_parameters"]["x0"] = 2 * pi / numerics.kx
             else:
-                self.data["kt_grids_box_parameters"]["jtwist"] = int(
-                    (numerics.ky * shat * 2 * pi / numerics.kx) + 0.1
-                )
+                if numerics.kx == 0:
+                    self.data["kt_grids_box_parameters"]["jtwist"] = 1
+                else:
+                    self.data["kt_grids_box_parameters"]["jtwist"] = int(
+                        (numerics.ky * shat * 2 * pi / numerics.kx) + 0.1
+                    )
 
         self.data["theta_grid_parameters"]["ntheta"] = numerics.ntheta
 

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -690,9 +690,12 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             if abs(shat) < 1e-6:
                 self.data["kt_grids_box_parameters"]["x0"] = 2 * pi / numerics.kx
             else:
-                self.data["kt_grids_box_parameters"]["jtwist"] = int(
-                    (numerics.ky * shat * 2 * pi / numerics.kx) + 0.1
-                )
+                if numerics.kx == 0:
+                    self.data["kt_grids_box_parameters"]["jtwist"] = 1
+                else:
+                    self.data["kt_grids_box_parameters"]["jtwist"] = int(
+                        (numerics.ky * shat * 2 * pi / numerics.kx) + 0.1
+                    )
 
         self.data["zgrid_parameters"]["nzed"] = numerics.ntheta
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,4 +1,4 @@
-from pyrokinetics import Pyro
+from pyrokinetics import Pyro, template_dir
 from pyrokinetics.templates import gk_templates
 import numpy as np
 import pint
@@ -164,6 +164,23 @@ def test_compare_roundtrip(setup_roundtrip, gk_code_a, gk_code_b):
                 code_b.local_species[key],
                 pyro.norms,
             )
+
+
+@pytest.mark.parametrize("gk_code_out", ["CGYRO", "GS2", "STELLA", "GENE", "GKW"])
+def test_switch_code_nl_tglf(gk_code_out, tmp_path):
+    # Create directory to work in
+    tglf_input = template_dir / "outputs" / "TGLF_transport" / "input.tglf"
+
+    pyro = Pyro(gk_file=tglf_input)
+
+    gk_file_out = pathlib.Path(tmp_path / f"input.{gk_code_out.lower()}")
+    pyro.write_gk_file(
+        file_name=gk_file_out,
+        gk_code=gk_code_out,
+        template_file=gk_templates[gk_code_out],
+    )
+
+    assert gk_file_out.is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
TGLF doesn't set a kx grid which can break calculations of `BOX_SIZE` or `jtwist`. Here we check if `kx==0` and set the radial box multiplier to 1 in these cases.

Added a test to check this.