### PR TITLE
Switch TGLF to use MillerTurnbull

### DIFF
--- a/docs/examples/example_JETTO.py
+++ b/docs/examples/example_JETTO.py
@@ -39,7 +39,8 @@ def main(base_path: Union[os.PathLike, str] = ".", geometry_type: str = "Miller"
     # in the call.
     pyro.write_gk_file(file_name=base_path / "test_jetto.gene", gk_code="GENE")
 
-    pyro.write_gk_file(file_name=base_path / "test_jetto.tglf", gk_code="TGLF")
+    if geometry_type == "Miller":
+        pyro.write_gk_file(file_name=base_path / "test_jetto.tglf", gk_code="TGLF")
 
     pyro.write_gk_file(file_name=base_path / "test_jetto.gkw", gk_code="GKW")
 

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -262,7 +262,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         miller_turnbull_data = default_miller_turnbull_inputs()
 
         for (pyro_key, tglf_key), tglf_default in zip(
-            self.pyro_tglf_miller_turnbull.items(), self.pyro_tglf_miller_turnbull_defaults.values()
+            self.pyro_tglf_miller_turnbull.items(),
+            self.pyro_tglf_miller_turnbull_defaults.values(),
         ):
             miller_turnbull_data[pyro_key] = self.data.get(tglf_key, tglf_default)
 
@@ -271,7 +272,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         )
 
         miller_turnbull_data["shat"] = (
-            self.data.get("q_prime_loc", 16.0) * (miller_turnbull_data["rho"] / miller_turnbull_data["q"]) ** 2
+            self.data.get("q_prime_loc", 16.0)
+            * (miller_turnbull_data["rho"] / miller_turnbull_data["q"]) ** 2
         )
 
         miller_turnbull_data["ip_ccw"] = 1

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -267,7 +267,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         ):
             miller_turnbull_data[pyro_key] = self.data.get(tglf_key, tglf_default)
 
-        miller_data["s_delta"] = self.data.get("s_delta_loc", 0.0) / np.sqrt(
+        miller_turnbull_data["s_delta"] = self.data.get("s_delta_loc", 0.0) / np.sqrt(
             1 - miller_data["delta"] ** 2
         )
 

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -268,7 +268,7 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             miller_turnbull_data[pyro_key] = self.data.get(tglf_key, tglf_default)
 
         miller_turnbull_data["s_delta"] = self.data.get("s_delta_loc", 0.0) / np.sqrt(
-            1 - miller_data["delta"] ** 2
+            1 - miller_turnbull_data["delta"] ** 2
         )
 
         miller_turnbull_data["shat"] = (

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -375,13 +375,11 @@ def setup_roundtrip_mxh(tmp_path_factory):
 
     cgyro = Pyro(gk_file=tmp_path / "test_jetto.cgyro", gk_code="CGYRO")
     gene = Pyro(gk_file=tmp_path / "test_jetto.gene", gk_code="GENE")
-    tglf = Pyro(gk_file=tmp_path / "test_jetto.tglf", gk_code="TGLF")
 
     return {
         "pyro": pyro,
         "cgyro": cgyro,
         "gene": gene,
-        "tglf": tglf,
     }
 
 


### PR DESCRIPTION
TGLF uses `MillerTurnbull` when including squareness, **NOT** MXH which is what I had originally thought (silly me). 
This reverts it back to `MillerTurnbull`. It was this this originally so I must have been confused when changing it to MXH.


