### PR TITLE
Reset local_geometry/species record after each load_local

### DIFF
--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -416,7 +416,6 @@ class Pyro:
         # Check that the provided gk_code is valid
         if gk_code is not None and gk_code not in self.supported_gk_inputs:
             raise ValueError(f"The gyrokinetics code '{gk_code}' is not supported")
-
         # If we've already seen this context before, or the new context is None, change
         # context and return.
         if gk_code is None or (
@@ -1211,9 +1210,9 @@ class Pyro:
                 "eigenvalues" in self.gk_output
                 and "time" in self.gk_output["eigenvalues"].dims
             ):
-                self.gk_output.data["growth_rate_tolerance"] = (
-                    self.gk_output.get_growth_rate_tolerance()
-                )
+                self.gk_output.data[
+                    "growth_rate_tolerance"
+                ] = self.gk_output.get_growth_rate_tolerance()
 
     # ==================================
     # Set properties for file attributes
@@ -1800,6 +1799,10 @@ class Pyro:
         Exception
             See exceptions for ``load_local_geometry()`` and ``load_local_species()``.
         """
+        if self._local_geometry_record:
+            self._local_geometry_record = {}
+        if self._local_species_record:
+            self._local_species_record = {}
 
         if local_geometry_kwargs is None:
             local_geometry_kwargs = {}

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1210,9 +1210,9 @@ class Pyro:
                 "eigenvalues" in self.gk_output
                 and "time" in self.gk_output["eigenvalues"].dims
             ):
-                self.gk_output.data[
-                    "growth_rate_tolerance"
-                ] = self.gk_output.get_growth_rate_tolerance()
+                self.gk_output.data["growth_rate_tolerance"] = (
+                    self.gk_output.get_growth_rate_tolerance()
+                )
 
     # ==================================
     # Set properties for file attributes

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -220,6 +220,24 @@ def test_pyro_load_local(eq_type, kinetics_type):
     assert pyro.local_species is not local_species
 
 
+def test_pyro_multiple_load_local():
+    pyro = Pyro(gk_file=gk_templates["CGYRO"])
+    local_geometry_record = None
+    local_species_record = None
+    pyro.load_global_eq(eq_templates["GEQDSK"])
+    pyro.load_global_kinetics(kinetics_templates["TRANSP"])
+    for psi_n in [0.4, 0.5, 0.6]:
+        pyro.load_local(psi_n=psi_n)
+        if local_geometry_record is None:
+            local_geometry_record = pyro._local_geometry_record
+        else:
+            assert pyro._local_geometry_record is not local_geometry_record
+        if local_species_record is None:
+            local_species_record = pyro._local_species_record
+        else:
+            assert pyro._local_species_record is not local_species_record
+
+
 @pytest.mark.parametrize(
     "n_moments,a_minor",
     [*product([6, 8], [1, 2])],


### PR DESCRIPTION
Previously doing multiple `pyro.load_local` would work but would not reset the record of `local_species` and `local_geometry` meaning that if you then modify the object somehow (say a `merge_species`) due to a older record existing that change may not take when actually writing a file.  This PR fixes that by resetting the record for each call of `load_local` and adds a test.