### PR TITLE
Add higher moments to CGYRO 

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -71,12 +71,24 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         "cn1": "SHAPE_COS1",
         "cn2": "SHAPE_COS2",
         "cn3": "SHAPE_COS3",
+        "cn4": "SHAPE_COS4",
+        "cn5": "SHAPE_COS5",
+        "cn6": "SHAPE_COS6",
         "sn3": "SHAPE_SIN3",
+        "sn4": "SHAPE_SIN4",
+        "sn5": "SHAPE_SIN5",
+        "sn6": "SHAPE_SIN6",
         "dcndr0": "SHAPE_S_COS0",
         "dcndr1": "SHAPE_S_COS1",
         "dcndr2": "SHAPE_S_COS2",
         "dcndr3": "SHAPE_S_COS3",
+        "dcndr4": "SHAPE_S_COS4",
+        "dcndr5": "SHAPE_S_COS5",
+        "dcndr6": "SHAPE_S_COS6",
         "dsndr3": "SHAPE_S_SIN3",
+        "dsndr4": "SHAPE_S_SIN4",
+        "dsndr5": "SHAPE_S_SIN5",
+        "dsndr6": "SHAPE_S_SIN6",
     }
 
     pyro_cgyro_miller_defaults = {
@@ -749,6 +761,11 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 else:
                     index = int(key[-1])
                     new_key = key[:-1]
+
+                    # Skip in index beyond n_moments
+                    if index >= local_geometry.n_moments:
+                        continue
+
                     if "SHAPE_S" in val:
                         self.data[val] = (
                             getattr(local_geometry, new_key)[index] * local_geometry.rho

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -115,12 +115,24 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         "cn1": 0.0,
         "cn2": 0.0,
         "cn3": 0.0,
+        "cn4": 0.0,
+        "cn5": 0.0,
+        "cn6": 0.0,
         "sn3": 0.0,
+        "sn4": 0.0,
+        "sn5": 0.0,
+        "sn6": 0.0,
         "dcndr0": 0.0,
         "dcndr1": 0.0,
         "dcndr2": 0.0,
         "dcndr3": 0.0,
+        "dcndr4": 0.0,
+        "dcndr5": 0.0,
+        "dcndr6": 0.0,
         "dsndr3": 0.0,
+        "dsndr4": 0.0,
+        "dsndr5": 0.0,
+        "dsndr6": 0.0,
     }
 
     pyro_cgyro_fourier = pyro_cgyro_miller
@@ -325,7 +337,7 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         """
         Load MXH object from CGYRO file
         """
-        mxh_data = default_mxh_inputs()
+        mxh_data = default_mxh_inputs(n_moments=7)
 
         for (key, val), default in zip(
             self.pyro_cgyro_mxh.items(), self.pyro_cgyro_mxh_defaults.values()
@@ -341,6 +353,16 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                     )
                 else:
                     mxh_data[new_key][index] = self.data.get(val, default)
+
+        mxh_keys = ["cn", "sn", "dcndr", "dsndr"]
+        for i_moment in range(6, -1, -1):
+            if np.all(
+                [True if mxh_data[key][i_moment] == 0.0 else False for key in mxh_keys]
+            ):
+                for key in mxh_keys:
+                    mxh_data[key] = mxh_data[key][:-1]
+            else:
+                break
 
         # Force dsndr[0] = 0 as is definition
         mxh_data["dsndr"][0] = 0.0

--- a/src/pyrokinetics/local_geometry/mxh.py
+++ b/src/pyrokinetics/local_geometry/mxh.py
@@ -10,11 +10,10 @@ from ..units import ureg as units
 from .local_geometry import LocalGeometry, default_inputs
 
 
-def default_mxh_inputs():
+def default_mxh_inputs(n_moments: int = 4):
     # Return default args to build a LocalGeometryMXH
     # Uses a function call to avoid the user modifying these values
 
-    n_moments = 4
     base_defaults = default_inputs()
     mxh_defaults = {
         "cn": np.zeros(n_moments),

--- a/src/pyrokinetics/local_geometry/mxh.py
+++ b/src/pyrokinetics/local_geometry/mxh.py
@@ -176,6 +176,10 @@ class LocalGeometryMXH(LocalGeometry):
 
         R_upper = R[Zind_upper]
 
+        Zind_lower = np.argmin(Z)
+
+        R_lower = R[Zind_lower]
+
         normalised_height = (Z - Zmid) / (kappa * self.rho)
 
         # Floating point error can lead to >|1.0|
@@ -199,8 +203,9 @@ class LocalGeometryMXH(LocalGeometry):
 
         thetaR = np.arccos(normalised_radius)
 
-        theta = np.where(R < R_upper, np.pi - theta, theta)
-        theta = np.where((R >= R_upper) & (Z <= Zmid), 2 * np.pi + theta, theta)
+        theta = np.where((R < R_upper) & (Z >= Zmid), np.pi - theta, theta)
+        theta = np.where((R < R_lower) & (Z <= Zmid), np.pi - theta, theta)
+        theta = np.where((R >= R_lower) & (Z <= Zmid), 2 * np.pi + theta, theta)
         thetaR = np.where(Z <= Zmid, 2 * np.pi - thetaR, thetaR)
 
         # Ensure first point is close to 0 rather than 2pi


### PR DESCRIPTION
PR adds missing higher order moments to CGYRO when `n_moments > 3` which is the default.

Also we are slightly more careful with the setting of `theta` when calculating from a list of `R` and `Z` in `set_shape_coefficients`, mostly relevant for non-up down symmetric plasmas