### PR TITLE
Update gs2.py to force fapar and fbpar to zero if beta is zero

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -462,8 +462,12 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
         # Set no. of fields
         numerics_data["phi"] = self.data["knobs"].get("fphi", 0.0) > 0.0
-        numerics_data["apar"] = self.data["knobs"].get("fapar", 0.0) > 0.0 and self._get_beta() > 0.0
-        numerics_data["bpar"] = self.data["knobs"].get("fbpar", 0.0) > 0.0 and self._get_beta() > 0.0
+        numerics_data["apar"] = (
+            self.data["knobs"].get("fapar", 0.0) > 0.0 and self._get_beta() > 0.0
+        )
+        numerics_data["bpar"] = (
+            self.data["knobs"].get("fbpar", 0.0) > 0.0 and self._get_beta() > 0.0
+        )
 
         # Set time stepping
         delta_time = self.data["knobs"].get("delt", 0.005)

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -462,8 +462,8 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
         # Set no. of fields
         numerics_data["phi"] = self.data["knobs"].get("fphi", 0.0) > 0.0
-        numerics_data["apar"] = self.data["knobs"].get("fapar", 0.0) > 0.0
-        numerics_data["bpar"] = self.data["knobs"].get("fbpar", 0.0) > 0.0
+        numerics_data["apar"] = self.data["knobs"].get("fapar", 0.0) > 0.0 and self._get_beta() > 0.0
+        numerics_data["bpar"] = self.data["knobs"].get("fbpar", 0.0) > 0.0 and self._get_beta() > 0.0
 
         # Set time stepping
         delta_time = self.data["knobs"].get("delt", 0.005)


### PR DESCRIPTION
This replicates logic inside GS2 which disables the apar and bpar flag if beta is zero