### PR TITLE
GENE set beta_prime correctly if amhd=-1

### DIFF
--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -380,13 +380,21 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             local_geometry_data["B0"] = None
 
         dpdx = self.data["geometry"].get("dpdx_pm", -2)
+        amhd = self.data["geometry"].get("amhd", 0.0)
+        local_species = self.get_local_species()
 
-        amhd_beta_prime = -self.data["geometry"].get("amhd", 0.0) / (
-            local_geometry_data["q"] ** 2 * local_geometry_data["Rmaj"]
-        )
+        if amhd != -1:
+            amhd_beta_prime = -amhd / (
+                local_geometry_data["q"] ** 2 * local_geometry_data["Rmaj"]
+            )
+        else:
+            amhd_beta_prime = (
+                -local_species.inverse_lp.m
+                * local_species.pressure.m
+                / local_geometry_data["B0"] ** 2
+            )
 
         if dpdx == -1:
-            local_species = self.get_local_species()
             local_geometry_data["beta_prime"] = (
                 -local_species.inverse_lp.m
                 * local_species.pressure.m


### PR DESCRIPTION
When `amhd=-1` in GENE, $\beta'$ should be set consistently from beta/gradients but that wasn't being captured so that is fixed here.

Only relevant for reading in existing GENE runs where `amhd=-1` **and** `dpdx_pm=-2`.

Any files written by pyro from a global equilibrium, or any tracer_efit runs would have the correct $\beta'$