### PR TITLE
Enhancements/flux surface volumes

### DIFF
--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -612,23 +612,29 @@ class LocalGeometry:
         Calculate the poloidal and toroidal area of the flux surface
         and the toroidal volume in units of lref
 
-        :math:`f = \frac{2\pi q}{\oint \frac{dl}{R^2 B_{\theta}}}`
+        :math:`A_{toroidal} = 2\pi \int_0^{2\pi}  R\frac{\partial L}{\partial \theta} d\theta`
 
-        See eqn 97 in Candy Plasma Phys. Control. Fusion 51 (2009) 105009
+        :math:`A_{poloidal} = \int_0^{2\pi}  R\frac{\partial Z}{\partial \theta} d\theta`
+
+        :math:`V_{toroidal} = \pi \ int_0^{2\pi}  R^2\frac{\partial Z}{\partial \theta} d\theta`
 
         Returns
         -------
-        f : Float
-            Prediction for :math:`f_\psi` from B_poloidal
+        poloidal_area : float, units [lref**2]
+            Calculation of the poloidal surface area  :math:`A_{poloidal}`
+        toroidal_area : float, units [lref**2]
+            Calculation of the toroidal surface area  :math:`A_{toroidal}`
+        toroidal_volume : float, units [lref**3]
+            Calculation of the poloidal volume :math:`V_{toroidal}`
         """
 
         lref = self.R.units
 
         # Calculate using Green's theorem
         def poloidal_surface_integrand(theta):
-            R, Z = self.get_flux_surface(theta)
+            R, _ = self.get_flux_surface(theta)
             (
-                dRdtheta,
+                _,
                 _,
                 dZdtheta,
                 _,
@@ -679,11 +685,11 @@ class LocalGeometry:
         def toroidal_volume_integral():
             return np.pi * quad(toroidal_volume_integrand, 0.0, 2 * np.pi)[0]
 
-        area = poloidal_surface_integral()
-        surface = toroidal_surface_integral()
-        volume = toroidal_volume_integral()
+        poloidal_area = poloidal_surface_integral()
+        toroidal_area = toroidal_surface_integral()
+        toroidal_volume = toroidal_volume_integral()
 
-        return area, surface, volume
+        return poloidal_area, toroidal_area, toroidal_volume
 
     def test_safety_factor(self):
         r"""

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -634,7 +634,7 @@ class LocalGeometry:
                 _,
             ) = self.get_RZ_derivatives(theta)
             # Expect dimensionless quantity
-            result = units.Quantity(R * dZdtheta - Z * dRdtheta).magnitude
+            result = units.Quantity(R * dZdtheta).magnitude
             # Avoid SciPy warning when returning array with a single element
             if np.ndim(result) == 1 and np.size(result) == 1:
                 result = result[0]
@@ -642,7 +642,7 @@ class LocalGeometry:
 
         @units.wraps(lref**2, (), False)
         def poloidal_surface_integral():
-            return 0.5 * quad(poloidal_surface_integrand, 0.0, 2 * np.pi)[0]
+            return quad(poloidal_surface_integrand, 0.0, 2 * np.pi)[0]
 
         # Calculate using line integral * 2pi R
         def toroidal_surface_integrand(theta):
@@ -663,7 +663,7 @@ class LocalGeometry:
         def toroidal_volume_integrand(theta):
             R, Z = self.get_flux_surface(theta)
             (
-                dRdtheta,
+                _,
                 _,
                 dZdtheta,
                 _,

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -607,6 +607,86 @@ class LocalGeometry:
 
         return 2 * pi * q / integral
 
+    def get_flux_surface_area_volume(self):
+        r"""
+        Calculate the poloidal and toroidal area of the flux surface
+        and the toroidal volume in units of lref
+
+        :math:`f = \frac{2\pi q}{\oint \frac{dl}{R^2 B_{\theta}}}`
+
+        See eqn 97 in Candy Plasma Phys. Control. Fusion 51 (2009) 105009
+
+        Returns
+        -------
+        f : Float
+            Prediction for :math:`f_\psi` from B_poloidal
+        """
+
+        lref = self.R.units
+
+        # Calculate using Green's theorem
+        def poloidal_surface_integrand(theta):
+            R, Z = self.get_flux_surface(theta)
+            (
+                dRdtheta,
+                _,
+                dZdtheta,
+                _,
+            ) = self.get_RZ_derivatives(theta)
+            # Expect dimensionless quantity
+            result = units.Quantity(R * dZdtheta - Z * dRdtheta).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref**2, (), False)
+        def poloidal_surface_integral():
+            return 0.5 * quad(poloidal_surface_integrand, 0.0, 2 * np.pi)[0]
+
+        # Calculate using line integral * 2pi R
+        def toroidal_surface_integrand(theta):
+            R, _ = self.get_flux_surface(theta)
+            dLdtheta = self.get_dLdtheta(theta)
+            # Expect dimensionless quantity
+            result = units.Quantity(R * dLdtheta).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref**2, (), False)
+        def toroidal_surface_integral():
+            return 2.0 * np.pi * quad(toroidal_surface_integrand, 0.0, 2 * np.pi)[0]
+
+        # Calculate using Harry's suggestion
+        def toroidal_volume_integrand(theta):
+            R, Z = self.get_flux_surface(theta)
+            (
+                dRdtheta,
+                _,
+                dZdtheta,
+                _,
+            ) = self.get_RZ_derivatives(theta)
+            # Expect dimensionless quantity
+            result = units.Quantity(
+                (R**2 * dZdtheta / 4) - (R * Z * dRdtheta / 2)
+            ).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref**3, (), False)
+        def toroidal_volume_integral():
+            return 2.0 * np.pi * quad(toroidal_volume_integrand, 0.0, 2 * np.pi)[0]
+
+        area = poloidal_surface_integral()
+        surface = toroidal_surface_integral()
+        volume = toroidal_volume_integral()
+
+        return area, surface, volume
+
     def test_safety_factor(self):
         r"""
         Calculate safety factor from LocalGeometry object b poloidal field

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -669,9 +669,7 @@ class LocalGeometry:
                 _,
             ) = self.get_RZ_derivatives(theta)
             # Expect dimensionless quantity
-            result = units.Quantity(
-                (R**2 * dZdtheta / 4) - (R * Z * dRdtheta / 2)
-            ).magnitude
+            result = units.Quantity((R**2 * dZdtheta)).magnitude
             # Avoid SciPy warning when returning array with a single element
             if np.ndim(result) == 1 and np.size(result) == 1:
                 result = result[0]
@@ -679,7 +677,7 @@ class LocalGeometry:
 
         @units.wraps(lref**3, (), False)
         def toroidal_volume_integral():
-            return 2.0 * np.pi * quad(toroidal_volume_integrand, 0.0, 2 * np.pi)[0]
+            return np.pi * quad(toroidal_volume_integrand, 0.0, 2 * np.pi)[0]
 
         area = poloidal_surface_integral()
         surface = toroidal_surface_integral()

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -691,6 +691,119 @@ class LocalGeometry:
 
         return poloidal_area, toroidal_area, toroidal_volume
 
+    def get_flux_surface_area_volume_derivatives(self):
+        r"""
+        Calculate the derivative of the poloidal and toroidal
+        area of the flux surface and the toroidal volume with respect to
+        r
+
+        :math:`\frac{\partial A_{toroidal}}{\partial r} = 2\pi \int_0^{2\pi}  R\frac{\partial L}{\partial \theta} d\theta`
+
+        :math:`\frac{\partial A_{poloidal}}{\partial r} = \int_0^{2\pi} \frac{J}{R} d\theta`
+
+        :math:`V_{toroidal} = 2\pi \ int_0^{2\pi} J d\theta`
+
+        Returns
+        -------
+        poloidal_area : float, units [lref**2]
+            Calculation of the poloidal surface area  :math:`A_{poloidal}`
+        toroidal_area : float, units [lref**2]
+            Calculation of the toroidal surface area  :math:`A_{toroidal}`
+        toroidal_volume : float, units [lref**3]
+            Calculation of the poloidal volume :math:`V_{toroidal}`
+        """
+
+        lref = self.R.units
+
+        # Calculate using Green's theorem
+        def poloidal_surface_derivative_integrand(theta):
+            (
+                dRdtheta,
+                dRdr,
+                dZdtheta,
+                dZdr,
+            ) = self.get_RZ_derivatives(theta)
+            # Expect dimensionless quantity
+            result = units.Quantity(dRdr * dZdtheta - dZdr * dRdtheta).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref, (), False)
+        def poloidal_surface_derivative_integral():
+            return quad(poloidal_surface_derivative_integrand, 0.0, 2 * np.pi)[0]
+
+        # Calculate using line integral * 2pi R
+        def toroidal_surface_derivative_integrand(theta):
+            R, _ = self.get_flux_surface(theta)
+            (
+                dRdtheta,
+                dRdr,
+                dZdtheta,
+                dZdr,
+            ) = self.get_RZ_derivatives(theta)
+            (
+                d2Rdtheta2,
+                d2Rdrdtheta,
+                d2Zdtheta2,
+                d2Zdrdtheta,
+            ) = self.get_RZ_second_derivatives(theta)
+            g_tt = dRdtheta**2 + dZdtheta**2
+
+            integrand = dRdr * np.sqrt(g_tt) + R / np.sqrt(g_tt) * (
+                dRdtheta * d2Rdrdtheta + dZdtheta * d2Zdrdtheta
+            )
+            # Expect dimensionless quantity
+            result = units.Quantity(integrand).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref, (), False)
+        def toroidal_surface_derivative_integral():
+            return (
+                2.0
+                * np.pi
+                * quad(toroidal_surface_derivative_integrand, 0.0, 2 * np.pi)[0]
+            )
+
+        # Calculate using Harry's suggestion
+        def toroidal_volume_derivative_integrand(theta):
+            R, _ = self.get_flux_surface(theta)
+            (
+                dRdtheta,
+                dRdr,
+                dZdtheta,
+                dZdr,
+            ) = self.get_RZ_derivatives(theta)
+            Jacobian = R * (dRdr * dZdtheta - dZdr * dRdtheta)
+            # Expect dimensionless quantity
+            result = units.Quantity(Jacobian).magnitude
+            # Avoid SciPy warning when returning array with a single element
+            if np.ndim(result) == 1 and np.size(result) == 1:
+                result = result[0]
+            return result
+
+        @units.wraps(lref**2, (), False)
+        def toroidal_volume_derivative_integral():
+            return (
+                2
+                * np.pi
+                * quad(toroidal_volume_derivative_integrand, 0.0, 2 * np.pi)[0]
+            )
+
+        poloidal_area_derivative = poloidal_surface_derivative_integral()
+        toroidal_area_derivative = toroidal_surface_derivative_integral()
+        toroidal_volume_derivative = toroidal_volume_derivative_integral()
+
+        return (
+            poloidal_area_derivative,
+            toroidal_area_derivative,
+            toroidal_volume_derivative,
+        )
+
     def test_safety_factor(self):
         r"""
         Calculate safety factor from LocalGeometry object b poloidal field

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -1,6 +1,8 @@
 import numpy as np
-
+import netCDF4 as nc
 import pyrokinetics as pk
+
+import pytest
 
 
 def test_normalise():
@@ -22,3 +24,65 @@ def test_normalise():
     assert geometry.Rmaj.units == norms.units.lref_major_radius
     assert geometry.a_minor.units == norms.units.lref_major_radius
     assert (geometry.Rmaj / geometry.a_minor) == (Rmaj / a_minor)
+
+
+@pytest.fixture(scope="module")
+def setup_area_volume():
+
+    transp_file = pk.template_dir / "transp.cdf"
+    data = nc.Dataset(transp_file)
+
+    transp_dvol = data["DVOL"][-1, :] * 1e-6
+    transp_volume = np.cumsum(transp_dvol)
+
+    transp_darea = data["DAREA"][-1, :] * 1e-4
+    transp_area = np.cumsum(transp_darea)
+
+    transp_surface = data["SURF"][-1, :] * 1e-4
+
+    transp_psi_n = data["PLFLX"][-1, :] / data["PLFLX"][-1, -1]
+
+    # Load up pyro object
+    pyro = pk.Pyro(
+        eq_file=transp_file,
+        eq_type="TRANSP",
+        eq_kwargs={"neighbors": 64},
+        kinetics_file=transp_file,
+        kinetics_type="TRANSP",
+    )
+
+    # Rename the ion species in the original pyro object
+
+    return {
+        "pyro": pyro,
+        "transp_psi_n": transp_psi_n,
+        "transp_area": transp_area,
+        "transp_surface": transp_surface,
+        "transp_volume": transp_volume,
+    }
+
+
+@pytest.mark.parametrize("psi_n", [0.25, 0.5, 0.75, 0.99])
+def test_flux_surface_area_volume(setup_area_volume, psi_n):
+
+    pyro = setup_area_volume["pyro"]
+    transp_psi_n = setup_area_volume["transp_psi_n"]
+    transp_area = setup_area_volume["transp_area"]
+    transp_surface = setup_area_volume["transp_surface"]
+    transp_volume = setup_area_volume["transp_volume"]
+
+    psi_n_index = np.argmin(np.abs(transp_psi_n - psi_n))
+
+    pyro.load_local_geometry(
+        psi_n=transp_psi_n[psi_n_index], local_geometry="MXH", n_moments=7
+    )
+
+    area, surface, volume = pyro.local_geometry.get_flux_surface_area_volume()
+
+    surface = surface.to("meter**2").m
+    area = area.to("meter**2").m
+    volume = volume.to("meter**3").m
+
+    assert np.isclose(area, transp_area[psi_n_index], rtol=1e-2)
+    assert np.isclose(surface, transp_surface[psi_n_index], rtol=1e-2)
+    assert np.isclose(volume, transp_volume[psi_n_index], rtol=1e-2)

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -42,6 +42,12 @@ def setup_area_volume():
 
     transp_psi_n = data["PLFLX"][-1, :] / data["PLFLX"][-1, -1]
 
+    transp_r = data["RMNMP"][-1, :] * 1e-2
+
+    transp_dVdr = np.gradient(transp_volume, transp_r)
+    transp_dAdr = np.gradient(transp_area, transp_r)
+    transp_dSdr = np.gradient(transp_surface, transp_r)
+
     # Load up pyro object
     pyro = pk.Pyro(
         eq_file=transp_file,
@@ -59,10 +65,13 @@ def setup_area_volume():
         "transp_area": transp_area,
         "transp_surface": transp_surface,
         "transp_volume": transp_volume,
+        "transp_darea": transp_dAdr,
+        "transp_dsurface": transp_dSdr,
+        "transp_dvolume": transp_dVdr,
     }
 
 
-@pytest.mark.parametrize("psi_n", [0.25, 0.5, 0.75, 0.99])
+@pytest.mark.parametrize("psi_n", [0.25, 0.5, 0.75, 0.95])
 def test_flux_surface_area_volume(setup_area_volume, psi_n):
 
     pyro = setup_area_volume["pyro"]
@@ -70,6 +79,9 @@ def test_flux_surface_area_volume(setup_area_volume, psi_n):
     transp_area = setup_area_volume["transp_area"]
     transp_surface = setup_area_volume["transp_surface"]
     transp_volume = setup_area_volume["transp_volume"]
+    transp_darea = setup_area_volume["transp_darea"]
+    transp_dsurface = setup_area_volume["transp_dsurface"]
+    transp_dvolume = setup_area_volume["transp_dvolume"]
 
     psi_n_index = np.argmin(np.abs(transp_psi_n - psi_n))
 
@@ -86,3 +98,15 @@ def test_flux_surface_area_volume(setup_area_volume, psi_n):
     assert np.isclose(area, transp_area[psi_n_index], rtol=1e-2)
     assert np.isclose(surface, transp_surface[psi_n_index], rtol=1e-2)
     assert np.isclose(volume, transp_volume[psi_n_index], rtol=1e-2)
+
+    darea, dsurface, dvolume = (
+        pyro.local_geometry.get_flux_surface_area_volume_derivatives()
+    )
+
+    dsurface = dsurface.to("meter").m
+    darea = darea.to("meter").m
+    dvolume = dvolume.to("meter**2").m
+
+    assert np.isclose(darea, transp_darea[psi_n_index], rtol=1e-2)
+    assert np.isclose(dsurface, transp_dsurface[psi_n_index], rtol=1e-2)
+    assert np.isclose(dvolume, transp_dvolume[psi_n_index], rtol=1e-2)


### PR DESCRIPTION
Add a method to `LocalGeometry` that calculates the toroidal and poloidal surface area as well as the volume enclosed by the flux surface using the analytical fits

$A_{toroidal} = \int_0^{2\pi}  R\frac{\partial L}{\partial \theta} d\theta$

where $\frac{\partial L}{\partial \theta} = \sqrt{\frac{\partial R}{\partial \theta} ^2 + \frac{\partial Z}{\partial \theta} ^2}$

$A_{poloidal} = \int_0^{2\pi}  R\frac{\partial Z}{\partial \theta} d\theta$

$V_{toroidal} = \pi \int_0^{2\pi}  R^2\frac{\partial Z}{\partial \theta} d\theta$

This also maintains units so we can convert to SI easily. Called by doing `area, surface, volume = local_geometry.get_flux_surface_area_volume`

These names here are a bit confusing I admit so happy to take suggestions

I've added a test using the template TRANSP netCDF which stores these as outputs.