### PR TITLE
get_charge() method fix

### DIFF
--- a/src/pyrokinetics/species.py
+++ b/src/pyrokinetics/species.py
@@ -49,7 +49,7 @@ class Species:
 
         charge = self.charge(psi_n)
 
-        if np.isclose(charge, np.rint(charge)):
+        if np.allclose(charge, np.rint(charge)):
             charge = np.rint(charge)
 
         return charge


### PR DESCRIPTION
The `get_charge()` method was breaking if one tried to construct a `psi_n` grid for charges, which has now been fixed. 