### PR TITLE
Bugfix/gk output field coord

### DIFF
--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -707,10 +707,12 @@ def get_nonlinear_fields(gk_output: GKOutput):
 
     for field in gk_output["field"].data:
         field_name = imas_pyro_field_names[field]
-        field_data_norm = gk_output[field]
 
-        # Normalised
-        fields[f"{field_name}_perturbed_norm"] = field_data_norm.data.m
+        if field in gk_output:
+            field_data_norm = gk_output[field]
+
+            # Normalised
+            fields[f"{field_name}_perturbed_norm"] = field_data_norm.data.m
 
     if field_data_norm.ndim == 4:
         fields = gkids.GyrokineticsFieldsNl4D(**fields)

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -483,7 +483,9 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         }
 
         # Add field, flux and moment coords
-        if fields is not None:
+        if coords.field is not None:
+            dataset_coords["field"] = make_var("field", coords.field, "Field")
+        elif fields is not None:
             dataset_coords["field"] = make_var(
                 "field", np.array(fields.coords), "Field"
             )
@@ -493,10 +495,6 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
             dataset_coords["moment"] = make_var(
                 "moment", np.array(moments.coords), "Moment"
             )
-
-        # Edge case where field coord is set but not fields
-        if fields is None and coords.field is not None:
-            dataset_coords["field"] = make_var("field", coords.field, "Field")
 
         # Remove None entries
         dataset_coords = {k: v for k, v in dataset_coords.items() if v is not None}

--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -315,7 +315,10 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                 for field, imas_field in zip(
                     coords["field"], imas_pyro_field_names.values()
                 ):
-                    results[field] = getattr(fields, f"{imas_field}_perturbed_norm")
+                    field_data = getattr(fields, f"{imas_field}_perturbed_norm")
+                    if len(field_data):
+                        results[field] = field_data
+
             elif len(ids.non_linear.fields_intensity_1d.phi_potential_perturbed_norm):
                 results = {
                     field: np.empty((nky), dtype=complex) for field in coords["field"]
@@ -327,7 +330,9 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                 for field, imas_field in zip(
                     coords["field"], imas_pyro_field_names.values()
                 ):
-                    results[field] = getattr(fields, f"{imas_field}_perturbed_norm")
+                    field_data = getattr(fields, f"{imas_field}_perturbed_norm")
+                    if len(field_data):
+                        results[field] = field_data
 
         field_dims = tuple(field_dims)
 

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -940,7 +940,7 @@ class GKOutputReaderSTELLA(FileReader, file_type="STELLA", reads=GKOutput):
 
         # field coords
         # stella is hardcoded to require phi, only apar and bpar are optional
-        field_vals = {}
+        field_vals = {"phi": True}
         for field, default in zip(["apar", "bpar"], [False, False]):
             try:
                 field_vals[field] = gk_input.data["physics_flags"][f"include_{field}"]


### PR DESCRIPTION
Currently pyro uses the `Field` object to determine the coordinate `field` in the `GKOutput` object. However, is the case where there is no electromagnetic field output but there is electromagnetic flux output (the default in CGYRO...) this breaks the code. 

Here we directly take the `field` coordinate from the `Coords` object which is determined from the input file. Fixes #378 
