### PR TITLE
Force the sign of ky to be positive when loading gk_output

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1255,6 +1255,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         pos += ntheta_ballooning
 
         ky = grid_data[pos : pos + nky] / bunit_over_b0
+        ky = np.abs(ky) # Force the sign of ky to be positive
 
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1254,8 +1254,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         theta_ballooning = grid_data[pos : pos + ntheta_ballooning]
         pos += ntheta_ballooning
 
-        ky = grid_data[pos : pos + nky] / bunit_over_b0
-        ky = np.abs(ky)  # Force the sign of ky to be positive
+        ky = np.abs(grid_data[pos : pos + nky] / bunit_over_b0)  # Force the sign of ky to be positive
 
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1254,7 +1254,9 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         theta_ballooning = grid_data[pos : pos + ntheta_ballooning]
         pos += ntheta_ballooning
 
-        ky = np.abs(grid_data[pos : pos + nky] / bunit_over_b0)  # Force the sign of ky to be positive
+        ky = np.abs(
+            grid_data[pos : pos + nky] / bunit_over_b0
+        )  # Force the sign of ky to be positive
 
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1255,7 +1255,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         pos += ntheta_ballooning
 
         ky = grid_data[pos : pos + nky] / bunit_over_b0
-        ky = np.abs(ky) # Force the sign of ky to be positive
+        ky = np.abs(ky)  # Force the sign of ky to be positive
 
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx


### PR DESCRIPTION
I thought it would be useful for various cases/parts of the code for the sign of `ky` to be forced to be positive when it happens to be negative in `CGYRO`. This does not cause any loss of information, given that it can be reconstructed from various inputs/outputs already saved by `CGRYO` and `pyro`. 