### PR TITLE
Pin numpy to <2.1 and remove some warnings with numpy>=2.0

### DIFF
--- a/.environment.yaml
+++ b/.environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - cmake
   - numpy
   - compilers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy >= 1.20.3, <= 2.1.0",
     "matplotlib >= 3.3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 requires-python = ">=3.9"
 dependencies = [
-    "numpy >= 1.20.3",
+    "numpy >= 1.20.3, <= 2.1.0",
     "matplotlib >= 3.3.4",
     "f90nml >= 1.4.2",
     "scipy >= 1.10.1",

--- a/src/pyrokinetics/dataset_wrapper.py
+++ b/src/pyrokinetics/dataset_wrapper.py
@@ -113,6 +113,11 @@ class DatasetWrapper:
         """Redirects to underlying Xarray Dataset dims."""
         return self.data.dims
 
+    @property
+    def sizes(self) -> Mapping[str, int]:
+        """Redirects to underlying Xarray Dataset sizes."""
+        return self.data.sizes
+
     def __getitem__(self, key: str) -> Any:
         """Redirect indexing to self.data"""
         try:

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1519,7 +1519,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         phase = np.abs(phi_theta_star) / phi_theta_star
         field_squared = np.sum(np.abs(eigenfunctions) ** 2, 0)
         amplitude = np.sqrt(
-            np.trapz(field_squared, coords["theta"], axis=0) / (2 * np.pi)
+            np.trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
         )
 
         result = eigenfunctions * phase / amplitude

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from cleverdict import CleverDict
+from scipy.integrate import trapezoid
 
 from ..constants import pi
 from ..file_utils import FileReader
@@ -1519,7 +1520,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         phase = np.abs(phi_theta_star) / phi_theta_star
         field_squared = np.sum(np.abs(eigenfunctions) ** 2, 0)
         amplitude = np.sqrt(
-            np.trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
+            trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
         )
 
         result = eigenfunctions * phase / amplitude

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -18,6 +18,7 @@ from typing import (
 import numpy as np
 import pint
 from numpy.typing import ArrayLike
+from scipy.integrate import trapezoid
 
 from ..dataset_wrapper import DatasetWrapper
 from ..file_utils import ReadableFromFile
@@ -682,11 +683,11 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
             square_fields += np.abs(field.magnitude) ** 2
 
         # Integrate over theta
-        field_amplitude = np.trapezoid(square_fields, theta, axis=0) ** 0.5
+        field_amplitude = trapezoid(square_fields, theta, axis=0) ** 0.5
         # Differentiate with respect to time
         growth_rate = np.gradient(np.log(field_amplitude), time, axis=-1)
 
-        field_angle = np.angle(np.trapezoid(sum_fields, theta, axis=0))
+        field_angle = np.angle(trapezoid(sum_fields, theta, axis=0))
 
         # Change angle by 2pi for every rotation so gradient is easier to calculate
         pi_change = np.cumsum(
@@ -723,7 +724,7 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         for field in fields.values():
             field_squared += np.abs(field.m) ** 2
 
-        amplitude = np.sqrt(np.trapezoid(field_squared, theta, axis=0) / (2 * np.pi))
+        amplitude = np.sqrt(trapezoid(field_squared, theta, axis=0) / (2 * np.pi))
 
         return amplitude
 

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -682,11 +682,11 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
             square_fields += np.abs(field.magnitude) ** 2
 
         # Integrate over theta
-        field_amplitude = np.trapz(square_fields, theta, axis=0) ** 0.5
+        field_amplitude = np.trapezoid(square_fields, theta, axis=0) ** 0.5
         # Differentiate with respect to time
         growth_rate = np.gradient(np.log(field_amplitude), time, axis=-1)
 
-        field_angle = np.angle(np.trapz(sum_fields, theta, axis=0))
+        field_angle = np.angle(np.trapezoid(sum_fields, theta, axis=0))
 
         # Change angle by 2pi for every rotation so gradient is easier to calculate
         pi_change = np.cumsum(
@@ -723,7 +723,7 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         for field in fields.values():
             field_squared += np.abs(field.m) ** 2
 
-        amplitude = np.sqrt(np.trapz(field_squared, theta, axis=0) / (2 * np.pi))
+        amplitude = np.sqrt(np.trapezoid(field_squared, theta, axis=0) / (2 * np.pi))
 
         return amplitude
 

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1256,7 +1256,7 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
             else:
                 continue
 
-            fluxes[iflux, ifield, ...] = flux
+            fluxes[iflux, ifield, ...] = flux.data
 
         for iflux, flux in enumerate(coords["flux"]):
             if not np.all(fluxes[iflux, ...] == 0):
@@ -1301,12 +1301,12 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
                 eigenfunction = raw_eigenfunction.transpose("ri", "theta", "kx", "ky")
 
                 eigenfunctions[ifield, ...] = (
-                    eigenfunction[0, ...] + 1j * eigenfunction[1, ...]
+                    eigenfunction[0, ...].data + 1j * eigenfunction[1, ...].data
                 )
 
         square_fields = np.sum(np.abs(eigenfunctions) ** 2, axis=0)
         field_amplitude = np.sqrt(
-            np.trapz(square_fields, coords["theta"], axis=0) / (2 * np.pi)
+            np.trapezoid(square_fields, coords["theta"], axis=0) / (2 * np.pi)
         )
 
         first_field = eigenfunctions[0, ...]

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -10,6 +10,7 @@ import f90nml
 import numpy as np
 import pint
 from cleverdict import CleverDict
+from scipy.integrate import trapezoid
 
 from ..constants import pi
 from ..file_utils import FileReader
@@ -1306,7 +1307,7 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
 
         square_fields = np.sum(np.abs(eigenfunctions) ** 2, axis=0)
         field_amplitude = np.sqrt(
-            np.trapezoid(square_fields, coords["theta"], axis=0) / (2 * np.pi)
+            trapezoid(square_fields, coords["theta"], axis=0) / (2 * np.pi)
         )
 
         first_field = eigenfunctions[0, ...]

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -1092,7 +1092,7 @@ class GKOutputReaderSTELLA(FileReader, file_type="STELLA", reads=GKOutput):
             else:
                 continue
 
-            fluxes[iflux, ...] = flux
+            fluxes[iflux, ...] = flux.data
 
         for iflux, flux in enumerate(coords["flux"]):
             if not np.all(fluxes[iflux, ...] == 0):

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -1097,7 +1097,7 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
             phase = np.abs(phi_theta_star) / phi_theta_star
             field_squared = np.sum(np.abs(eigenfunctions[:, i_mode, :]) ** 2, -1)
             amplitude = np.sqrt(
-                np.trapz(field_squared, coords["theta"], axis=0) / (2 * np.pi)
+                np.trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
             )
             phase_amplitude[:, i_mode, :] = phase / amplitude
 

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from cleverdict import CleverDict
+from scipy.integrate import trapezoid
 
 from ..constants import pi
 from ..file_utils import FileReader
@@ -1097,7 +1098,7 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
             phase = np.abs(phi_theta_star) / phi_theta_star
             field_squared = np.sum(np.abs(eigenfunctions[:, i_mode, :]) ** 2, -1)
             amplitude = np.sqrt(
-                np.trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
+                trapezoid(field_squared, coords["theta"], axis=0) / (2 * np.pi)
             )
             phase_amplitude[:, i_mode, :] = phase / amplitude
 

--- a/tests/databases/test_imas.py
+++ b/tests/databases/test_imas.py
@@ -132,7 +132,6 @@ def test_pyro_to_imas_roundtrip(tmp_path, input_path):
         template_dir / "outputs" / "TGLF_transport" / "input.tglf",
     ],
 )
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_pyro_to_imas_roundtrip_nonlinear(tmp_path, input_path):
 
     pyro = Pyro(gk_file=input_path)

--- a/tests/databases/test_imas.py
+++ b/tests/databases/test_imas.py
@@ -6,7 +6,6 @@ import pytest
 import numpy as np
 import os
 import shutil
-import sys
 import pint
 from pathlib import Path
 from idspy_dictionaries import ids_gyrokinetics_local

--- a/tests/equilibrium/test_equilibrium.py
+++ b/tests/equilibrium/test_equilibrium.py
@@ -270,11 +270,12 @@ def parametrized_eq(request, expected):
     return eq
 
 
-def test_parametrized_eq_dims(parametrized_eq, expected):
-    dims = parametrized_eq.dims
-    assert dims["R_dim"] == expected["n_R"]
-    assert dims["Z_dim"] == expected["n_Z"]
-    assert dims["psi_dim"] == expected["n_psi"]
+def test_parametrized_eq_sizes(parametrized_eq, expected):
+    sizes = parametrized_eq.sizes
+    assert sizes["R_dim"] == expected["n_R"]
+    assert sizes["Z_dim"] == expected["n_Z"]
+    assert sizes["psi_dim"] == expected["n_psi"]
+    print(sizes["R_dim"], expected["n_R"])
 
 
 def test_parametrized_eq_coords(parametrized_eq, expected):

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -207,7 +207,8 @@ def test_amplitude(load_fields):
     field_squared = np.abs(eigenfunctions) ** 2
 
     amplitude = np.sqrt(
-        field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
+        field_squared.pint.dequantify().sum(dim="field").integrate(coord="theta")
+        / (2 * np.pi)
     )
 
     assert hasattr(eigenfunctions.data, "units")

--- a/tests/gk_code/test_gk_output_reader_stella.py
+++ b/tests/gk_code/test_gk_output_reader_stella.py
@@ -102,7 +102,8 @@ def test_amplitude(load_fields):
     field_squared = np.abs(eigenfunctions) ** 2
 
     amplitude = np.sqrt(
-        field_squared.sum(dim="field").integrate(coord="theta") / (2 * np.pi)
+        field_squared.pint.dequantify().sum(dim="field").integrate(coord="theta")
+        / (2 * np.pi)
     )
 
     assert hasattr(eigenfunctions.data, "units")


### PR DESCRIPTION
Tests in #395 failing with python>3.9 due to deprecation warning becoming an error in `numpy=2.2.0` inside `idspy_toolkit`.

```
if field_value[()] in default_vals_list:
ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.
```

Could maybe get this fixed in `idspy_toolkit` but with `imaspy` being made public and hopefully on PyPi soon its not worth doing too much to fix this.

Also fixed a bunch of small things causing other deprecation/unnecessary warnings but currently the above is causing over 1600 warnings...