### PR TITLE
Update gs2.in to remove diagnostics_config and merge parameters to knobs

### DIFF
--- a/src/pyrokinetics/templates/outputs/GS2_linear/gs2.in
+++ b/src/pyrokinetics/templates/outputs/GS2_linear/gs2.in
@@ -57,6 +57,9 @@
     delt = 0.0014142135623730952
     nstep = 1000
     wstar_units = .true.
+    beta = 0.0
+    tite = 1.0
+    zeff = 1.0    
 /
 
 &layouts_knobs
@@ -129,14 +132,4 @@
     omegatinst = 500.0
     nsave = 50000
     save_for_restart = .true.
-/
-
-&parameters
-    beta = 0.0
-    tite = 1.0
-    zeff = 1.0
-/
-
-&diagnostics_config
-    nwrite = 100000000
 /


### PR DESCRIPTION
The diagnostics_config hasn't been used in many years and the values in the parameters namelist should appear in knobs now instead