### PR TITLE
Saturation rules - KBM MG rule

### DIFF
--- a/docs/examples/example_saturation.py
+++ b/docs/examples/example_saturation.py
@@ -1,0 +1,77 @@
+from pyrokinetics import Pyro, PyroScan
+from pyrokinetics.diagnostics.saturation_rules import SaturationRules
+import numpy as np
+
+# Choose convention
+output_convention = "pyrokinetics"
+
+# Base file
+base_dir = "/common/CSD3/ir-giac2/t3d/resolution/nth128/restart6/outputs"
+base_file = "r3-ky0-th00-0.in"
+
+pyro = Pyro(gk_file=f"{base_dir}/{base_file}")
+
+base_ky = pyro.numerics.ky.to(pyro.norms.pyrokinetics).m / 2
+
+# Set up ky and theta0 grid
+param_1 = "ky"
+param_2 = "th0"
+
+kys = np.array([2, 3, 5, 10, 20, 30, 40, 50, 70, 100, 120, 140]) * base_ky
+th0s = np.array([0, 0.1, 0.2, 0.4, 1.2, 3.14])
+
+values_1 = kys
+values_2 = th0s
+
+# Create dictionary mapping input files to parameters in scan
+runfile_dict = {}
+for iky, ky in enumerate(kys):
+    for ith0, th0 in enumerate(th0s):
+        runfile_dict[
+            (f"{param_1}_{values_1[iky]}", f"{param_2}_{values_2[ith0]}")
+        ] = f"{base_dir}/r3-ky{iky}-th0{ith0}-0.in"
+
+# Dictionary of param and values
+param_dict = {param_1: values_1, param_2: values_2}
+
+# Create PyroScan object
+pyro_scan = PyroScan(
+    pyro,
+    param_dict,
+    value_fmt="d",
+    value_separator="",
+    parameter_separator="-",
+    file_name="",
+    base_directory=base_dir,
+    runfile_dict=runfile_dict,
+)
+
+# Add in path to each defined parameter to scan through
+pyro_scan.add_parameter_key(
+    param_1, "gk_input", ["data", "kt_grids_single_parameters", "n0"]
+)
+
+# Load outputs
+pyro_scan.load_gk_output(output_convention=output_convention, tolerance_time_range=0.9)
+
+# Create saturation object
+saturation = SaturationRules(pyro_scan)
+
+# Inputs for QL model
+alpha = 2.5
+Q0 = 25
+
+# Must match convention
+gamma_exb = 0.04380304982261718
+
+qflux = saturation.mg_saturation(
+    Q0=Q0,
+    alpha=alpha,
+    gamma_exb=gamma_exb,
+    output_convention=output_convention,
+    gamma_tolerance=0.3,
+    equal_arc_theta=True,
+    theta0_dim="th0",
+)
+
+print("Heat flux calculation", qflux)

--- a/docs/examples/example_saturation.py
+++ b/docs/examples/example_saturation.py
@@ -64,7 +64,7 @@ Q0 = 25
 # Must match convention
 gamma_exb = 0.04380304982261718
 
-qflux = saturation.mg_saturation(
+gk_output = saturation.mg_saturation(
     Q0=Q0,
     alpha=alpha,
     gamma_exb=gamma_exb,
@@ -74,4 +74,6 @@ qflux = saturation.mg_saturation(
     theta0_dim="th0",
 )
 
-print("Heat flux calculation", qflux)
+print("GK output", gk_output)
+print("Heat flux calculation", gk_output["heat"])
+print("Gamma flux calculation", gk_output["particle"])

--- a/src/pyrokinetics/diagnostics/saturation_rules.py
+++ b/src/pyrokinetics/diagnostics/saturation_rules.py
@@ -27,6 +27,35 @@ class SaturationRules:
         ky_dim: str = "ky",
         theta0_dim: str = "theta0",
     ):
+        """
+        Please see doi:10.1017/S0022377824001107 for details on this quasi-linear model.
+
+        Parameters
+        ----------
+        Q0: float
+            Heat flux absolute magnitude from fitted model
+        alpha: float
+            Power to raise QL metric Lambda
+        gamma_exb: float
+            Rate of ExB shear. Note must be in units matching output_convention
+        output_convention: str
+            Choice of output convention
+        gamma_tolerance: float
+            Tolerance of growth rate to be included in calculation
+        equal_arc_theta: bool
+            Whether theta grid is equally spaced in arc length
+        ky_dim: str
+            Name of the dimension in PyroScan object corresponding to ky
+        theta0_dim
+            Name of the dimension in PyroScan object corresponding to theta0
+
+        Returns
+        -------
+        gk_output: xr.Dataset
+            Dataset containing heat and particle flux with dimensions of Species and
+            other in original PyroScan object
+
+        """
         if not hasattr(self.pyro_scan, "gk_output"):
             self.pyro_scan.load_gk_output(output_convention=output_convention)
 

--- a/src/pyrokinetics/diagnostics/saturation_rules.py
+++ b/src/pyrokinetics/diagnostics/saturation_rules.py
@@ -1,8 +1,8 @@
-from ..pyroscan import PyroScan
-
 import numpy as np
-from scipy.integrate import cumulative_trapezoid
 import xarray as xr
+from scipy.integrate import cumulative_trapezoid
+
+from ..pyroscan import PyroScan
 
 
 class SaturationRules:

--- a/src/pyrokinetics/diagnostics/saturation_rules.py
+++ b/src/pyrokinetics/diagnostics/saturation_rules.py
@@ -1,0 +1,170 @@
+from ..pyroscan import PyroScan
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import numpy as np
+from scipy.integrate import cumulative_trapezoid
+
+class SaturationRules:
+    r"""
+    Contains all the different saturation rules that can be applied
+
+    Need a PyroScan object to apply the rule to
+    """
+    
+    def __init__(self, pyro_scan):
+
+        self.pyro_scan = pyro_scan
+
+    def mg_saturation(
+            self,
+            Q0: float = 25.0,
+            alpha: float = 2.5,
+            gamma_exb: float = 0.0,
+            output_convention: str = "pyrokinetics",
+            gamma_tolerance: float = 0.001,
+            equal_arc_theta: bool = True,
+            ky_dim: str = "ky",
+            theta0_dim: str = "theta0",
+            k_perp_in = None,
+    ):
+        if not self.pyro_scan.gk_output:
+            self.pyro_scan.load_gk_output(output_convention=output_convention)
+
+        data = self.pyro_scan.gk_output
+        pyro = self.pyro_scan.base_pyro
+
+        kys = data[ky_dim]
+        theta0s = data[theta0_dim]
+
+        shat = pyro.local_geometry.shat
+        bunit_over_b0 = pyro.local_geometry.bunit_over_b0.m
+
+        theta = data["theta"].data
+        eigenfunctions = data["eigenfunctions"]
+        growth_rate_tolerance = data["growth_rate_tolerance"]
+
+        growth_rate = data["growth_rate"].where(growth_rate_tolerance < gamma_tolerance, 0.0)
+
+        heat_tot = data["heat"].sum(dim=("field", "species"))
+        heat = (
+            data["heat"].where(growth_rate_tolerance < gamma_tolerance, 0.0).sum(dim="field")
+        / heat_tot
+        )
+        field_squared = (
+            np.abs(data["eigenfunctions"].where(growth_rate_tolerance < gamma_tolerance, 0.0)) ** 2
+        )
+
+        # Set up Jacobian and k_perp
+        k_perp = field_squared.data * 0.0
+        jacobian = field_squared.data * 0.0
+
+        # Need to load MetricTerms
+        pyro.load_metric_terms(ntheta=1024)
+        theta_metric = pyro.metric_terms.regulartheta
+
+        # Add one to cover additional theta grids (like in CGYRO)
+        nperiod = pyro.numerics.nperiod + 1
+        g_tt = pyro.metric_terms.field_aligned_covariant_metric("theta", "theta")
+
+        # Can remove when we adjust outputs to handle equal_arc = True in GS2
+        if equal_arc_theta:
+            # Parallel gradient
+            grho = np.sqrt(g_tt)
+
+            # regulartheta foes from -pi to pi
+            l_theta = cumulative_trapezoid(grho, theta_metric, initial=0.0)
+            g_tt_eq = (l_theta[-1] / (2 * np.pi)) ** 2
+            
+            l_theta *= 1.0 / l_theta[-1] * 2 * np.pi
+            l_theta += -np.pi
+        else:
+            l_theta = theta_metric
+
+        # Geometric theta on grid on evenly spaced l(theta) grid
+        even_l_theta = np.linspace(-np.pi, np.pi, len(l_theta))
+        theta_geo = np.interp(even_l_theta, l_theta, theta_metric)
+        
+        m = np.linspace(-(nperiod - 1), nperiod - 1, 2 * nperiod - 1)
+        ntheta = len(theta_geo) - 1
+        m = np.repeat(m, ntheta)
+        theta_geo_long = np.tile(theta_geo[:-1], 2 * nperiod - 1) + 2.0 * np.pi * m
+        
+        # L(theta) grid on regular theta grid long
+        m = np.linspace(-(nperiod - 1), nperiod - 1, 2 * nperiod - 1)
+        ntheta = len(l_theta) - 1
+        m = np.repeat(m, ntheta)
+        l_theta_long = np.tile(l_theta[:-1], 2 * nperiod - 1) + 2.0 * np.pi * m
+        
+        for itheta0, theta0 in enumerate(theta0s.data):
+            theta_long, k_perp_long = pyro.metric_terms.k_perp(
+                ky=1.0, theta0=theta0, nperiod=nperiod
+            )
+
+            # Interp on to equal arc grid
+            if equal_arc_theta:
+                k_perp_interp = np.interp(theta, l_theta_long, k_perp_long)
+            else:
+                k_perp_interp = np.interp(theta, theta_long, k_perp_long)
+            for iky, ky in enumerate(kys.data):
+                # Technically k_perp / ky
+                k_perp[iky, itheta0, :, :] = k_perp_interp.m * ky * bunit_over_b0
+        
+        bmag = pyro.metric_terms.B_magnitude
+        
+        if equal_arc_theta:
+            bmag_eq_arc = np.interp(theta_geo, theta_metric, bmag)
+            bmag_long = np.tile(bmag_eq_arc[:-1], 2 * nperiod - 1)
+            pyro_jacob = pyro.metric_terms.dpsidr * np.sqrt(g_tt_eq) / bmag_long
+        else:
+            g_tt_long = np.tile(g_tt[:-1], 2 * nperiod - 1)
+            bmag_long = np.tile(bmag[:-1], 2 * nperiod - 1)
+            pyro_jacob = pyro.metric_terms.dpsidr * np.sqrt(g_tt_long) / bmag_long
+
+        jacobian_long = pyro_jacob
+
+        # Extend onto ballooning space
+        jacobian = np.interp(theta, theta_long, jacobian_long)[
+            np.newaxis, np.newaxis, np.newaxis, :
+        ]
+        
+        # Numerator in Lambda
+        numerator = (field_squared * jacobian).integrate(coord="theta")
+        
+        # Denominator
+        denom = (field_squared * jacobian * k_perp**2).integrate(coord="theta")
+
+        # Ratio of fields
+        field_factor = np.sqrt(
+            field_squared.max(dim="theta") / field_squared.sel(field="phi").max(dim="theta")
+        )
+        
+        # Sum over fields
+        ql_metric = (growth_rate * numerator * field_factor / denom).sum(dim="field")
+
+        # Q_ql = Q_ql * Lambda
+        heat_ql = heat * ql_metric
+        
+        # Find theta0_max
+        max_gam = growth_rate.max(dim=theta0_dim)
+        thmax = gamma_exb / (shat * max_gam)
+
+        thmax = thmax.where(thmax < np.pi, np.pi)
+        thmax = thmax.where(thmax > theta0s[1], theta0s[1])
+        
+        # Select relevant theta0
+        heat_theta0 = heat_ql.where(theta0s < thmax, 0.0) / thmax
+        ql_metric_theta0 = ql_metric.where(theta0s < thmax, 0.0) / thmax
+        
+        # Integrate up to theta0_max
+        heat_ky = heat_theta0.integrate(coord=theta0_dim)
+        ql_metric_ky = ql_metric_theta0.integrate(coord=theta0_dim)
+        
+        # Integrate over ky
+        heat = heat_ky.integrate(coord=ky_dim)
+        ql_metric = ql_metric_ky.integrate(coord=ky_dim)
+
+        # Full flux calculation
+        qflux = Q0 * heat * ql_metric ** (alpha - 1)
+        
+        return qflux
+

--- a/src/pyrokinetics/diagnostics/saturation_rules.py
+++ b/src/pyrokinetics/diagnostics/saturation_rules.py
@@ -97,8 +97,6 @@ class SaturationRules:
 
         # Set up Jacobian and k_perp
         k_perp = field_squared.data * 0.0
-        jacobian = field_squared.data * 0.0
-        field_factor = field_squared.data * 0.0
 
         # Need to load MetricTerms
         pyro.load_metric_terms(ntheta=1024)

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1141,6 +1141,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             ntheta = ntheta_ballooning
             kx = [0.0]
             nkx = 1
+            theta0 = theta[int(ntheta) // 2 + ntheta_plot // 2]
         else:
             # Output data actually given on theta_plot grid
             ntheta = ntheta_plot
@@ -1151,6 +1152,9 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 * np.linspace(-int(nkx / 2), int((nkx + 1) / 2) - 1, nkx)
                 / length_x
             ) / bunit_over_b0
+            theta0 = 0.0
+
+        theta += -theta0
 
         # Get rho_star from equilibrium file
         if len(raw_data["equilibrium"]) == 54 + 7 * nspecies:

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -806,7 +806,8 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         import pint_xarray  # noqa
         import xarray as xr
 
-        data = self.data.expand_dims("ReIm", axis=-1)  # Add ReIm axis at the end
+        # Add ReIm axis at the end
+        data = self.data.expand_dims("ReIm", axis=-1)
         data = xr.concat([data.real, data.imag], dim="ReIm")
 
         data.pint.dequantify().to_netcdf(*args, **kwargs)

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1296,13 +1296,20 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         )
 
         # Loop through all fields and add eigenfunction if it exists
+        bmag = raw_data["bmag"].data[
+            :,
+            np.newaxis,
+            np.newaxis,
+        ]
+        scale_factor = [1.0, 0.5, bmag]
+
         for ifield, raw_eigenfunction in enumerate(raw_eig_data):
             if raw_eigenfunction is not None:
                 eigenfunction = raw_eigenfunction.transpose("ri", "theta", "kx", "ky")
 
                 eigenfunctions[ifield, ...] = (
                     eigenfunction[0, ...] + 1j * eigenfunction[1, ...]
-                )
+                ) * scale_factor[ifield]
 
         square_fields = np.sum(np.abs(eigenfunctions) ** 2, axis=0)
         field_amplitude = np.sqrt(

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -818,9 +818,17 @@ class MetricTerms:  # CleverDict
 
         theta = theta + 2.0 * np.pi * m
 
-        g_rr = self.field_aligned_contravariant_metric("r", "r")[:-1]
-        g_ra = self.field_aligned_contravariant_metric("r", "alpha")[:-1]
-        g_aa = self.field_aligned_contravariant_metric("alpha", "alpha")[:-1]
+        g_rr = self.field_aligned_contravariant_metric("r", "r")
+        g_ra = self.field_aligned_contravariant_metric("r", "alpha")
+        g_aa = self.field_aligned_contravariant_metric("alpha", "alpha")
+
+        g_rr_final = g_rr[-1]
+        g_ra_final = g_ra[-1]
+        g_aa_final = g_aa[-1]
+
+        g_rr = g_rr[:-1]
+        g_ra = g_ra[:-1]
+        g_aa = g_aa[:-1]
 
         g_xx = np.tile(g_rr, 2 * nperiod - 1)
         g_xy = np.tile(g_ra, 2 * nperiod - 1) * Cy
@@ -830,6 +838,18 @@ class MetricTerms:  # CleverDict
         kx = shat * (theta0 + m * 2.0 * np.pi)
 
         k_perp2 = g_xx * kx**2 + 2.0 * g_xy * kx + g_yy
+
+        # Append final point
+        theta_final = 2*np.pi * (m[-1]) + np.pi
+        kx_final = shat * (theta0 + theta_final - np.pi)
+        g_xx_final = g_rr_final
+        g_xy_final = g_ra_final * Cy
+        g_yy_final = g_aa_final * Cy**2
+
+        k_perp2_final = g_xx_final * kx_final**2 + 2.0 * g_xy_final * kx_final + g_yy_final
+
+        theta = np.append(theta, theta_final)
+        k_perp2 = np.append(k_perp2, k_perp2_final)
 
         # Need to normalise to ky
         k_perp = np.sqrt(k_perp2) * ky

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -840,13 +840,15 @@ class MetricTerms:  # CleverDict
         k_perp2 = g_xx * kx**2 + 2.0 * g_xy * kx + g_yy
 
         # Append final point
-        theta_final = 2*np.pi * (m[-1]) + np.pi
+        theta_final = 2 * np.pi * (m[-1]) + np.pi
         kx_final = shat * (theta0 + theta_final - np.pi)
         g_xx_final = g_rr_final
         g_xy_final = g_ra_final * Cy
         g_yy_final = g_aa_final * Cy**2
 
-        k_perp2_final = g_xx_final * kx_final**2 + 2.0 * g_xy_final * kx_final + g_yy_final
+        k_perp2_final = (
+            g_xx_final * kx_final**2 + 2.0 * g_xy_final * kx_final + g_yy_final
+        )
 
         theta = np.append(theta, theta_final)
         k_perp2 = np.append(k_perp2, k_perp2_final)

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -283,7 +283,9 @@ class PyroScan:
         parameter_location = ["kappa"]
         self.add_parameter_key(parameter_key, parameter_attr, parameter_location)
 
-    def load_gk_output(self, output_convention="pyrokinetics"):
+    def load_gk_output(
+        self, output_convention="pyrokinetics", tolerance_time_range=0.8
+    ):
         """
         Loads GKOutput as a xarray Sataset
 
@@ -316,6 +318,7 @@ class PyroScan:
             # Load gk_output in copies of pyro
             for pyro in self.pyro_dict.values():
                 try:
+
                     pyro.load_gk_output(output_convention=output_convention)
 
                     if "time" in pyro.gk_output.dims:
@@ -353,9 +356,9 @@ class PyroScan:
                                 .drop_vars(["time"])
                             )
 
-                        tolerance = pyro.gk_output[
-                            "growth_rate_tolerance"
-                        ].data.flatten()[0]
+                        tolerance = pyro.gk_output.get_growth_rate_tolerance(
+                            tolerance_time_range
+                        )
 
                         growth_rate_tolerance.append(tolerance)
 

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -48,6 +48,7 @@ class PyroScan:
         base_directory=".",
         load_default_parameter_keys=True,
         pyroscan_json=None,
+        runfile_dict=None,
     ):
         # Mapping from parameter to location in Pyro
         self.parameter_map = {}
@@ -104,6 +105,9 @@ class PyroScan:
         # Get len of values for each parameter
         self.value_size = [len(value) for value in self.parameter_dict.values()]
 
+        # Used to overwrite default pyro method of reading files
+        self.runfile_dict = runfile_dict
+
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
         )
@@ -113,12 +117,16 @@ class PyroScan:
         """
         Concatenate parameter names/values with separator
         """
-        return self.parameter_separator.join(
-            (
-                f"{param}{self.value_separator}{getattr(value, 'magnitude', value):{self.value_fmt}}"
-                for param, value in parameters.items()
+        if self.runfile_dict is not None:
+            key = tuple(f"{key}_{value}" for key, value in parameters.items())
+            return self.runfile_dict[key]
+        else:
+            return self.parameter_separator.join(
+                (
+                    f"{param}{self.value_separator}{getattr(value, 'magnitude', value):{self.value_fmt}}"
+                    for param, value in parameters.items()
+                )
             )
-        )
 
     def create_single_run(self, parameters: dict):
         """
@@ -126,7 +134,8 @@ class PyroScan:
         """
         name = self.format_single_run_name(parameters)
         new_run = copy.deepcopy(self.base_pyro)
-        new_run.gk_file = self.base_directory / name / self.file_name
+
+        new_run.gk_file = self.base_directory / (str(name) + self.file_name)
         new_run.run_parameters = copy.deepcopy(parameters)
         return name, new_run
 
@@ -232,7 +241,8 @@ class PyroScan:
 
         for example
 
-        {'electron_temp_gradient': ["local_species", ['electron','inverse_lt']] }
+        {'electron_temp_gradient': [
+            "local_species", ['electron','inverse_lt']] }
         """
 
         self.parameter_map = {}
@@ -273,7 +283,7 @@ class PyroScan:
         parameter_location = ["kappa"]
         self.add_parameter_key(parameter_key, parameter_attr, parameter_location)
 
-    def load_gk_output(self):
+    def load_gk_output(self, output_convention="pyrokinetics"):
         """
         Loads GKOutput as a xarray Sataset
 
@@ -306,7 +316,7 @@ class PyroScan:
             # Load gk_output in copies of pyro
             for pyro in self.pyro_dict.values():
                 try:
-                    pyro.load_gk_output()
+                    pyro.load_gk_output(output_convention=output_convention)
 
                     if "time" in pyro.gk_output.dims:
                         growth_rate.append(pyro.gk_output["growth_rate"].isel(time=-1))

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -135,7 +135,7 @@ class PyroScan:
         name = self.format_single_run_name(parameters)
         new_run = copy.deepcopy(self.base_pyro)
 
-        new_run.gk_file = self.base_directory / (str(name) + self.file_name)
+        new_run.gk_file = self.base_directory / name / self.file_name
         new_run.run_parameters = copy.deepcopy(parameters)
         return name, new_run
 


### PR DESCRIPTION
In this PR I add in the saturation rule from https://arxiv.org/abs/2404.17453 designed for KBM turbulence.

The model has two inputs ($Q_0$ and $\alpha$) and takes in a `PyroScan` object that has the dimensions ($k_y$ and $\theta_0$).  Note I have added the ability to load a `PyroScan` object by specifying a dictionary that maps the different parameter values to an input file so it is easier to load in pre-existing scans.

This should be extensible to any number of dimensions but this particular saturation rule requires those two dimensions.

I've written it in such a way that it should be straightforward to add in other saturation rules (TGLF sat for example). It is current imported from `diagnostics` but maybe it deserves its own folder...

@tomneiser this is what I was thinking a similar set up could be for TGLF. Could pass a `GKInputTGLF` file along with a `PyroScan` to get the fluxes.


I've included an example script and found that it matches T3D simulation results so pretty happy with it as is. Had to do quite a bit of fiddling with the outputs as it was trained using the default pyro units but there were subtleties in the unit conversion with ratios/definitions of the fields.

If the rule gets updated in the future we can likely adjust this and simplify the whole conversions.

```python
from pyrokinetics import Pyro, PyroScan
from pyrokinetics.diagnostics.saturation_rules import SaturationRules
import numpy as np

# Choose convention
output_convention = "pyrokinetics"

# Base file
base_dir = "/common/CSD3/ir-giac2/t3d/resolution/nth128/restart6/outputs"
base_file = "r3-ky0-th00-0.in"

pyro = Pyro(gk_file=f"{base_dir}/{base_file}")

base_ky = pyro.numerics.ky.to(pyro.norms.pyrokinetics).m / 2

# Set up ky and theta0 grid
param_1 = "ky"
param_2 = "th0"

kys = np.array([2, 3, 5, 10, 20, 30, 40, 50, 70, 100, 120, 140]) * base_ky
th0s = np.array([0, 0.1, 0.2, 0.4, 1.2, 3.14])

values_1 = kys
values_2 = th0s

# Create dictionary mapping input files to parameters in scan
runfile_dict = {}
for iky, ky in enumerate(kys):
    for ith0, th0 in enumerate(th0s):
        runfile_dict[
            (f"{param_1}_{values_1[iky]}", f"{param_2}_{values_2[ith0]}")
        ] = f"{base_dir}/r3-ky{iky}-th0{ith0}-0.in"

# Dictionary of param and values
param_dict = {param_1: values_1, param_2: values_2}

# Create PyroScan object
pyro_scan = PyroScan(
    pyro,
    param_dict,
    value_fmt="d",
    value_separator="",
    parameter_separator="-",
    file_name="",
    base_directory=base_dir,
    runfile_dict=runfile_dict,
)

# Add in path to each defined parameter to scan through
pyro_scan.add_parameter_key(
    param_1, "gk_input", ["data", "kt_grids_single_parameters", "n0"]
)

# Load outputs
pyro_scan.load_gk_output(output_convention=output_convention, tolerance_time_range=0.9)

# Create saturation object
saturation = SaturationRules(pyro_scan)

# Inputs for QL model
alpha = 2.5
Q0 = 25

# Must match convention
gamma_exb = 0.04380304982261718

gk_output = saturation.mg_saturation(
    Q0=Q0,
    alpha=alpha,
    gamma_exb=gamma_exb,
    output_convention=output_convention,
    gamma_tolerance=0.3,
    equal_arc_theta=True,
    theta0_dim="th0",
)

print("GK output", gk_output)
print("Heat flux calculation", gk_output["heat"])
print("Gamma flux calculation", gk_output["particle"])

```

~Currently this just returns an `xr.DataArray` with the heat flux as a function of species but this could/should be extended to be a general `GKOutput` object.~
Now the output is an xarray Dataset, currently with the heat flux and particle flux for each species

```
GK output <xarray.Dataset>
Dimensions:   (species: 2)
Coordinates:
  * species   (species) <U8 'electron' 'ion1'
Data variables:
    heat      (species) float64 [([tref] / [mref])**(0.5)·([tref] / [mref])**(0.5) * [mref] / [bref_B0])²·nref_electron·tref_electron/lref_minor_radius²] ...
    particle  (species) float64 [([tref] / [mref])**(0.5)·([tref] / [mref])**(0.5) * [mref] / [bref_B0])²·nref_electron/lref_minor_radius²] ...
Heat flux calculation <xarray.DataArray 'heat' (species: 2)>
<Quantity([0.09994335 0.17957855], 'nref_electron * rhoref_pyro ** 2 * tref_electron * vref_nrl / lref_minor_radius ** 2')>
Coordinates:
  * species  (species) <U8 'electron' 'ion1'
Gamma flux calculation <xarray.DataArray 'particle' (species: 2)>
<Quantity([0.01806394 0.01806394], 'nref_electron * rhoref_pyro ** 2 * vref_nrl / lref_minor_radius ** 2')>
Coordinates:
  * species  (species) <U8 'electron' 'ion1'

```

@arkabokshi FYI