### PR TITLE
IMAS ignore default values in R, Z, psi

### DIFF
--- a/src/pyrokinetics/equilibrium/equilibrium.py
+++ b/src/pyrokinetics/equilibrium/equilibrium.py
@@ -294,7 +294,7 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
             if len(grid.shape) != 1:
                 raise ValueError(f"The grid {name} must be 1D.")
             diff = np.diff(grid)
-            if not np.allclose(diff, diff[0], rtol=1e-4):
+            if not np.allclose(diff, diff[0], rtol=1e-4):   
                 raise ValueError(f"The grid {name} must linearly spaced.")
             if diff[0] <= 0.0:
                 raise ValueError(f"The grid {name} must have a positive spacing.")

--- a/src/pyrokinetics/equilibrium/equilibrium.py
+++ b/src/pyrokinetics/equilibrium/equilibrium.py
@@ -294,7 +294,7 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
             if len(grid.shape) != 1:
                 raise ValueError(f"The grid {name} must be 1D.")
             diff = np.diff(grid)
-            if not np.allclose(diff, diff[0], rtol=1e-4):   
+            if not np.allclose(diff, diff[0], rtol=1e-4):
                 raise ValueError(f"The grid {name} must linearly spaced.")
             if diff[0] <= 0.0:
                 raise ValueError(f"The grid {name} must have a positive spacing.")

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -84,18 +84,13 @@ def _flux_surface_contour(
         )
     # Get contours, raising error if none are found: added by Juan 13/02/2025
     if psi < np.min(psi_RZ):
-        print(f"Skipping psi={psi} (out of range (min): [{np.min(psi_RZ)}])")
-        psi = np.min(psi_RZ) + 1e-10
-    elif psi > np.max(psi_RZ):
-        print(f"Skipping psi={psi} (out of range (max): [{np.max(psi_RZ)}])")
-        psi = np.max(psi_RZ) - 1e-10
-        # return None  # or return an empty list, array, etc.
+        raise ValueError(f"psi={psi} is out of range (min): [{np.min(psi_RZ)}])")
+    if psi > np.max(psi_RZ):
+        raise ValueError(f"psi={psi} is out of range (max): [{np.max(psi_RZ)}])")
 
+    # Get contours, raising error if none are found
     cont_gen = contour_generator(x=Z, y=R, z=psi_RZ)
     contours = cont_gen.lines(psi)
-    # threshold = 1e30  # Define an upper limit for reasonable values
-    # psi_RZ = np.where(np.abs(psi_RZ) > threshold, np.nan, psi_RZ)
-    # psi_RZ = np.nan_to_num(psi_RZ, nan=np.median(psi_RZ))  # Replace NaNs with median
 
     if not contours:
         raise RuntimeError(f"Could not find flux surface contours for psi={psi}")

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -82,10 +82,21 @@ def _flux_surface_contour(
             f"The grid psi_RZ has shape {psi_RZ.shape}. "
             f"It should have shape {(len(R), len(Z))}."
         )
-
-    # Get contours, raising error if none are found
+    # Get contours, raising error if none are found: added by Juan 13/02/2025
+    if psi < np.min(psi_RZ) :
+        print(f"Skipping psi={psi} (out of range (min): [{np.min(psi_RZ)}])")
+        psi = np.min(psi_RZ) + 1e-10
+    elif psi > np.max(psi_RZ):
+        print(f"Skipping psi={psi} (out of range (max): [{np.max(psi_RZ)}])")
+        psi = np.max(psi_RZ) - 1e-10
+        #return None  # or return an empty list, array, etc.
+    
     cont_gen = contour_generator(x=Z, y=R, z=psi_RZ)
     contours = cont_gen.lines(psi)
+    #threshold = 1e30  # Define an upper limit for reasonable values
+    #psi_RZ = np.where(np.abs(psi_RZ) > threshold, np.nan, psi_RZ)
+    #psi_RZ = np.nan_to_num(psi_RZ, nan=np.median(psi_RZ))  # Replace NaNs with median
+    
     if not contours:
         raise RuntimeError(f"Could not find flux surface contours for psi={psi}")
 

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -83,20 +83,20 @@ def _flux_surface_contour(
             f"It should have shape {(len(R), len(Z))}."
         )
     # Get contours, raising error if none are found: added by Juan 13/02/2025
-    if psi < np.min(psi_RZ) :
+    if psi < np.min(psi_RZ):
         print(f"Skipping psi={psi} (out of range (min): [{np.min(psi_RZ)}])")
         psi = np.min(psi_RZ) + 1e-10
     elif psi > np.max(psi_RZ):
         print(f"Skipping psi={psi} (out of range (max): [{np.max(psi_RZ)}])")
         psi = np.max(psi_RZ) - 1e-10
-        #return None  # or return an empty list, array, etc.
-    
+        # return None  # or return an empty list, array, etc.
+
     cont_gen = contour_generator(x=Z, y=R, z=psi_RZ)
     contours = cont_gen.lines(psi)
-    #threshold = 1e30  # Define an upper limit for reasonable values
-    #psi_RZ = np.where(np.abs(psi_RZ) > threshold, np.nan, psi_RZ)
-    #psi_RZ = np.nan_to_num(psi_RZ, nan=np.median(psi_RZ))  # Replace NaNs with median
-    
+    # threshold = 1e30  # Define an upper limit for reasonable values
+    # psi_RZ = np.where(np.abs(psi_RZ) > threshold, np.nan, psi_RZ)
+    # psi_RZ = np.nan_to_num(psi_RZ, nan=np.median(psi_RZ))  # Replace NaNs with median
+
     if not contours:
         raise RuntimeError(f"Could not find flux surface contours for psi={psi}")
 

--- a/src/pyrokinetics/equilibrium/imas.py
+++ b/src/pyrokinetics/equilibrium/imas.py
@@ -118,21 +118,23 @@ class EquilibriumReaderIMAS(FileReader, file_type="IMAS", reads=Equilibrium):
                 data["time_slice[]&profiles_2d[]&grid&dim1"][time_index, 0, ...]
                 * units.meter
             )
-            R = R[ np.where(R > -8e40 * units.meter) ]
-            print(R)    # juan
+            R = R[np.where(R > -8e40 * units.meter)]
+            print(R)  # juan
             Z = (
                 data["time_slice[]&profiles_2d[]&grid&dim2"][time_index, 0, ...]
                 * units.meter
             )
-            Z = Z[ np.where(Z > -8e40 * units.meter) ]
+            Z = Z[np.where(Z > -8e40 * units.meter)]
             psi_RZ = (
                 data["time_slice[]&profiles_2d[]&psi"][time_index, 0, ...].T * psi_units
-            )[:len(R), :len(Z)] # cutoff extra points
+            )[
+                : len(R), : len(Z)
+            ]  # cutoff extra points
             print(Z)
             print(np.shape(R))
             print(np.shape(Z))
             print(np.shape(psi_RZ))
-            
+
             # Get quantities on the psi grid
             # The number of psi values is the same as the number of r values. The psi grid
             # uniformly increases from psi_axis to psi_lcfs

--- a/src/pyrokinetics/equilibrium/imas.py
+++ b/src/pyrokinetics/equilibrium/imas.py
@@ -119,26 +119,21 @@ class EquilibriumReaderIMAS(FileReader, file_type="IMAS", reads=Equilibrium):
                 * units.meter
             )
             R = R[np.where(R > -8e40 * units.meter)]
-            print(R)  # juan
+
             Z = (
                 data["time_slice[]&profiles_2d[]&grid&dim2"][time_index, 0, ...]
                 * units.meter
             )
             Z = Z[np.where(Z > -8e40 * units.meter)]
+
             psi_RZ = (
                 data["time_slice[]&profiles_2d[]&psi"][time_index, 0, ...].T * psi_units
-            )[
-                : len(R), : len(Z)
-            ]  # cutoff extra points
-            print(Z)
-            print(np.shape(R))
-            print(np.shape(Z))
-            print(np.shape(psi_RZ))
+            )[: len(R), : len(Z)]
 
             # Get quantities on the psi grid
             # The number of psi values is the same as the number of r values. The psi grid
             # uniformly increases from psi_axis to psi_lcfs
-            psi_grid = data["time_slice[]&profiles_1d&psi"][time_index]
+            psi_grid = data["time_slice[]&profiles_1d&psi"][time_index] * psi_units
 
             F = data["time_slice[]&profiles_1d&f"][time_index] * F_units
             FF_prime = (
@@ -169,7 +164,9 @@ class EquilibriumReaderIMAS(FileReader, file_type="IMAS", reads=Equilibrium):
                 else:
                     index = 1
                     # Discard elements off the end of the grid, insert new psi_lcfs
+
                 psi_grid_new = np.concatenate((psi_grid[:lcfs_idx], [psi_lcfs_new]))
+
                 # Linearly interpolate each grid onto the new psi_grid
                 # Need psi to be increasing for np.interp
                 F = np.interp(psi_grid_new, psi_grid[::index], F[::index])
@@ -196,13 +193,35 @@ class EquilibriumReaderIMAS(FileReader, file_type="IMAS", reads=Equilibrium):
             R_major[-1] = 0.5 * (max(Rbdry) + min(Rbdry)) * units.meter
             r_minor[-1] = 0.5 * (max(Rbdry) - min(Rbdry)) * units.meter
             Z_mid[-1] = 0.5 * (max(Zbdry) + min(Zbdry)) * units.meter
+
+            idx_skipped = []
             for idx, psi in enumerate(psi_grid[1:-1], start=1):
-                Rc, Zc = _flux_surface_contour(R, Z, psi_RZ, R_axis, Z_axis, psi)
-                R_min, R_max = min(Rc), max(Rc)
-                Z_min, Z_max = min(Zc), max(Zc)
-                R_major[idx] = 0.5 * (R_max + R_min)
-                r_minor[idx] = 0.5 * (R_max - R_min)
-                Z_mid[idx] = 0.5 * (Z_max + Z_min)
+                try:
+                    Rc, Zc = _flux_surface_contour(R, Z, psi_RZ, R_axis, Z_axis, psi)
+                    R_min, R_max = min(Rc), max(Rc)
+                    Z_min, Z_max = min(Zc), max(Zc)
+                    R_major[idx] = 0.5 * (R_max + R_min)
+                    r_minor[idx] = 0.5 * (R_max - R_min)
+                    Z_mid[idx] = 0.5 * (Z_max + Z_min)
+                except ValueError:
+                    idx_skipped.append(idx)
+
+            for idx in idx_skipped:
+                R_major[idx] = np.interp(
+                    abs(psi_grid[idx]),
+                    abs(psi_grid[idx - 1 : idx + 2 : 2]),
+                    R_major[idx - 1 : idx + 2 : 2],
+                )
+                r_minor[idx] = np.interp(
+                    abs(psi_grid[idx]),
+                    abs(psi_grid[idx - 1 : idx + 2 : 2]),
+                    r_minor[idx - 1 : idx + 2 : 2],
+                )
+                Z_mid[idx] = np.interp(
+                    abs(psi_grid[idx]),
+                    abs(psi_grid[idx - 1 : idx + 2 : 2]),
+                    Z_mid[idx - 1 : idx + 2 : 2],
+                )
 
             a_minor = r_minor[-1]
 

--- a/src/pyrokinetics/equilibrium/imas.py
+++ b/src/pyrokinetics/equilibrium/imas.py
@@ -118,14 +118,21 @@ class EquilibriumReaderIMAS(FileReader, file_type="IMAS", reads=Equilibrium):
                 data["time_slice[]&profiles_2d[]&grid&dim1"][time_index, 0, ...]
                 * units.meter
             )
+            R = R[ np.where(R > -8e40 * units.meter) ]
+            print(R)    # juan
             Z = (
                 data["time_slice[]&profiles_2d[]&grid&dim2"][time_index, 0, ...]
                 * units.meter
             )
+            Z = Z[ np.where(Z > -8e40 * units.meter) ]
             psi_RZ = (
                 data["time_slice[]&profiles_2d[]&psi"][time_index, 0, ...].T * psi_units
-            )
-
+            )[:len(R), :len(Z)] # cutoff extra points
+            print(Z)
+            print(np.shape(R))
+            print(np.shape(Z))
+            print(np.shape(psi_RZ))
+            
             # Get quantities on the psi grid
             # The number of psi values is the same as the number of r values. The psi grid
             # uniformly increases from psi_axis to psi_lcfs


### PR DESCRIPTION
Fixes issue where $R$ $Z$ and $\psi$ can have default values of `-9e40` so we select only the values above a reasonable value.

Also sometimes the contour fitting in `imas.py` fails near the axis so we interpolate inputs to the `Equilibrium` around there. 