### PR TITLE
Bicoherence diagnostics

### DIFF
--- a/docs/examples/bicoherence.rst
+++ b/docs/examples/bicoherence.rst
@@ -113,7 +113,8 @@ like for :math:`\delta \phi`, :math:`\delta n_e`, :math:`\delta v_e` by doing
     data = diagnostics.cross_bicoherence(phi, density, velocity)
 
 
- If a single is not stationary (like during the linear phase of
- a nonlinear simulation), it is possible to examine the bicoherence
- of the phase of the fluctuations :math:`\hat{X} = X / |X|`  by setting
+
+If a single is not stationary (like during the linear phase of
+a nonlinear simulation), it is possible to examine the bicoherence
+of the phase of the fluctuations :math:`\hat{X} = X / |X|`  by setting
 `stationary=False` as a kwarg.

--- a/docs/examples/bicoherence.rst
+++ b/docs/examples/bicoherence.rst
@@ -33,11 +33,12 @@ coupled). It should be noted that bicoherence cannot determine the direction of 
 transfer but only if modes are coupled.
 
 
-The Bicoherence of :math:`phi` can be calculated from a nonlinear simulation output
+The Bicoherence of :math:`\phi` can be calculated from a nonlinear simulation output
 with the following
 
 
-.. code-block:: python
+.. code:: python
+
     from pyrokinetics import Pyro, template_dir
     from pyrokinetics.diagnostics import Diagnostics
 
@@ -75,7 +76,8 @@ One can also calculate the cross-bicoherence between 3 different fields
 like for :math:`\delta \phi`, :math:`\delta n_e`, :math:`\delta v_e` by doing
 
 
-.. code-block:: python
+.. code:: python
+
     from pyrokinetics import Pyro, template_dir
     from pyrokinetics.diagnostics import Diagnostics
 

--- a/docs/examples/bicoherence.rst
+++ b/docs/examples/bicoherence.rst
@@ -114,7 +114,7 @@ like for :math:`\delta \phi`, :math:`\delta n_e`, :math:`\delta v_e` by doing
 
 
 
-If a single is not stationary (like during the linear phase of
+If a signal is not stationary (like during the linear phase of
 a nonlinear simulation), it is possible to examine the bicoherence
 of the phase of the fluctuations :math:`\hat{X} = X / |X|`  by setting
 `stationary=False` as a kwarg.

--- a/docs/examples/bicoherence.rst
+++ b/docs/examples/bicoherence.rst
@@ -1,0 +1,117 @@
+====================
+Bicoherence analysis
+====================
+
+Bicoherence is an analysis method that determines the level of triadic mode
+coupling by examining whether three modes remain phase locked throughout the
+statistically equivalent periods of a simulation. Given that nonlinear
+simulations have two wavenumbers in two direction we determine the 2D
+bicoherence. The 2D bicoherence square for a complex field :math:`X` is given by
+
+.. math::
+    b^2(X) = \frac{|B(k_{x1}, k_{y1},k_{x2}, k_{y2})|^{2}}{\langle
+    |X(k_{x1}, k_{y1})X(k_{x2}, k_{y2})|\rangle^2 \langle|{X(k_{x3}, k_{y3})
+    \rangle|^2}}
+
+
+where :math:`B`, the bispectrum is given by
+
+.. math::
+    B(k_{x1}, k_{y1},k_{x2}, k_{y2}) = \langle X(k_{x1}, k_{y1})X(k_{x2}, k_{y2})
+    \overline{X(k_{x3}, k_{y3})}\rangle
+
+
+is the bispectrum, with :math:`k_{x3} = k_{x1} + k_{x2}`, :math:`k_{y3} = k_{y1} + k_{y2}`,
+:math:`\overline{X}` denoted a complex conjugate and :math:`\langle\rangle` denoting
+an average over many realisations. If the modes at :math:`(k_{x1},k_{y1})`,
+:math:`(k_{x2},k_{y2})` and :math:`(k_{x3},k_{y3})` are not coupled then that
+complex triple product will have random phases so will average to zero over many
+realisations, but if there is strong coupling then this average will have a
+non-zero value. This can then be normalised to the total amplitude of the fluctuations
+such that :math:`b^2` runs between 0 (no phase coupling) and 1 (entirely phase
+coupled). It should be noted that bicoherence cannot determine the direction of energy
+transfer but only if modes are coupled.
+
+
+The Bicoherence of :math:`phi` can be calculated from a nonlinear simulation output
+with the following
+
+
+.. code-block:: python
+    from pyrokinetics import Pyro, template_dir
+    from pyrokinetics.diagnostics import Diagnostics
+
+    # Set up simulation
+    data_dir = template_dir / "CGYRO_nonlinear"
+    file_name = f"{data_dir}/input.cgyro"
+
+    # Load phi data
+    pyro = Pyro(gk_file=file_name)
+    pyro.load_gk_output()
+    data = pyro.gk_output.data
+
+    # Need dimensions (kx, ky, time)
+    phi = (
+        data["phi"]
+        .sel(theta=0.0, method="nearest")
+        .pint.dequantify()
+    )
+
+    # Set up diagnostic and calculate bicoherence
+    diagnostics  = Diagnostics(pyro)
+    data = diagnostics.bicoherence(phi)
+    
+    # Read in bicoherence and phase data
+    bicoherence = data["bicoherence"]
+    phase = data["phase"]
+    
+    # Filter data where bicoherence is strong
+    threshold= 0.5
+    phase = phase.where(bicoherence > threshold, np.nan)
+    bicoherence = bicoherence.where(bicoherence > threshold, np.nan)
+
+
+One can also calculate the cross-bicoherence between 3 different fields
+like for :math:`\delta \phi`, :math:`\delta n_e`, :math:`\delta v_e` by doing
+
+
+.. code-block:: python
+    from pyrokinetics import Pyro, template_dir
+    from pyrokinetics.diagnostics import Diagnostics
+
+    # Set up simulation
+    data_dir = template_dir / "CGYRO_nonlinear"
+    file_name = f"{data_dir}/input.cgyro"
+
+    # Load data from 3 different fields
+    pyro = Pyro(gk_file=file_name)
+    pyro.load_gk_output()
+
+    # Ensure dimensions are (kx, ky, time)
+    phi = (
+        data["phi"]
+        .sel(theta=0.0, method="nearest")
+        .pint.dequantify()
+    )
+    density = (
+        data["density"]
+        .sel(theta=0.0, method="nearest")
+	.sel(species="electron")
+        .pint.dequantify()
+    )
+    velocity = (
+        data["velcoity"]
+        .sel(theta=0.0, method="nearest")
+	.sel(species="electron")
+        .pint.dequantify()
+    )
+    
+    # Set up diagnostic and calculate cross-bicoherence
+    diagnostics  = Diagnostics(pyro)
+    data = diagnostics.cross_bicoherence(phi, density, velocity)
+
+
+ If a single is not stationary (like during the linear phase of
+ a nonlinear simulation), it is possible to examine the bicoherence
+ of the phase of the fluctuations :math:`\hat{X} = X / |X|`  by setting
+`stationary=False` as a kwarg.

--- a/src/pyrokinetics/diagnostics/__init__.py
+++ b/src/pyrokinetics/diagnostics/__init__.py
@@ -481,8 +481,8 @@ class Diagnostics:
         kx3 = kx1 + kx2
         ky3 = ky1 + ky2
 
-        kx3 = np.where(abs(kx3) <= max(kx), kx3, kx3 % kx_max * np.sign(kx3))
-        ky3 = np.where(abs(ky3) <= max(ky), ky3, ky3 % ky_max * np.sign(ky3))
+        kx3 = np.where(abs(kx3) <= max(abs(kx)), kx3, kx3 % kx_max * np.sign(kx3))
+        ky3 = np.where(abs(ky3) <= max(abs(ky)), ky3, ky3 % ky_max * np.sign(ky3))
 
         # Extract the relevant data slices based on calculated indices
         # fft_data for (kx1, ky1), (kx2, ky2), (kx3, ky3) Currently in the form

--- a/src/pyrokinetics/diagnostics/__init__.py
+++ b/src/pyrokinetics/diagnostics/__init__.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 import xrft
 from scipy.integrate import simpson
 from scipy.interpolate import RectBivariateSpline
@@ -390,6 +391,138 @@ class Diagnostics:
         )
 
         return gamma
+
+    def bicoherence(self, fluctuation, wavenumber_tolerance=1e-5):
+        r"""
+        Perform bicoherence analysis for a given DataArray
+
+        Bispectrum given by:
+
+        .. math::
+            Bi(k_{x,1}, k_{y,1}, k_{x,2}, k_{y,2}) = \langle f_1 * f_2 * f_3^\dagger\rangle_{t}
+
+        The bispectrum phase tells us about the direction of energy
+        transfer
+
+        The bicoherence is normalised to
+
+        .. math::
+            b^2 = \frac{|Bi|^2}{\langle|f_1 * f_2|^2\rangle_{t} \langle|f_3|^2\rangle_{t}}
+
+        where
+
+        .. math::
+            f_1 = fluctuation(k_{x,1}, k_{y,1}, t)
+
+        .. math::
+            f_2 = fluctuation(k_{x,2}, k_{y,2}, t)
+
+        .. math::
+            f_3 = fluctuation(k_{x,3}, k_{y,3}, t)
+
+
+        with :math:`\langle\rangle_{t}` being an average over time
+
+        where
+        :math:`k_{x,3} = k_{x,1}+k_{x,2}`
+        :math:`k_{y,3} = k_{y,1}+k_{y,2}`
+
+        Parameters
+        ----------
+        fluctuation: xr.DataArray
+            Fluctuation dataset which must be a DataArray with
+            dimensions (:math:`k_x`, :math:`k_y`, :math:`t`)
+
+        wavenumber_tolerance: float
+            Tolerance to find matching wavenumbers in :math:`k_{x,3}, k_{y,3}`
+
+        Returns
+        -------
+        Bicoherence: xr.Dataset
+            Bicoherence data of with units
+            (:math:`k_{x,1}`, :math:`k_{y,1}`,:math:`k_{x,2}`, :math:`k_{y,2}`)
+
+        Phase: xr.Dataset
+            Phase information of average Bispectrum with units
+            (:math:`k_{x,1}`, :math:`k_{y,1}`,:math:`k_{x,2}`, :math:`k_{y,2}`)
+        """
+
+        time = fluctuation["time"].data
+        kx = fluctuation["kx"].data
+        ky = fluctuation["ky"].data
+
+        ntime = len(time)
+        nkx = len(kx)
+        nky = len(ky)
+
+        kx_max = max(abs(kx))
+        ky_max = max(abs(ky))
+
+        # Initialise different Arrays
+        bispectrum = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
+        )
+
+        phase = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
+        )
+
+        power_total = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)), dims=["kx1", "ky1", "kx2", "ky2"]
+        )
+
+        # Create mesh grids of the kx and ky values
+        kx1, kx2 = np.meshgrid(kx, kx, indexing="ij")
+        ky1, ky2 = np.meshgrid(ky, ky, indexing="ij")
+
+        # Compute kx3 and ky3 with modular arithmetic
+        kx3 = kx1 + kx2
+        ky3 = ky1 + ky2
+
+        kx3 = np.where(abs(kx3) <= max(kx), kx3, kx3 % kx_max * np.sign(kx3))
+        ky3 = np.where(abs(ky3) <= max(ky), ky3, ky3 % ky_max * np.sign(ky3))
+
+        # Extract the relevant data slices based on calculated indices
+        # fft_data for (kx1, ky1), (kx2, ky2), (kx3, ky3) Currently in the form
+        fluctuation_kx1_ky1 = fluctuation.sel(
+            kx=kx1.ravel(), ky=ky1.ravel()
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+        fluctuation_kx2_ky2 = fluctuation.sel(
+            kx=kx2.ravel(), ky=ky2.ravel()
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+        fluctuation_kx3_ky3 = fluctuation.sel(
+            kx=kx3.ravel(),
+            ky=ky3.ravel(),
+            method="nearest",
+            tolerance=wavenumber_tolerance,
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+
+        # Swap axes such that dimensions are (kx1, ky1, kx2, ky2)
+        fluctuation_kx1_ky1 = np.swapaxes(fluctuation_kx1_ky1, 1, 2)
+        fluctuation_kx2_ky2 = np.swapaxes(fluctuation_kx2_ky2, 1, 2)
+        fluctuation_kx3_ky3 = np.swapaxes(fluctuation_kx3_ky3, 1, 2)
+
+        power_total.data = np.mean(
+            np.abs(fluctuation_kx1_ky1 * fluctuation_kx2_ky2) ** 2, axis=-1
+        ) * np.mean(np.abs(fluctuation_kx3_ky3) ** 2, axis=-1)
+
+        bispectrum_data = (
+            fluctuation_kx1_ky1 * fluctuation_kx2_ky2 * np.conj(fluctuation_kx3_ky3)
+        )
+        phase.data = np.mean(
+            np.arctan2(bispectrum_data.imag, bispectrum_data.real), axis=-1
+        )
+        bispectrum.data = np.abs(np.mean(bispectrum_data, axis=-1))
+
+        bicoherence = np.abs(bispectrum) ** 2 / (power_total)
+
+        bicoherence = bicoherence.fillna(0.0)
+
+        return bicoherence, phase
 
 
 def gamma_ball_full(

--- a/src/pyrokinetics/diagnostics/__init__.py
+++ b/src/pyrokinetics/diagnostics/__init__.py
@@ -35,6 +35,7 @@ class Diagnostics:
         time: float,
         rhostar: float,
         use_invfft: bool = False,
+        smoothing: float = 1.0,
     ):
         """
         Generates a poincare map. It returns the (x, y) coordinates of
@@ -43,7 +44,7 @@ class Diagnostics:
         This routine may take a while depending on ``nturns`` and on
         the number of magnetic field lines. The parameter rhostar is
         required by the flux-tube boundary condition.
-        Available for CGYRO, GENE and GS2 nonlinear simulations
+        Available for nonlinear simulations
 
         You need to load the output files of a simulation
         berore calling this function.
@@ -61,6 +62,7 @@ class Diagnostics:
         use_invfft: bool, if True, the inverse Fourier transform is computed
                  every (x, y) points along the magnetic field line. It is much
                  more accurate but very slow.
+        smoothing: float Sets level of smoothing done in RectBivariateSpline
 
         Returns
         -------
@@ -153,7 +155,7 @@ class Diagnostics:
                     byfft.sel(theta=theta, method="nearest"),
                     kx=5,
                     ky=5,
-                    s=1,
+                    s=smoothing,
                 )
                 for theta in byfft.theta
             ]
@@ -164,7 +166,7 @@ class Diagnostics:
                     bxfft.sel(theta=theta, method="nearest"),
                     kx=5,
                     ky=5,
-                    s=1,
+                    s=smoothing,
                 )
                 for theta in bxfft.theta
             ]
@@ -392,7 +394,7 @@ class Diagnostics:
 
         return gamma
 
-    def bicoherence(self, fluctuation, wavenumber_tolerance=1e-5):
+    def bicoherence(self, fluctuation, wavenumber_tolerance=1e-5, stationary=True):
         r"""
         Perform bicoherence analysis for a given DataArray
 
@@ -400,9 +402,6 @@ class Diagnostics:
 
         .. math::
             Bi(k_{x,1}, k_{y,1}, k_{x,2}, k_{y,2}) = \langle f_1 * f_2 * f_3^\dagger\rangle_{t}
-
-        The bispectrum phase tells us about the direction of energy
-        transfer
 
         The bicoherence is normalised to
 
@@ -438,13 +437,10 @@ class Diagnostics:
 
         Returns
         -------
-        Bicoherence: xr.Dataset
-            Bicoherence data of with units
+        data: xr.Dataset
+            Dataset with DataArray of bicoherence and phase with dimensions
             (:math:`k_{x,1}`, :math:`k_{y,1}`,:math:`k_{x,2}`, :math:`k_{y,2}`)
 
-        Phase: xr.Dataset
-            Phase information of average Bispectrum with units
-            (:math:`k_{x,1}`, :math:`k_{y,1}`,:math:`k_{x,2}`, :math:`k_{y,2}`)
         """
 
         time = fluctuation["time"].data
@@ -465,14 +461,16 @@ class Diagnostics:
             dims=["kx1", "ky1", "kx2", "ky2"],
         )
 
-        phase = xr.DataArray(
+        bicoherence = xr.DataArray(
             np.zeros((nkx, nky, nkx, nky)),
             coords=[kx, ky, kx, ky],
             dims=["kx1", "ky1", "kx2", "ky2"],
         )
 
-        power_total = xr.DataArray(
-            np.zeros((nkx, nky, nkx, nky)), dims=["kx1", "ky1", "kx2", "ky2"]
+        phase = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
         )
 
         # Create mesh grids of the kx and ky values
@@ -506,9 +504,10 @@ class Diagnostics:
         fluctuation_kx2_ky2 = np.swapaxes(fluctuation_kx2_ky2, 1, 2)
         fluctuation_kx3_ky3 = np.swapaxes(fluctuation_kx3_ky3, 1, 2)
 
-        power_total.data = np.mean(
-            np.abs(fluctuation_kx1_ky1 * fluctuation_kx2_ky2) ** 2, axis=-1
-        ) * np.mean(np.abs(fluctuation_kx3_ky3) ** 2, axis=-1)
+        if not stationary:
+            fluctuation_kx1_ky1 *= 1.0 / np.abs(fluctuation_kx1_ky1)
+            fluctuation_kx2_ky2 *= 1.0 / np.abs(fluctuation_kx2_ky2)
+            fluctuation_kx3_ky3 *= 1.0 / np.abs(fluctuation_kx3_ky3)
 
         bispectrum_data = (
             fluctuation_kx1_ky1 * fluctuation_kx2_ky2 * np.conj(fluctuation_kx3_ky3)
@@ -516,13 +515,173 @@ class Diagnostics:
         phase.data = np.mean(
             np.arctan2(bispectrum_data.imag, bispectrum_data.real), axis=-1
         )
+
+        power_total = np.mean(
+            np.abs(fluctuation_kx1_ky1 * fluctuation_kx2_ky2) ** 2, axis=-1
+        ) * np.mean(np.abs(fluctuation_kx3_ky3) ** 2, axis=-1)
+
         bispectrum.data = np.abs(np.mean(bispectrum_data, axis=-1))
 
-        bicoherence = np.abs(bispectrum) ** 2 / (power_total)
+        bicoherence.data = np.abs(bispectrum) ** 2 / (power_total)
 
         bicoherence = bicoherence.fillna(0.0)
 
-        return bicoherence, phase
+        data = bicoherence.to_dataset(name="bicoherence")
+        data["phase"] = phase
+
+        return data
+
+    def cross_bicoherence(
+        self,
+        fluctuation1,
+        fluctuation2,
+        fluctuation3,
+        wavenumber_tolerance=1e-5,
+        stationary=True,
+    ):
+        r"""
+        Perform cross bicoherence analysis for a given DataArray
+
+        Bispectrum given by:
+
+        .. math::
+            Bi(k_{x,1}, k_{y,1}, k_{x,2}, k_{y,2}) = \langle f_1 * f_2 * f_3^\dagger\rangle_{t}
+
+        The bicoherence is normalised to
+
+        .. math::
+            b^2 = \frac{|Bi|^2}{\langle|f_1 * f_2|^2\rangle_{t} \langle|f_3|^2\rangle_{t}}
+
+        where
+
+        .. math::
+            f_1 = fluctuation1(k_{x,1}, k_{y,1}, t)
+
+        .. math::
+            f_2 = fluctuation2(k_{x,2}, k_{y,2}, t)
+
+        .. math::
+            f_3 = fluctuation3(k_{x,3}, k_{y,3}, t)
+
+
+        with :math:`\langle\rangle_{t}` being an average over time
+
+        where
+        :math:`k_{x,3} = k_{x,1}+k_{x,2}`
+        :math:`k_{y,3} = k_{y,1}+k_{y,2}`
+
+        Parameters
+        ----------
+        fluctuation1: xr.DataArray
+            First fluctuation dataset which must be a DataArray with
+            dimensions (:math:`k_x`, :math:`k_y`, :math:`t`)
+
+        fluctuation2: xr.DataArray
+            Second fluctuation dataset which must be a DataArray with
+            dimensions (:math:`k_x`, :math:`k_y`, :math:`t`)
+
+        fluctuation3: xr.DataArray
+            Third fluctuation dataset which must be a DataArray with
+            dimensions (:math:`k_x`, :math:`k_y`, :math:`t`)
+
+        wavenumber_tolerance: float
+            Tolerance to find matching wavenumbers in :math:`k_{x,3}, k_{y,3}`
+
+        Returns
+        -------
+        data: xr.Dataset
+            Dataset with DataArray of cross-bicoherence and phase with dimensions
+            (:math:`k_{x,1}`, :math:`k_{y,1}`,:math:`k_{x,2}`, :math:`k_{y,2}`)
+
+        """
+
+        time = fluctuation1["time"].data
+        kx = fluctuation1["kx"].data
+        ky = fluctuation1["ky"].data
+
+        ntime = len(time)
+        nkx = len(kx)
+        nky = len(ky)
+
+        kx_max = max(abs(kx))
+        ky_max = max(abs(ky))
+
+        # Initialise different Arrays
+        bispectrum = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
+        )
+
+        bicoherence = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
+        )
+
+        phase = xr.DataArray(
+            np.zeros((nkx, nky, nkx, nky)),
+            coords=[kx, ky, kx, ky],
+            dims=["kx1", "ky1", "kx2", "ky2"],
+        )
+
+        # Create mesh grids of the kx and ky values
+        kx1, kx2 = np.meshgrid(kx, kx, indexing="ij")
+        ky1, ky2 = np.meshgrid(ky, ky, indexing="ij")
+
+        # Compute kx3 and ky3 with modular arithmetic
+        kx3 = kx1 + kx2
+        ky3 = ky1 + ky2
+
+        kx3 = np.where(abs(kx3) <= max(kx), kx3, kx3 % kx_max * np.sign(kx3))
+        ky3 = np.where(abs(ky3) <= max(ky), ky3, ky3 % ky_max * np.sign(ky3))
+
+        # Extract the relevant data slices based on calculated indices
+        # fft_data for (kx1, ky1), (kx2, ky2), (kx3, ky3) Currently in the form
+        fluctuation_kx1_ky1 = fluctuation1.sel(
+            kx=kx1.ravel(), ky=ky1.ravel()
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+        fluctuation_kx2_ky2 = fluctuation2.sel(
+            kx=kx2.ravel(), ky=ky2.ravel()
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+        fluctuation_kx3_ky3 = fluctuation3.sel(
+            kx=kx3.ravel(),
+            ky=ky3.ravel(),
+            method="nearest",
+            tolerance=wavenumber_tolerance,
+        ).values.reshape(nkx, nkx, nky, nky, ntime)
+
+        # Swap axes such that dimensions are (kx1, ky1, kx2, ky2)
+        fluctuation_kx1_ky1 = np.swapaxes(fluctuation_kx1_ky1, 1, 2)
+        fluctuation_kx2_ky2 = np.swapaxes(fluctuation_kx2_ky2, 1, 2)
+        fluctuation_kx3_ky3 = np.swapaxes(fluctuation_kx3_ky3, 1, 2)
+
+        if not stationary:
+            fluctuation_kx1_ky1 *= 1.0 / np.abs(fluctuation_kx1_ky1)
+            fluctuation_kx2_ky2 *= 1.0 / np.abs(fluctuation_kx2_ky2)
+            fluctuation_kx3_ky3 *= 1.0 / np.abs(fluctuation_kx3_ky3)
+
+        bispectrum_data = (
+            fluctuation_kx1_ky1 * fluctuation_kx2_ky2 * np.conj(fluctuation_kx3_ky3)
+        )
+        phase.data = np.mean(
+            np.arctan2(bispectrum_data.imag, bispectrum_data.real), axis=-1
+        )
+
+        power_total = np.mean(
+            np.abs(fluctuation_kx1_ky1 * fluctuation_kx2_ky2) ** 2, axis=-1
+        ) * np.mean(np.abs(fluctuation_kx3_ky3) ** 2, axis=-1)
+
+        bispectrum.data = np.abs(np.mean(bispectrum_data, axis=-1))
+
+        bicoherence.data = np.abs(bispectrum) ** 2 / (power_total)
+
+        bicoherence = bicoherence.fillna(0.0)
+
+        data = bicoherence.to_dataset(name="bicoherence")
+        data["phase"] = phase
+
+        return data
 
 
 def gamma_ball_full(


### PR DESCRIPTION
Here we add in an auto-bicoherence/cross-bicoherence diagnostic for nonlinear simulation outputs which gives information about the level of mode coupling between two different modes.

$$b^2(X) = \frac{|B(k_{x1}, k_{y1},k_{x2}, k_{y2})|^{2}}{\langle
    |X(k_{x1}, k_{y1})X(k_{x2}, k_{y2})|\rangle^2 \langle|{X(k_{x3}, k_{y3})
    \rangle|^2}}$$


where $B$, the bispectrum is given by

$$
    B(k_{x1}, k_{y1},k_{x2}, k_{y2}) = \langle X(k_{x1}, k_{y1})X(k_{x2}, k_{y2})
    \overline{X(k_{x3}, k_{y3})}\rangle
$$

is the bispectrum
with $k_{x3} = k_{x1} + k_{x2}$, $k_{y3} = k_{y1} + k_{y2}$, 
$\overline{X}$ denoted a complex conjugate 
$\langle\rangle$ denoting an average over many realisations.

If the modes at $(k_{x1},k_{y1})$, $(k_{x2},k_{y2})$ and $(k_{x3},k_{y3})$ are not  coupled then that complex triple product will have random phases so will average to zero over many realisations, but if there is strong coupling then this average will have a non-zero value. This can then be normalised to the total amplitude of the fluctuations such that $b^2$ runs between 0 (no phase coupling) and 1 (entirely phase coupled). It should be noted that bicoherence cannot determine the direction of energy transfer but only if modes are coupled.


We currently calculation this and the cross-bicoherence. Right now we have a bit of redundancy as the bicoherence is symmetric when swapping $k_{x1}$/$k_{x2}$ and $k_{y1}$/$k_{y2}$ so we could hit memory issues.

We currently return a xarray Dataset with the bicoherence and phase data which has dimensions (`kx1`, `kx2`, `ky1`, `ky2`).

Plotting this is tricky but can be informative. Here is an example output for $phi$ for a GA-STD for the lowest `ky1=0.05`, `kx1=0.0` which has strong coupling with `ky2=0.05`, `kx2=0.05` suggesting that the mode at `ky3=0.1`, `kx3=0.05` is coupled. 
Similarly there is coupling at `ky2=0.0`, `kx2=-0.05` indicating there is coupling to the zonal field probably to higher `kx`

![image](https://github.com/user-attachments/assets/2447150a-04d8-41a5-b3b7-4a439f389d6b)
