### PR TITLE
Minor/find gs2 species type without reading the input data

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1217,16 +1217,6 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         fields = {"phi": "es", "apar": "apar", "bpar": "bpar"}
         fluxes_dict = {"particle": "part", "heat": "heat", "momentum": "mom"}
 
-        # Get species names from input file
-        species = []
-        ion_num = 0
-        for idx in range(gk_input.data["species_knobs"]["nspec"]):
-            if gk_input.data[f"species_parameters_{idx+1}"]["z"] == -1:
-                species.append("electron")
-            else:
-                ion_num += 1
-                species.append(f"ion{ion_num}")
-
         results = {}
 
         coord_names = ["flux", "field", "species", "ky", "time"]

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1119,12 +1119,14 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
                 field_vals["bpar"] = 0.0
         fields = [field for field, val in field_vals.items() if val > 0]
 
-        # species coords
-        # TODO is there some way to get this info without looking at the input data?
+        # species coords - Note this assumes the gs2 charge normalisation
+        # is the proton charge. We could instead use the "type_of_species"
+        # property instead, but would then need to maintain the mapping
+        # from this integer to the actual species type (unlikely to change).
         species = []
         ion_num = 0
-        for idx in range(gk_input.data["species_knobs"]["nspec"]):
-            if gk_input.data[f"species_parameters_{idx + 1}"]["z"] == -1:
+        for idx, z in enumerate(raw_data["charge"].data):
+            if np.isclose(-1):
                 species.append("electron")
             else:
                 ion_num += 1

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1125,8 +1125,8 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         # from this integer to the actual species type (unlikely to change).
         species = []
         ion_num = 0
-        for idx, z in enumerate(raw_data["charge"].data):
-            if np.isclose(-1):
+        for z in raw_data["charge"].data:
+            if np.isclose(z, -1):
                 species.append("electron")
             else:
                 ion_num += 1

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -302,8 +302,10 @@ def mock_reader(monkeypatch, request):
                 np.ones(gs2_field_shape),
             )
 
-        data_vars["charge"] = [self.data[f"species_parameters_{num+1}"]["z"]
-                               for num in range(self.data["species_knobs"]["nspec"])]
+        data_vars["charge"] = [
+            self.data[f"species_parameters_{num+1}"]["z"]
+            for num in range(self.data["species_knobs"]["nspec"])
+        ]
 
         moments = ["part", "heat", "mom"]
         for field, moment in product(fields, moments):

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -302,6 +302,9 @@ def mock_reader(monkeypatch, request):
                 np.ones(gs2_field_shape),
             )
 
+        data_vars["charge"] = [self.data[f"species_parameters_{num+1}"]["z"]
+                               for num in range(self.data["species_knobs"]["nspec"])]
+
         moments = ["part", "heat", "mom"]
         for field, moment in product(fields, moments):
             flux_field = "es" if field == "phi" else field

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -302,10 +302,7 @@ def mock_reader(monkeypatch, request):
                 np.ones(gs2_field_shape),
             )
 
-        data_vars["charge"] = [
-            self.data[f"species_parameters_{num+1}"]["z"]
-            for num in range(self.data["species_knobs"]["nspec"])
-        ]
+        data_vars["charge"] = [-1, 1]
 
         moments = ["part", "heat", "mom"]
         for field, moment in product(fields, moments):


### PR DESCRIPTION
Try to fix a simple TODO and avoid inspecting input parameters to determine GS2 species types.