### PR TITLE
GENE IMAS fixes

### DIFF
--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -452,7 +452,8 @@ def pyro_to_imas_mapping(
             }
 
             fields, fields_name = get_nonlinear_fields(gk_output)
-            non_linear[fields_name] = fields
+            if fields:
+                non_linear[fields_name] = fields
 
             non_linear.update(get_nonlinear_fluxes(gk_output, time_interval))
 
@@ -704,23 +705,26 @@ def get_nonlinear_fields(gk_output: GKOutput):
     """
 
     fields = {}
+    field_data_norm = None
+    field_name = None
 
     for field in gk_output["field"].data:
-        field_name = imas_pyro_field_names[field]
+        imas_field_name = imas_pyro_field_names[field]
 
         if field in gk_output:
             field_data_norm = gk_output[field]
 
             # Normalised
-            fields[f"{field_name}_perturbed_norm"] = field_data_norm.data.m
+            fields[f"{imas_field_name}_perturbed_norm"] = field_data_norm.data.m
 
-    if field_data_norm.ndim == 4:
-        fields = gkids.GyrokineticsFieldsNl4D(**fields)
-        field_name = "fields_4d"
-    elif field_data_norm.ndim == 2:
-        fields = {k: v[:, 0] for k, v in fields.items()}
-        fields = gkids.GyrokineticsFieldsNl1D(**fields)
-        field_name = "fields_intensity_1d"
+    if field_data_norm:
+        if field_data_norm.ndim == 4:
+            fields = gkids.GyrokineticsFieldsNl4D(**fields)
+            field_name = "fields_4d"
+        elif field_data_norm.ndim == 2:
+            fields = {k: v[:, 0] for k, v in fields.items()}
+            fields = gkids.GyrokineticsFieldsNl1D(**fields)
+            field_name = "fields_intensity_1d"
 
     return fields, field_name
 

--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -717,7 +717,7 @@ def get_nonlinear_fields(gk_output: GKOutput):
             # Normalised
             fields[f"{imas_field_name}_perturbed_norm"] = field_data_norm.data.m
 
-    if field_data_norm:
+    if field_data_norm is not None:
         if field_data_norm.ndim == 4:
             fields = gkids.GyrokineticsFieldsNl4D(**fields)
             field_name = "fields_4d"

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -491,7 +491,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             # Always force to Rmaj norm and then re-normalise to pyro after
             species_data["inverse_lt"] = gene_data["omt"]
             species_data["inverse_ln"] = gene_data["omn"]
-            species_data["omega0"] = external_contr["omega0_tor"]
+            species_data["omega0"] = external_contr.get("omega0_tor", 0.0)
             species_data["domega_drho"] = domega_drho
 
             if species_data.z == -1:

--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -459,12 +459,12 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                     results[key] = results[key].squeeze(axis=2)
                 flux_dims.remove("kx")
         else:
-            if len(ids.non_linear.fluxes_2d_k_x_sum.particles_phi_potential) != 0:
-                flux_dims = ["field", "species", "ky"]
-                fluxes = ids.non_linear.fluxes_2d_k_x_sum
-            elif len(ids.non_linear.fluxes_2d_k_x_k_y_sum.particles_phi_potential) != 0:
+            if len(ids.non_linear.fluxes_2d_k_x_k_y_sum.particles_phi_potential) != 0:
                 flux_dims = ["field", "species", "time"]
                 fluxes = ids.non_linear.fluxes_2d_k_x_k_y_sum
+            elif len(ids.non_linear.fluxes_2d_k_x_sum.particles_phi_potential) != 0:
+                flux_dims = ["field", "species", "ky"]
+                fluxes = ids.non_linear.fluxes_2d_k_x_sum
             elif len(ids.non_linear.fluxes_1d.particles_phi_potential) != 0:
                 flux_dims = ["field", "species"]
                 fluxes = ids.non_linear.fluxes_1d

--- a/src/pyrokinetics/gk_code/ids.py
+++ b/src/pyrokinetics/gk_code/ids.py
@@ -459,13 +459,22 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                     results[key] = results[key].squeeze(axis=2)
                 flux_dims.remove("kx")
         else:
+            if len(ids.non_linear.fluxes_2d_k_x_sum.particles_phi_potential) != 0:
+                flux_dims = ["field", "species", "ky"]
+                fluxes = ids.non_linear.fluxes_2d_k_x_sum
+            elif len(ids.non_linear.fluxes_2d_k_x_k_y_sum.particles_phi_potential) != 0:
+                flux_dims = ["field", "species", "time"]
+                fluxes = ids.non_linear.fluxes_2d_k_x_k_y_sum
+            elif len(ids.non_linear.fluxes_1d.particles_phi_potential) != 0:
+                flux_dims = ["field", "species"]
+                fluxes = ids.non_linear.fluxes_1d
+
             results = {
-                flux: np.empty((nfield, nspecies, nky, ntime), dtype=complex)
+                flux: np.empty(
+                    ([len(coords[flux_dim]) for flux_dim in flux_dims]), dtype=complex
+                )
                 for flux in coords["flux"]
             }
-            flux_dims = ["field", "species", "ky", "time"]
-
-            fluxes = ids.non_linear.fluxes_2d_k_x_sum
 
             for isp in range(len(coords["species"])):
                 for imom, (flux, imas_flux) in enumerate(
@@ -476,13 +485,7 @@ class GKOutputReaderIDS(FileReader, file_type="IDS", reads=GKOutput):
                     ):
                         results[flux][ifield, ...] = getattr(
                             fluxes, f"{imas_flux}_{imas_field}"
-                        )[:, :, np.newaxis]
-
-            # GENE does not have flux as a function of ky
-            if coords["gk_code"] == "GENE":
-                for key, flux in results.items():
-                    results[key] = flux[:, :, 0, :]
-                flux_dims.remove("ky")
+                        )
 
         flux_dims = tuple(flux_dims)
 

--- a/tests/databases/test_imas.py
+++ b/tests/databases/test_imas.py
@@ -187,8 +187,8 @@ def test_pyro_to_imas_roundtrip_nonlinear(tmp_path, input_path):
             continue
         if data_var in average_time and "time" in old_gk_output[data_var].dims:
             assert array_similar(
-                old_gk_output[data_var].mean(dim="time"),
-                new_gk_output[data_var].isel(time=-1, missing_dims="ignore"),
+                old_gk_output[data_var].sum(dim="ky"),
+                new_gk_output[data_var],
             )
         else:
             assert array_similar(old_gk_output[data_var], new_gk_output[data_var])


### PR DESCRIPTION
Adds default to `omega0_tor` in GENE, fixes #381 

EDIT:
Also for IMAS data dictionaries, checks if nonlinear field are loaded and adds to data dictionary if available.

EDIT:
Now we carefully check the dimensions of the nonlinear fluxes and populate the ids entries that we can. Similarly when loading in the ids data we see what is available and add it accordingly. 

This does have a caveat that currently the IDS does not store the fluxes with dimensions  `Fluxes(field, species, ky, time)`. It stores either `Fluxes(field, species, time)` or `Fluxes(field, species, ky)` so we can't have both. Right now pyro chooses to load the former though that is up for debate. **Note that this does change the behaviour when loading an IDS in. Before we loaded in  `Fluxes(field, species, ky)` first**. This does not affect the writing out of data.

Ideally what we want is to do is store the full 4D flux in the IDS. @ycamenen would it be possible to add in something like `fluxes_3d_k_x_sum` as that is a common output for a lot of codes.