### PR TITLE
Remove extra species namelist from inputs when removed

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -746,7 +746,18 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                         self.data[val] = getattr(local_geometry, new_key)[index]
 
         # Kinetic data
-        self.data["N_SPECIES"] = local_species.nspec
+        n_species = local_species.nspec
+        self.data["N_SPECIES"] = n_species
+
+        stored_species = len([key for key in self.data.keys() if "DENS_" in key])
+        extra_species = stored_species - n_species
+
+        if extra_species > 0:
+            for i_sp in range(extra_species):
+                pyro_cgyro_species = self.get_pyro_cgyro_species(i_sp + 1 + n_species)
+                for cgyro_key in pyro_cgyro_species.values():
+                    if cgyro_key in self.data:
+                        self.data.pop(cgyro_key)
 
         for i_sp, name in enumerate(local_species.names):
             pyro_cgyro_species = self.get_pyro_cgyro_species(i_sp + 1)

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -1537,11 +1537,11 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
                             raw_moment = np.frombuffer(
                                 binary_moment, dtype=np.complex128
                             )
-                            sliced_moment[
-                                i_sp, i_moment, :, :, :, i_time
-                            ] = raw_moment.reshape(
-                                (nx, nky, nz),
-                                order="F",
+                            sliced_moment[i_sp, i_moment, :, :, :, i_time] = (
+                                raw_moment.reshape(
+                                    (nx, nky, nz),
+                                    order="F",
+                                )
                             )
                             file.seek(int_size, 1)
                         if i_time < ntime - 1:

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -827,7 +827,15 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         self.data["geometry"]["sign_Bt_CW"] = -1 * local_geometry.bt_ccw
 
         # Kinetic data
-        self.data["box"]["n_spec"] = local_species.nspec
+        n_species = local_species.nspec
+        self.data["box"]["n_spec"] = n_species
+
+        stored_species = len(self.data["species"])
+        extra_species = stored_species - n_species
+
+        if extra_species > 0:
+            for i in range(extra_species):
+                del self.data["species"][-1]
 
         iIon = 1
         for iSp, name in enumerate(local_species.names):
@@ -1529,11 +1537,11 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
                             raw_moment = np.frombuffer(
                                 binary_moment, dtype=np.complex128
                             )
-                            sliced_moment[i_sp, i_moment, :, :, :, i_time] = (
-                                raw_moment.reshape(
-                                    (nx, nky, nz),
-                                    order="F",
-                                )
+                            sliced_moment[
+                                i_sp, i_moment, :, :, :, i_time
+                            ] = raw_moment.reshape(
+                                (nx, nky, nz),
+                                order="F",
                             )
                             file.seek(int_size, 1)
                         if i_time < ntime - 1:

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -624,8 +624,16 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         self.data["spcgeneral"]["betaprime_type"] = "ref"
         self.data["spcgeneral"]["betaprime_ref"] = local_geometry.beta_prime
 
-        # species
-        self.data["gridsize"]["number_of_species"] = local_species.nspec
+        # Kinetic data
+        n_species = local_species.nspec
+        self.data["gridsize"]["number_of_species"] = n_species
+
+        stored_species = len(self.data["species"])
+        extra_species = stored_species - n_species
+
+        if extra_species > 0:
+            for i in range(extra_species):
+                del self.data["species"][-1]
 
         for iSp, name in enumerate(local_species.names):
             try:

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -590,8 +590,20 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
         )
 
         # Set local species bits
+        n_species = local_species.nspec
         self.data["species_knobs"]["nspec"] = local_species.nspec
         self.data["species_knobs"]["species_option"] = "stella"
+
+        stored_species = len(
+            [key for key in self.data.keys() if "species_parameters_" in key]
+        )
+        extra_species = stored_species - n_species
+
+        if extra_species > 0:
+            for i_sp in range(extra_species):
+                stella_key = f"species_parameters_{i_sp + 1 + n_species}"
+                if stella_key in self.data:
+                    self.data.pop(stella_key)
 
         for iSp, name in enumerate(local_species.names):
             # add new outer params for each species

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -570,7 +570,25 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         )
 
         # Set local species bits
-        self.data["ns"] = local_species.nspec
+        n_species = local_species.nspec
+
+        self.data["ns"] = n_species
+
+        stored_species = len([key for key in self.data.keys() if "zs_" in key])
+        extra_species = stored_species - local_species.nspec
+
+        if extra_species > 0:
+            for iSp in range(extra_species):
+                tglf_species = self.pyro_TGLF_species(iSp + 1 + n_species)
+                for tglf_key in tglf_species.values():
+                    if tglf_key in self.data:
+                        self.data.pop(tglf_key)
+
+                if f"vpar_{iSp+1+n_species}" in self.data:
+                    self.data.pop(f"vpar_{iSp+1+n_species}")
+                if f"vpar_shear_{iSp+1+n_species}" in self.data:
+                    self.data.pop(f"vpar_shear_{iSp+1+n_species}")
+
         for iSp, name in enumerate(local_species.names):
             tglf_species = self.pyro_TGLF_species(iSp + 1)
 

--- a/tests/gk_code/test_gk_input_cgyro.py
+++ b/tests/gk_code/test_gk_input_cgyro.py
@@ -2,12 +2,17 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import sys
 
 from pyrokinetics import Pyro, template_dir
 from pyrokinetics.gk_code import GKInputCGYRO
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
+
+docs_dir = Path(__file__).parent.parent.parent / "docs"
+sys.path.append(str(docs_dir))
+from examples import example_JETTO  # noqa
 
 template_file = template_dir / "input.cgyro"
 
@@ -119,3 +124,24 @@ def test_beta_star_scale(tmp_path):
     pyro.write_gk_file(tmp_path / "input.cgyro")
 
     assert pyro.gk_input.data["BETA_STAR_SCALE"] == 1.0
+
+
+def test_drop_species(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+    pyro.gk_code = "CGYRO"
+
+    n_species = pyro.local_species.nspec
+    stored_species = len([key for key in pyro.gk_input.data.keys() if "DENS_" in key])
+    assert stored_species == n_species
+
+    pyro.local_species.merge_species(
+        base_species="deuterium",
+        merge_species=["deuterium", "impurity1"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+    )
+
+    pyro.update_gk_code()
+    n_species = pyro.local_species.nspec
+    stored_species = len([key for key in pyro.gk_input.data.keys() if "DENS_" in key])
+    assert stored_species == n_species

--- a/tests/gk_code/test_gk_input_gene.py
+++ b/tests/gk_code/test_gk_input_gene.py
@@ -141,3 +141,22 @@ def test_species_order(tmp_path):
     pyro.write_gk_file(file_name=tmp_path / "input.in")
 
     assert Path(tmp_path / "input.in").exists()
+
+
+def test_drop_species(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+    pyro.gk_code = "GENE"
+
+    n_species = pyro.local_species.nspec
+    assert len(pyro.gk_input.data["species"]) == n_species
+
+    pyro.local_species.merge_species(
+        base_species="deuterium",
+        merge_species=["deuterium", "impurity1"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+    )
+
+    pyro.update_gk_code()
+    n_species = pyro.local_species.nspec
+    assert len(pyro.gk_input.data["species"]) == n_species

--- a/tests/gk_code/test_gk_input_gkw.py
+++ b/tests/gk_code/test_gk_input_gkw.py
@@ -142,3 +142,22 @@ def test_species_order(tmp_path):
     pyro.write_gk_file(file_name=tmp_path / "input.in")
 
     assert Path(tmp_path / "input.in").exists()
+
+
+def test_drop_species(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+    pyro.gk_code = "GKW"
+
+    n_species = pyro.local_species.nspec
+    assert len(pyro.gk_input.data["species"]) == n_species
+
+    pyro.local_species.merge_species(
+        base_species="deuterium",
+        merge_species=["deuterium", "impurity1"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+    )
+
+    pyro.update_gk_code()
+    n_species = pyro.local_species.nspec
+    assert len(pyro.gk_input.data["species"]) == n_species

--- a/tests/gk_code/test_gk_input_stella.py
+++ b/tests/gk_code/test_gk_input_stella.py
@@ -4,12 +4,17 @@ from typing import Dict, Optional
 import f90nml
 import numpy as np
 import pytest
+import sys
 
 from pyrokinetics import template_dir
 from pyrokinetics.gk_code import GKInputSTELLA
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
+
+docs_dir = Path(__file__).parent.parent.parent / "docs"
+sys.path.append(str(docs_dir))
+from examples import example_JETTO  # noqa
 
 template_file = template_dir / "input.stella"
 
@@ -189,3 +194,28 @@ def test_stella_linear_range(tmp_path):
     assert numerics.nky == 12
     expected_ky = np.linspace(2, 8, 12)
     assert np.allclose(numerics.ky.m, expected_ky)
+
+
+def test_drop_species(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+    pyro.gk_code = "STELLA"
+
+    n_species = pyro.local_species.nspec
+    stored_species = len(
+        [key for key in pyro.gk_input.data.keys() if "species_parameters_" in key]
+    )
+    assert stored_species == n_species
+
+    pyro.local_species.merge_species(
+        base_species="deuterium",
+        merge_species=["deuterium", "impurity1"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+    )
+
+    pyro.update_gk_code()
+    n_species = pyro.local_species.nspec
+    stored_species = len(
+        [key for key in pyro.gk_input.data.keys() if "species_parameters_" in key]
+    )
+    assert stored_species == n_species

--- a/tests/gk_code/test_gk_input_tglf.py
+++ b/tests/gk_code/test_gk_input_tglf.py
@@ -2,12 +2,17 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import sys
 
 from pyrokinetics import template_dir
 from pyrokinetics.gk_code import GKInputTGLF
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
+
+docs_dir = Path(__file__).parent.parent.parent / "docs"
+sys.path.append(str(docs_dir))
+from examples import example_JETTO  # noqa
 
 template_file = template_dir / "input.tglf"
 
@@ -109,3 +114,24 @@ def test_write(tmp_path, tglf):
     assert local_species.nspec == new_local_species.nspec
     new_numerics = tglf_reader.get_numerics()
     assert numerics.ky == new_numerics.ky
+
+
+def test_drop_species(tmp_path):
+    pyro = example_JETTO.main(tmp_path)
+    pyro.gk_code = "TGLF"
+
+    n_species = pyro.local_species.nspec
+    stored_species = len([key for key in pyro.gk_input.data.keys() if "zs_" in key])
+    assert stored_species == n_species
+
+    pyro.local_species.merge_species(
+        base_species="deuterium",
+        merge_species=["deuterium", "impurity1"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+    )
+
+    pyro.update_gk_code()
+    n_species = pyro.local_species.nspec
+    stored_species = len([key for key in pyro.gk_input.data.keys() if "zs_" in key])
+    assert stored_species == n_species


### PR DESCRIPTION
When removing a species for any reason, input files would not be modified to reflect this and the removed species would end up persisting when writing out files. Here we check to make sure the total number of species matches the number in `LocalSpecies` and remove additional ones if need be. Added some tests for each code too.