### PR TITLE
Bugfix/adiabatic electron cgyro local species

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1143,7 +1143,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
         ky = grid_data[pos : pos + nky] / bunit_over_b0
 
-        if gk_input.is_linear():
+        if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx
             theta = theta_ballooning
             ntheta = ntheta_ballooning
@@ -1153,7 +1153,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         else:
             # Output data actually given on theta_plot grid
             ntheta = ntheta_plot
-            theta = [0.0] if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta]
+            theta = np.array([0.0]) if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta]
             kx = (
                 2
                 * pi
@@ -1168,6 +1168,8 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         if len(raw_data["equilibrium"]) == 54 + 7 * nspecies:
             rho_star = raw_data["equilibrium"][35]
         elif len(raw_data["equilibrium"]) == 54 + 9 * nspecies:
+            rho_star = raw_data["equilibrium"][35]
+        elif len(raw_data["equilibrium"]) == 55 + 10 * nspecies:
             rho_star = raw_data["equilibrium"][35]
         else:
             rho_star = raw_data["equilibrium"][23]
@@ -1245,7 +1247,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
             # If linear, convert from kx to ballooning space.
             # Use nradial instead of nkx, ntheta_plot instead of ntheta
-            if gk_input.is_linear():
+            if gk_input.is_linear() and nky == 1:
                 shape = (2, nradial, ntheta_plot, nky, full_ntime)
             else:
                 shape = (2, nkx, ntheta, nky, full_ntime)
@@ -1260,7 +1262,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             ]
 
             # If nonlinear, we can simply save the fields and continue
-            if gk_input.is_nonlinear():
+            if gk_input.is_nonlinear() or nky != 1:
                 fields = field_data.swapaxes(0, 1)
             else:
                 # If theta_plot != theta_grid, we get eigenfunction data and multiply by the
@@ -1350,7 +1352,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
             # If linear, convert from kx to ballooning space.
             # Use nradial instead of nkx, ntheta_plot instead of ntheta
-            if gk_input.is_linear():
+            if gk_input.is_linear() and nky == 1:
                 shape = (2, nradial, ntheta_plot, nspec, nky, full_ntime)
             else:
                 shape = (2, nkx, ntheta, nspec, nky, full_ntime)
@@ -1367,7 +1369,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             ]
 
             # If nonlinear, we can simply save the moments and continue
-            if gk_input.is_nonlinear():
+            if gk_input.is_nonlinear() or nky != 1:
                 moments = moment_data.swapaxes(0, 1)
             else:
                 # Poisson Sum (no negative in exponent to match frequency convention)

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1153,7 +1153,9 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         else:
             # Output data actually given on theta_plot grid
             ntheta = ntheta_plot
-            theta = np.array([0.0]) if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta]
+            theta = (
+                np.array([0.0]) if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta]
+            )
             kx = (
                 2
                 * pi

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -450,10 +450,17 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             # Add individual species data to dictionary of species
             local_species.add_species(name=name, species_data=species_data)
 
-        nu_ee = local_species.electron.nu
-        te = local_species.electron.temp
-        ne = local_species.electron.dens
-        me = local_species.electron.mass
+        # Handle adiabatic species if there
+        if self.data.get("AE_FLAG", 0) == 1:
+            nu_ee = self.data.get("NU_EE", 0.1) * convention.vref / convention.lref
+            te = self.data.get("TEMP_AE", 1.0) * convention.tref
+            ne = self.data.get("DENS_AE", 1.0) * convention.nref
+            me = self.data.get("MASS_AE", 2.724486e-4) * convention.mref
+        else:
+            nu_ee = local_species.electron.nu
+            te = local_species.electron.temp
+            ne = local_species.electron.dens
+            me = local_species.electron.mass
 
         # Get collision frequency of ion species
         for ion in range(ion_count):
@@ -988,7 +995,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         dirname = Path(dirname)
         for f in self._required_files(dirname).values():
             if not f.path.exists():
-                raise RuntimeError(f"Missing the file '{f}'")
+                raise RuntimeError(f"Missing the file '{f.path}'")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -519,6 +519,10 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
             for f in fields:
                 fields[f] *= amplitude
 
+            # Indices should be (kx, ky, 1)
+            if len(coords.kx) > 1:
+                amplitude = np.sum(amplitude, axis=0)
+
             if fluxes:
                 for f in fluxes:
                     fluxes[f] *= np.abs(amplitude) ** 2
@@ -723,8 +727,10 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         field_squared = 0.0
         for field in fields.values():
             field_squared += np.abs(field.m) ** 2
-
-        amplitude = np.sqrt(trapezoid(field_squared, theta, axis=0) / (2 * np.pi))
+        if len(theta) > 1:
+            amplitude = np.sqrt(trapezoid(field_squared, theta, axis=0) / (2 * np.pi))
+        else:
+            amplitude = np.sqrt(field_squared[0, ...] / (2 * np.pi))
 
         return amplitude
 

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -914,7 +914,7 @@ class GKOutputReaderGKW(FileReader, file_type="GKW", reads=GKOutput):
         dirname = Path(dirname)
         for f in self._required_files(dirname).values():
             if not f.path.exists():
-                raise RuntimeError(f"Missing the file '{f}'")
+                raise RuntimeError(f"Missing the file '{f.path}'")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -757,7 +757,7 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
         dirname = Path(dirname)
         for f in self._required_files(dirname).values():
             if not f.path.exists():
-                raise RuntimeError(f"Couldn't find TGLF file '{f}'")
+                raise RuntimeError(f"Couldn't find TGLF file '{f.path}'")
 
     @staticmethod
     def infer_path_from_input_file(filename: PathLike) -> Path:


### PR DESCRIPTION
Fixes issue with adiabatic electron runs in CGYRO failing during `get_local_species` as the "electron's" `Te`, `ne` and `nu_e` are needed to get the collisionality for other species.

Also fixes an separate issue when loading box style runs without the nonlinear term (`N_TOROIDAL >1` and `NONLINEAR=0`) and when `THETA_PLOT!=N_THETA` 