### PR TITLE
Add in deuterium mass if not in Kinetics object - Fast and Furious edition

### DIFF
--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -166,16 +166,13 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
                 if split_name[-1] == "SINGL":
                     name = "impurity"
                     impurity_charge = int(kinetics_data["XZIMP"][time_index].data)
-                    impurity_charge_func = (
-                        UnitSpline(
-                            psi_n,
-                            impurity_charge
-                            * unit_charge_array
-                            * units.elementary_charge,
-                        ),
+                    impurity_charge_func = UnitSpline(
+                        psi_n,
+                        impurity_charge * unit_charge_array * units.elementary_charge,
                     )
+
                     impurity_dens_data = (
-                        kinetics_data[f"NIMP"][time_index, :].data * units.cm**-3
+                        kinetics_data["NIMP"][time_index, :].data * 1e6 * units.m**-3
                     )
                     impurity_dens_func = UnitSpline(psi_n, impurity_dens_data)
 
@@ -203,7 +200,8 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
                         kinetics_data[f"NIMP_{split_name[1]}_{split_name[2]}"][
                             time_index, :
                         ].data
-                        * units.cm**-3
+                        * 1e6
+                        * units.m**-3
                     )
                     impurity_dens_func = UnitSpline(psi_n, impurity_dens_data)
 

--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -10,7 +10,6 @@ from ..units import UnitSpline
 from ..units import ureg as units
 from .kinetics import Kinetics
 
-
 species_mapping = {
     "C": ["carbon", 12.0],
     "BE": ["beryllium", 9.0],

--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -92,6 +92,14 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
 
             possible_species = [
                 {
+                    "species_name": "hydrogen",
+                    "transp_name": "NH",
+                    "charge": UnitSpline(
+                        psi_n, 1 * unit_charge_array * units.elementary_charge
+                    ),
+                    "mass": hydrogen_mass,
+                },
+                {
                     "species_name": "deuterium",
                     "transp_name": "ND",
                     "charge": UnitSpline(

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -274,7 +274,9 @@ class LocalSpecies(CleverDict):
             for key in species_data.items.keys():
                 if key == "name":
                     continue
-                if np.isclose(species_data[key].m, np.round(species_data[key].m)):
+                if np.isclose(
+                    species_data[key].m, np.round(species_data[key].m), atol=1e-16
+                ):
                     species_data[key] = (
                         np.round(species_data[key].m) * species_data[key].units
                     )

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -751,19 +751,42 @@ class SimulationNormalisation(Normalisation):
         """Set the temperature, density, and mass reference values for
         all the conventions"""
 
-        # Define physical units for each possible reference species
+        if "deuterium" in kinetics.species_names:
+            add_deuterium = False
+        elif "tritium" in kinetics.species_names:
+            add_deuterium = True
+            deuterium_factor = 2.0 / 3.0
+            base_mass = "tritium"
+        elif "hydrogen" in kinetics.species_names:
+            add_deuterium = True
+            deuterium_factor = 2.0
+            base_mass = "hydrogen"
+        else:
+            raise ValueError(
+                f"Pyrokinetics only supports plasma with at least 1 hydrogenic species, Kinetics oject only has {kinetics.species_names}"
+            )
+
+        # Define physical units for each possible reference species==######
         for species in REFERENCE_CONVENTIONS["tref"]:
-            tref = kinetics.species_data[species].get_temp(psi_n)
-            self.define(f"tref_{species}_{self.name} = {tref}", units=True)
+            if species in kinetics.species_data:
+                tref = kinetics.species_data[species].get_temp(psi_n)
+                self.define(f"tref_{species}_{self.name} = {tref}", units=True)
 
         for species in REFERENCE_CONVENTIONS["nref"]:
-            nref = kinetics.species_data[species].get_dens(psi_n)
-            self.define(f"nref_{species}_{self.name} = {nref}", units=True)
+            if species in kinetics.species_data:
+                nref = kinetics.species_data[species].get_dens(psi_n)
+                self.define(f"nref_{species}_{self.name} = {nref}", units=True)
 
         for species in REFERENCE_CONVENTIONS["mref"]:
             if species in kinetics.species_data:
                 mref = kinetics.species_data[species].get_mass()
                 self.define(f"mref_{species}_{self.name} = {mref}", units=True)
+
+        if add_deuterium:
+            self.define(
+                f"mref_deuterium_{self.name} = {deuterium_factor} mref_{base_mass}_{self.name}",
+                units=True,
+            )
 
         # We can also define physical vref now
         self.define(

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -225,10 +225,10 @@ def test_read_transp(transp_file, kinetics_type):
     transp = read_kinetics(transp_file, kinetics_type)
     assert transp.kinetics_type == "TRANSP"
 
-    assert transp.nspec == 3
+    assert transp.nspec == 4
     assert np.array_equal(
         sorted(transp.species_names),
-        sorted(["electron", "deuterium", "impurity"]),
+        sorted(["electron", "deuterium", "impurity", "deuterium_fast"]),
     )
 
     check_species(
@@ -262,8 +262,20 @@ def test_read_transp(transp_file, kinetics_type):
         12 * hydrogen_mass,
         midpoint_density=3.465402009669668e17,
         midpoint_density_gradient=0.30267160173086655,
-        midpoint_temperature=433.128653116985,
-        midpoint_temperature_gradient=2.0159650962726197,
+        midpoint_temperature=432.77471321988463,
+        midpoint_temperature_gradient=2.04184150650355,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
+    )
+    check_species(
+        transp.species_data["deuterium_fast"],
+        "deuterium_fast",
+        1,
+        1 * deuterium_mass,
+        midpoint_density=5.2138297041837216e17,
+        midpoint_density_gradient=6.169562307950176,
+        midpoint_temperature=16742.28912410173,
+        midpoint_temperature_gradient=0.9119287844383214,
         midpoint_angular_velocity=0.0,
         midpoint_angular_velocity_gradient=0.0,
     )
@@ -274,10 +286,10 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
     transp = read_kinetics(transp_file, kinetics_type, time_index=10)
     assert transp.kinetics_type == "TRANSP"
 
-    assert transp.nspec == 3
+    assert transp.nspec == 4
     assert np.array_equal(
         sorted(transp.species_names),
-        sorted(["electron", "deuterium", "impurity"]),
+        sorted(["electron", "deuterium", "impurity", "deuterium_fast"]),
     )
 
     check_species(
@@ -311,8 +323,20 @@ def test_read_transp_kwargs(transp_file, kinetics_type):
         12 * hydrogen_mass,
         midpoint_density=2.737639427605868e17,
         midpoint_density_gradient=0.5047206814879348,
-        midpoint_temperature=275.0882425446277,
-        midpoint_temperature_gradient=5.312259392804134,
+        midpoint_temperature=276.32130457101044,
+        midpoint_temperature_gradient=5.301042741230228,
+        midpoint_angular_velocity=0.0,
+        midpoint_angular_velocity_gradient=0.0,
+    )
+    check_species(
+        transp.species_data["deuterium_fast"],
+        "deuterium_fast",
+        1,
+        1 * deuterium_mass,
+        midpoint_density=2.72693515242587e17,
+        midpoint_density_gradient=6.9863694819602005,
+        midpoint_temperature=26577.97726842,
+        midpoint_temperature_gradient=0.5931113899453979,
         midpoint_angular_velocity=0.0,
         midpoint_angular_velocity_gradient=0.0,
     )


### PR DESCRIPTION
When setting up a reference values from a simulation (like TRANSP), pyro currently assumes that there will be Deuterium in the plasma. This are cases with Tritium/Hydrogen only plasmas so we add a check to ensure that we can handle these cases.

Add a simple check so when deuterium is not located in `Kinetics` object, we determine its mass from tritium/hydrogen and then add it to the physical reference values (note it is already in the simulation reference values by default).

EDIT

A few small bugs were addressed here and this is now basically about something else...
- Hydrogen species were not caught here in TRANSP and now they are
- Helium-3 had the wrong key name so that is now fixed
- A bigger change is that now we add in fast ion species in TRANSP which were not actually included before @juanruizruiz this may impact some of your runs...

The treatment of fast ions is probably best left as a separate PR but to summarise currently most codes treat them as a hot maxwellian. The issue here is that choice of how you define the temperature here is not well defined.

One could (and we currently) do in TRANSP
$T_{fast} = p_{fast} / n_{fast}$

here $p_{fast}$ which goes into the Grad-Shafranov solver in TRANSP is defined as (maybe this is a TRANSP specific thing...)

$p_{fast} = U_{\perp} + U_{||}/2$

where $U$ is the energy density in the perpendicular/parallel direction.

Doing so matches the "fast ion pressure" output from TRANSP
![image](https://github.com/user-attachments/assets/2fd12c7a-dfc3-4516-add7-65037959df4a)

But the overall energy content doesn't match as you need, see below

$U_{fast} =  U_{\perp} + U_{||}$
![image](https://github.com/user-attachments/assets/e14e756e-9acd-4765-91e6-656aecd043ff)

I think the issue boils do to the choice of distribution function. Technically with maxwellian distributions we should have

$p = \frac{2}{3}  U$

and we do this for JETTO

https://github.com/pyro-kinetics/pyrokinetics/blob/765d0f1032470937926431847a9f87efefcdcd41/src/pyrokinetics/kinetics/jetto.py#L101-L109

which is technically different

JETTO:
$T_{fast} = \frac{2}{3} U_{fast} / n_{fast} = \frac{2}{3} (U_\perp + U_{||}) / n_{fast}$

TRANSP:
$T_{fast} = (U_\perp + U_{||}/2) / n_{fast}$


Now I'm not 100% sure what the right answer is or if there is even a right answer... Any thoughts on this would be useful!


