### PR TITLE
Add option for kwargs in load_local and test

### DIFF
--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1771,8 +1771,8 @@ class Pyro:
         psi_n: float,
         local_geometry: str = "Miller",
         show_fit: bool = False,
-        local_geometry_kwargs={},
-        local_species_kwargs={},
+        local_geometry_kwargs: dict[str, Any] | None = None,
+        local_species_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
         Combines calls to ``load_local_geometry()`` and ``load_local_species()``

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1767,7 +1767,12 @@ class Pyro:
         self.local_species = local_species
 
     def load_local(
-        self, psi_n: float, local_geometry: str = "Miller", show_fit: bool = False
+        self,
+        psi_n: float,
+        local_geometry: str = "Miller",
+        show_fit: bool = False,
+        local_geometry_kwargs={},
+        local_species_kwargs={},
     ) -> None:
         """
         Combines calls to ``load_local_geometry()`` and ``load_local_species()``
@@ -1782,6 +1787,10 @@ class Pyro:
             ``supported_local_geometries``.
         show_fit: bool
             Show fit of LocalGeometry, default is False
+        local_geometry_kwargs: dict
+            Dictionary of kwargs to pass to load_local_geometry
+        local_species_kwargs: dict
+            Dictionary of kwargs to pass to load_local_species
         Returns
         -------
         ``None``
@@ -1792,9 +1801,12 @@ class Pyro:
             See exceptions for ``load_local_geometry()`` and ``load_local_species()``.
         """
         self.load_local_geometry(
-            psi_n, local_geometry=local_geometry, show_fit=show_fit
+            psi_n,
+            local_geometry=local_geometry,
+            show_fit=show_fit,
+            **local_geometry_kwargs,
         )
-        self.load_local_species(psi_n)
+        self.load_local_species(psi_n, **local_species_kwargs)
 
         self._load_local_geometry_species_dependency()
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1800,6 +1800,13 @@ class Pyro:
         Exception
             See exceptions for ``load_local_geometry()`` and ``load_local_species()``.
         """
+
+        if local_geometry_kwargs is None:
+            local_geometry_kwargs = {}
+
+        if local_species_kwargs is None:
+            local_species_kwargs = {}
+
         self.load_local_geometry(
             psi_n,
             local_geometry=local_geometry,

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -220,6 +220,30 @@ def test_pyro_load_local(eq_type, kinetics_type):
     assert pyro.local_species is not local_species
 
 
+@pytest.mark.parametrize(
+    "n_moments,a_minor",
+    [*product([6, 8], [1, 2])],
+)
+def test_pyro_load_local_kwargs(n_moments, a_minor):
+    pyro = Pyro(gk_file=gk_templates["CGYRO"])
+    local_geometry = pyro.local_geometry
+    local_species = pyro.local_species
+    pyro.load_global_eq(eq_templates["GEQDSK"])
+    pyro.load_global_kinetics(kinetics_templates["TRANSP"])
+    a_minor *= pyro.norms.units.meter
+    pyro.load_local(
+        psi_n=0.5,
+        local_geometry="MXH",
+        local_geometry_kwargs={"n_moments": n_moments},
+        local_species_kwargs={"a_minor": a_minor},
+    )
+    assert pyro.local_geometry.n_moments == n_moments
+    assert 1.0 * pyro.norms.lref == a_minor
+    # Ensure local_species and local_geometry were overwritten
+    assert pyro.local_geometry is not local_geometry
+    assert pyro.local_species is not local_species
+
+
 @pytest.mark.parametrize("gk_code", ["GS2", "CGYRO", "GENE"])
 def test_pyro_read_gk_file(gk_code):
     pyro = Pyro()


### PR DESCRIPTION
It was not possible to add kwargs for `load_local_geometry` and `load_local_species` to `pyro.load_local` before so we add that in now and include a test for this.

For example you can now do

```python
pyro.load_local(psi_n=psi_surf, 
                local_geometry='MXH',
                local_geometry_kwargs = {"n_moments": 6},
                local_species_kwargs = {"a_minor": 1.0 * pyro.norms.units.meter},)
```

which will get passed along appropriately.