### PR TITLE
CGYRO signs of Bt/Ip/q

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1255,7 +1255,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         pos += ntheta_ballooning
 
         ky = grid_data[pos : pos + nky] / bunit_over_b0
-        ip_ccw = gk_input.data.get("IPCCW", -1.0)
+
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx
             theta = theta_ballooning

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1393,11 +1393,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             bt_ccw = gk_input.data.get("BTCCW", -1)
             ip_ccw = gk_input.data.get("IPCCW", -1)
             mode_sign = int(
-                np.sign(
-                    np.sign(gk_input.data.get("S", 1.0))
-                    * bt_ccw
-                    * ip_ccw
-                )
+                np.sign(np.sign(gk_input.data.get("S", 1.0)) * bt_ccw * ip_ccw)
             )
 
             field_data = (field_data[0] + 1j * field_data[1]) / coords["rho_star"]

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1451,7 +1451,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 else:
                     fields = field_data.reshape([ntheta, nkx, nky, full_ntime])
 
-            if gk_input.data.get("IPCCW", -1.0) == -1:
+            if ip_ccw == -1:
                 fields = np.conj(fields)
 
             fields = fields[:, :, :, ::downsize]

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1255,14 +1255,14 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         pos += ntheta_ballooning
 
         ky = grid_data[pos : pos + nky] / bunit_over_b0
-
+        ip_ccw = gk_input.data.get("IPCCW", -1.0)
         if gk_input.is_linear() and nky == 1:
             # Convert to ballooning co-ordinate so only 1 kx
             theta = theta_ballooning
             ntheta = ntheta_ballooning
             kx = [0.0]
             nkx = 1
-            theta0 = theta[int(ntheta) // 2 + ntheta_plot // 2]
+            theta0 = gk_input.data.get("PX0", 0.0) * 2 * np.pi
         else:
             # Output data actually given on theta_plot grid
             ntheta = ntheta_plot
@@ -1389,11 +1389,14 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
+
+            bt_ccw = gk_input.data.get("BTCCW", -1)
+            ip_ccw = gk_input.data.get("IPCCW", -1)
             mode_sign = int(
                 np.sign(
                     np.sign(gk_input.data.get("S", 1.0))
-                    * gk_input.data.get("BTCCW", -1)
-                    * gk_input.data.get("IPCCW", -1)
+                    * bt_ccw
+                    * ip_ccw
                 )
             )
 
@@ -1438,16 +1441,18 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 for i_radial in range(nradial):
                     nx = -nradial // 2 + (i_radial - 1)
                     field_data[i_radial, ...] *= np.exp(
-                        -mode_sign * 2j * pi * (nx + nx0) * q
+                        -2j * pi * (nx + nx0) * np.abs(q)
                     )
 
                 if mode_sign == -1:
                     field_data = field_data[:, ::-1, :, :]
+                    fields = field_data.reshape([ntheta, nkx, nky, full_ntime])
+                    fields = fields[::-1, :, :, :]
+                else:
+                    fields = field_data.reshape([ntheta, nkx, nky, full_ntime])
 
-                fields = field_data.reshape([ntheta, nkx, nky, full_ntime])
-
-            # if gk_input.data.get("IPCCW", -1.0) == -1:
-            #    fields = np.conj(fields)
+            if gk_input.data.get("IPCCW", -1.0) == -1:
+                fields = np.conj(fields)
 
             fields = fields[:, :, :, ::downsize]
 

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1389,10 +1389,12 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
-            mode_sign = np.sign(
-                np.sign(gk_input.data.get("S", 1.0))
-                * gk_input.data.get("BTCCW", -1)
-                * gk_input.data.get("IPCCW", -1)
+            mode_sign = int(
+                np.sign(
+                    np.sign(gk_input.data.get("S", 1.0))
+                    * gk_input.data.get("BTCCW", -1)
+                    * gk_input.data.get("IPCCW", -1)
+                )
             )
 
             field_data = (field_data[0] + 1j * field_data[1]) / coords["rho_star"]
@@ -1436,7 +1438,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 for i_radial in range(nradial):
                     nx = -nradial // 2 + (i_radial - 1)
                     field_data[i_radial, ...] *= np.exp(
-                        -mode_sign * 2j * pi * mode_sign * (nx + nx0) * q
+                        -mode_sign * 2j * pi * (nx + nx0) * q
                     )
 
                 if mode_sign == -1:
@@ -1444,8 +1446,8 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
                 fields = field_data.reshape([ntheta, nkx, nky, full_ntime])
 
-            if gk_input.data.get("IPCCW", -1.0) == -1:
-                fields = np.conj(fields)
+            # if gk_input.data.get("IPCCW", -1.0) == -1:
+            #    fields = np.conj(fields)
 
             fields = fields[:, :, :, ::downsize]
 


### PR DESCRIPTION
The ballooning transform in CGYRO was not being done correctly when q is negative leading to jumps in the eigenfunctions. You need to be careful when rearranging from a flux tube to ballooning space here which we were not doing. All the eigenvalues match here (signs of ion direction/electron direction can be important but we force ion = positive here)

When in doubt, do every permutation possible...

Here is a case at $\theta_0 = 0$ (KBM). You can see (sort of as they overlap a lot( that when $I_p$ flips sign, we essentially flip the eigenfunctions along $\theta$ (much easier to see in the odd parity eigenfunctions).
![image](https://github.com/user-attachments/assets/ef453f0f-4bc9-4364-b279-df1628ff65ea)
![image](https://github.com/user-attachments/assets/f99af79c-5329-40b4-849d-0aadc99a6e4e)

![image](https://github.com/user-attachments/assets/f4aa4c72-5f1b-4d51-8f1a-0b3e5f7e22ca)
![image](https://github.com/user-attachments/assets/94c7de7e-2dfc-4735-8015-8732a4743694)

Here is a case with $\theta_0 = \pi$ (MTM)
![image](https://github.com/user-attachments/assets/eec1ec6d-fff1-4dc6-8e4c-46f3524847fc)
![image](https://github.com/user-attachments/assets/e3e65600-5cb2-446c-8bdf-83bd0303affe)

![image](https://github.com/user-attachments/assets/6f196d18-bf2c-4be9-8e94-62ed1495f804)
![image](https://github.com/user-attachments/assets/095c3bc1-78b3-4901-a113-12b8e6712901)
