### PR TITLE
Add option to handle loading in adiabatic electrons in GS2/STELLA

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -604,13 +604,13 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             electron_density = dens
             electron_temperature = temp
             e_mass = mass
-            electron_index = len(densities)
+            electron_index = 0
             found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(0)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(0)
 
             densities.append(dens)
             temperatures.append(temp)
@@ -626,13 +626,13 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                     electron_density = dens
                     electron_temperature = temp
                     e_mass = mass
-                    electron_index = len(densities)
+                    electron_index = i_sp
                     found_electron = True
 
                 if np.isclose(dens, 1.0):
-                    reference_density_index.append(len(densities))
+                    reference_density_index.append(i_sp)
                 if np.isclose(temp, 1.0):
-                    reference_temperature_index.append(len(temperatures))
+                    reference_temperature_index.append(i_sp)
 
                 densities.append(dens)
                 temperatures.append(temp)

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -1022,13 +1022,13 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                 electron_density = dens
                 electron_temperature = temp
                 e_mass = mass
-                electron_index = len(densities)
+                electron_index = i_sp
                 found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(i_sp)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(i_sp)
 
             densities.append(dens)
             temperatures.append(temp)

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -527,13 +527,13 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
                 electron_density = dens
                 electron_temperature = temp
                 e_mass = mass
-                electron_index = len(densities)
+                electron_index = i_sp
                 found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(i_sp)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(i_sp)
 
             densities.append(dens)
             temperatures.append(temp)

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -624,7 +624,6 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             and self.data["dist_fn_knobs"]["adiabatic_option"]
             in adiabatic_electron_flags
         ):
-            adiabatic_electron = True
             found_electron = True
             nspec = self.data["species_knobs"]["nspec"] + 1
             species_key = f"species_parameters_{nspec}"

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -12,7 +12,7 @@ import pint
 from cleverdict import CleverDict
 from scipy.integrate import trapezoid
 
-from ..constants import pi
+from ..constants import deuterium_mass, electron_mass, pi
 from ..file_utils import FileReader
 from ..local_geometry import LocalGeometry, LocalGeometryMiller, default_miller_inputs
 from ..local_species import LocalSpecies
@@ -625,12 +625,16 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             in adiabatic_electron_flags
         ):
             found_electron = True
-            nspec = self.data["species_knobs"]["nspec"] + 1
-            species_key = f"species_parameters_{nspec}"
 
-            electron_density = self.data[species_key]["dens"]
-            electron_temperature = self.data[species_key]["temp"]
-            e_mass = self.data[species_key]["mass"]
+            # Set from quasi-neutrality
+            qn_dens = 0.0
+            for i_sp in range(self.data["species_knobs"]["nspec"]):
+                species_key = f"species_parameters_{i_sp + 1}"
+                qn_dens += self.data[species_key]["dens"] * self.data[species_key]["z"]
+
+            electron_density = qn_dens
+            electron_temperature = 1.0 / self.data["knobs"].get("tite", 1.0)
+            e_mass = (electron_mass / deuterium_mass).m
 
         rgeo_rmaj = (
             self.data["theta_grid_parameters"]["r_geo"]

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -635,6 +635,13 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             electron_density = qn_dens
             electron_temperature = 1.0 / self.data["knobs"].get("tite", 1.0)
             e_mass = (electron_mass / deuterium_mass).m
+            n_species = self.data["species_knobs"]["nspec"]
+            electron_index = n_species + 1
+
+            if np.isclose(electron_density, 1.0):
+                reference_density_index.append(n_species + 1)
+            if np.isclose(electron_temperature, 1.0):
+                reference_temperature_index.append(n_species + 1)
 
         rgeo_rmaj = (
             self.data["theta_grid_parameters"]["r_geo"]

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -617,6 +617,22 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             temperatures.append(temp)
             masses.append(mass)
 
+        adiabatic_electron_flags = ["iphi00=2", "field-line-average-term"]
+
+        if (
+            not found_electron
+            and self.data["dist_fn_knobs"]["adiabatic_option"]
+            in adiabatic_electron_flags
+        ):
+            adiabatic_electron = True
+            found_electron = True
+            nspec = self.data["species_knobs"]["nspec"] + 1
+            species_key = f"species_parameters_{nspec}"
+
+            electron_density = self.data[species_key]["dens"]
+            electron_temperature = self.data[species_key]["temp"]
+            e_mass = self.data[species_key]["mass"]
+
         rgeo_rmaj = (
             self.data["theta_grid_parameters"]["r_geo"]
             / self.data["theta_grid_parameters"]["rmaj"]

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -605,13 +605,13 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
                 electron_density = dens
                 electron_temperature = temp
                 e_mass = mass
-                electron_index = len(densities)
+                electron_index = i_sp
                 found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(i_sp)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(i_sp)
 
             densities.append(dens)
             temperatures.append(temp)

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -517,7 +517,6 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             and self.data["physics_flag"]["adiabatic_option"]
             in adiabatic_electron_flags
         ):
-            adiabatic_electron = True
             found_electron = True
             nspec = self.data["species_knobs"]["nspec"] + 1
             species_key = f"species_parameters_{nspec}"

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -10,7 +10,7 @@ import numpy as np
 import pint
 from cleverdict import CleverDict
 
-from ..constants import pi
+from ..constants import deuterium_mass, electron_mass, pi
 from ..file_utils import FileReader
 from ..local_geometry import LocalGeometry, LocalGeometryMiller, default_miller_inputs
 from ..local_species import LocalSpecies
@@ -518,12 +518,9 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             in adiabatic_electron_flags
         ):
             found_electron = True
-            nspec = self.data["species_knobs"]["nspec"] + 1
-            species_key = f"species_parameters_{nspec}"
-
-            electron_density = self.data[species_key]["dens"]
-            electron_temperature = self.data[species_key]["temp"]
-            e_mass = self.data[species_key]["mass"]
+            electron_density = 1.0 / self.data["parameters"].get("nine", 1.0)
+            electron_temperature = 1.0 / self.data[species_key].get("tite", 1.0)
+            e_mass = (electron_mass / deuterium_mass).m
 
         rgeo_rmaj = (
             self.data["millergeo_parameters"]["rgeo"]

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -498,13 +498,13 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
                 electron_density = dens
                 electron_temperature = temp
                 e_mass = mass
-                electron_index = len(densities)
+                electron_index = i_sp
                 found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(i_sp)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(i_sp)
 
             densities.append(dens)
             temperatures.append(temp)

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -510,6 +510,22 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             temperatures.append(temp)
             masses.append(mass)
 
+        adiabatic_electron_flags = ["iphi00=2", "field-line-average-term"]
+
+        if (
+            not found_electron
+            and self.data["physics_flag"]["adiabatic_option"]
+            in adiabatic_electron_flags
+        ):
+            adiabatic_electron = True
+            found_electron = True
+            nspec = self.data["species_knobs"]["nspec"] + 1
+            species_key = f"species_parameters_{nspec}"
+
+            electron_density = self.data[species_key]["dens"]
+            electron_temperature = self.data[species_key]["temp"]
+            e_mass = self.data[species_key]["mass"]
+
         rgeo_rmaj = (
             self.data["millergeo_parameters"]["rgeo"]
             / self.data["millergeo_parameters"]["rmaj"]

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -521,6 +521,13 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             electron_density = 1.0 / self.data["parameters"].get("nine", 1.0)
             electron_temperature = 1.0 / self.data[species_key].get("tite", 1.0)
             e_mass = (electron_mass / deuterium_mass).m
+            n_species = self.data["species_knobs"]["nspec"]
+            electron_index = n_species + 1
+
+            if np.isclose(electron_density, 1.0):
+                reference_density_index.append(n_species + 1)
+            if np.isclose(electron_temperature, 1.0):
+                reference_temperature_index.append(n_species + 1)
 
         rgeo_rmaj = (
             self.data["millergeo_parameters"]["rgeo"]

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -482,13 +482,13 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
                 electron_density = dens
                 electron_temperature = temp
                 e_mass = mass
-                electron_index = len(densities)
+                electron_index = i_sp
                 found_electron = True
 
             if np.isclose(dens, 1.0):
-                reference_density_index.append(len(densities))
+                reference_density_index.append(i_sp)
             if np.isclose(temp, 1.0):
-                reference_temperature_index.append(len(temperatures))
+                reference_temperature_index.append(i_sp)
 
             densities.append(dens)
             temperatures.append(temp)

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -276,6 +276,10 @@ def test_pyro_no_electrons_gk_file(tmp_path, gk_code):
     # Change electron charge to +1
     pyro.local_species.electron.z *= -1
 
+    # Modify GS2 to not have adiabatic electrons
+    if gk_code == "GS2":
+        pyro.gk_input.data["dist_fn_knobs"]["adiabatic_option"] = "iphi00=0"
+
     # Write new file without electrons
     output_dir = tmp_path / "pyrokinetics_read_gk_file_no_electron_test"
     output_dir.mkdir()


### PR DESCRIPTION
Handles in adiabatic electrons cases in GS2/STELLA. The code was getting stuck on setting up the normalisation quantities as it couldn't find the electron species so couldn't make `tref_electron`.

The electron temp/density/mass is still set in the code so we can read them in, so we side step that here. 

We don't currently set them in the normalisations meaning you can't do `(1*tref_deuterium).to(units.tref_electron)` but I wonder if we should or not. Not sure to be honest.

This does mean we have to load it in the bespoke output convention and not convert to Pyro's default convention, see below

```python
from pyrokinetics import Pyro

pyro = Pyro(gk_file="cbc_linear_gs2.in")

pyro.load_gk_output(output_convention="gs2_bespoke")

print(pyro.gk_output.data)
```

So we can't convert the output to use say $T_{ref} = T_e$ or $m_{ref} = m_e$
```
<xarray.Dataset> Size: 18MB
Dimensions:                (theta: 73, kx: 1, ky: 15, time: 501, field: 1,
                            species: 1, energy: 16, pitch: 47, flux: 3)
Coordinates:
  * time                   (time) float64 4kB 0.0 0.5 1.0 ... 249.0 249.5 250.0
  * kx                     (kx) float64 8B 0.0
  * ky                     (ky) float64 120B 0.07071 0.1414 ... 0.9899 1.061
  * theta                  (theta) float64 584B -9.425 -9.076 ... 9.076 9.425
  * energy                 (energy) int32 64B 1 2 3 4 5 6 ... 11 12 13 14 15 16
  * pitch                  (pitch) float64 376B 0.001918 0.01006 ... 1.168 1.17
  * species                (species) <U4 16B 'ion1'
  * field                  (field) <U3 12B 'phi'
  * flux                   (flux) <U8 96B 'particle' 'heat' 'momentum'
Data variables:
    phi                    (theta, kx, ky, time) complex128 9MB [rhoref_gs2·tref_deuterium/e/lref_minor_radius] ...
    particle               (field, species, ky, time) float64 60kB [nref_deuterium·rhoref_gs2²·vref_most_probable/lref_minor_radius²] ...
    heat                   (field, species, ky, time) float64 60kB [nref_deuterium·rhoref_gs2²·tref_deuterium·vref_most_probable/lref_minor_radius²] ...
    momentum               (field, species, ky, time) float64 60kB [nref_deuterium·rhoref_gs2²·tref_deuterium/lref_minor_radius] ...
    growth_rate            (kx, ky, time) float64 60kB [vref_most_probable/lref_minor_radius] ...
    mode_frequency         (kx, ky, time) float64 60kB [vref_most_probable/lref_minor_radius] ...
    eigenvalues            (kx, ky, time) complex128 120kB [vref_most_probable/lref_minor_radius] ...
    eigenfunctions         (field, theta, kx, ky, time) complex128 9MB [] (0....
    growth_rate_tolerance  (kx, ky) float64 120B [] 0.02105 ... 9.304e-06
Attributes: (12/13)
    linear:            True
    gk_code:           GS2
    input_file:        \n\n\n\n&kt_grids_knobs\ngrid_option = 'range'\n/\n\n&...
    attribute_units:   {}
    title:             GKOutput
    software_name:     Pyrokinetics
    ...                ...
    object_type:       GKOutput
    object_uuid:       e421807e-5d8e-4cfa-8512-758c0324db93
    object_created:    2025-01-22 11:54:56.589850
    session_uuid:      5fb02907-87de-4cc4-8c15-9795abaac741
    session_started:   2025-01-22 11:54:50.631319
    netcdf4_version:   1.6.5
```


Any thoughts on this?



