### PR TITLE
Bugfix in gs2.py for normalisations value (qref-->zref)

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -893,7 +893,9 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             self.data["normalisations_knobs"]["vref"] = (1 * convention.vref).to(
                 "meter/second"
             )
-            self.data["normalisations_knobs"]["zref"] = 1 * convention.qref
+            self.data["normalisations_knobs"]["zref"] = (1 * convention.qref).to(
+                "coulomb"
+            )
             self.data["normalisations_knobs"]["rhoref"] = (1 * convention.rhoref).to(
                 "meter"
             )

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -893,7 +893,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
             self.data["normalisations_knobs"]["vref"] = (1 * convention.vref).to(
                 "meter/second"
             )
-            self.data["normalisations_knobs"]["qref"] = 1 * convention.qref
+            self.data["normalisations_knobs"]["zref"] = 1 * convention.qref
             self.data["normalisations_knobs"]["rhoref"] = (1 * convention.rhoref).to(
                 "meter"
             )


### PR DESCRIPTION
The GS2 input for the reference charge is zref.