### PR TITLE
Set default norm convention when reading IDS GKOutput and add test

### DIFF
--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -45,6 +45,8 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
 
         # Assign units and return GKOutput
         convention = norm.imas
+        norm.default_convention = output_convention.lower()
+
         # Check dimensions of outputs
         if fluxes["particle"].ndim == 4:
             flux_dims = ("field", "species", "ky", "time")

--- a/tests/databases/test_imas.py
+++ b/tests/databases/test_imas.py
@@ -291,6 +291,18 @@ FIXME_ignore_geometry_attrs = [
 ]
 
 
+def test_write_ids_roundtrip(direct_pyro, new_pyro, round_pyro):
+
+    ids = pyro_to_ids(direct_pyro, comment="Test IDS direct")
+    assert isinstance(ids, ids_gyrokinetics_local.GyrokineticsLocal)
+
+    ids = pyro_to_ids(new_pyro, comment="Test IDS new")
+    assert isinstance(ids, ids_gyrokinetics_local.GyrokineticsLocal)
+
+    ids = pyro_to_ids(round_pyro, comment="Test IDS round")
+    assert isinstance(ids, ids_gyrokinetics_local.GyrokineticsLocal)
+
+
 def test_compare_roundtrip_local_geometry(direct_pyro, new_pyro, round_pyro):
     for key in direct_pyro.local_geometry.keys():
         if key in FIXME_ignore_geometry_attrs:


### PR DESCRIPTION
The `default_convention` was not being set when reading an IDS in which mean you couldn't write a new one out if the conversion would fail.

For example when reading a GKW IDS, no information about `R_major/a_minor` is stored anywhere meaning you can't convert between say `gkw` and `pyrokinetics` Normalisation Conventions. This is normally fine but when writing out an IDS, we convert the `GKOutput` to the `imas` convention and convert it back to the `default_convention` As this was not being set it defaulted `pyrokinetics` which would fail at converting.

This fixes that and adds a test.