### PR TITLE
Fix to setting of omprimfac in gs2.py

### DIFF
--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -275,7 +275,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
             # Without PVG term in GS2, need to force to 0
             species_data.domega_drho = (
-                - self.data["dist_fn_knobs"].get("g_exb", 0.0)
+                -self.data["dist_fn_knobs"].get("g_exb", 0.0)
                 * self.data["dist_fn_knobs"].get("omprimfac", 1.0)
                 * self.data["theta_grid_parameters"]["qinp"]
                 / self.data["theta_grid_parameters"]["rhoc"]
@@ -789,7 +789,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         else:
             self.data["dist_fn_knobs"]["omprimfac"] = (
                 (
-                    - local_species.electron.domega_drho
+                    -local_species.electron.domega_drho
                     * local_geometry.rho
                     / local_geometry.q
                     / numerics.gamma_exb

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -784,7 +784,19 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
         self.data["dist_fn_knobs"]["g_exb"] = numerics.gamma_exb
         self.data["dist_fn_knobs"]["g_exbfac"] = 1.0
-        self.data["dist_fn_knobs"]["omprimfac"] = 1.0
+        if numerics.gamma_exb == 0.0:
+            self.data["dist_fn_knobs"]["omprimfac"] = 1.0
+        else:
+            self.data["dist_fn_knobs"]["omprimfac"] = (
+                (
+                    local_species.electron.domega_drho
+                    * local_geometry.rho
+                    / local_geometry.q
+                    / numerics.gamma_exb
+                )
+                .to_base_units()
+                .m
+            )
 
         self.data["dist_fn_knobs"]["mach"] = local_species.electron.omega0
         self.data["knobs"]["zeff"] = local_species.zeff

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -275,7 +275,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
             # Without PVG term in GS2, need to force to 0
             species_data.domega_drho = (
-                self.data["dist_fn_knobs"].get("g_exb", 0.0)
+                - self.data["dist_fn_knobs"].get("g_exb", 0.0)
                 * self.data["dist_fn_knobs"].get("omprimfac", 1.0)
                 * self.data["theta_grid_parameters"]["qinp"]
                 / self.data["theta_grid_parameters"]["rhoc"]
@@ -789,7 +789,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         else:
             self.data["dist_fn_knobs"]["omprimfac"] = (
                 (
-                    local_species.electron.domega_drho
+                    - local_species.electron.domega_drho
                     * local_geometry.rho
                     / local_geometry.q
                     / numerics.gamma_exb

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -784,19 +784,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
 
         self.data["dist_fn_knobs"]["g_exb"] = numerics.gamma_exb
         self.data["dist_fn_knobs"]["g_exbfac"] = 1.0
-        if numerics.gamma_exb == 0.0:
-            self.data["dist_fn_knobs"]["omprimfac"] = 1.0
-        else:
-            self.data["dist_fn_knobs"]["omprimfac"] = (
-                (
-                    local_species.electron.domega_drho
-                    * local_geometry.rho
-                    / local_geometry.q
-                    / numerics.gamma_exb
-                )
-                .to_base_units()
-                .m
-            )
+        self.data["dist_fn_knobs"]["omprimfac"] = 1.0
 
         self.data["dist_fn_knobs"]["mach"] = local_species.electron.omega0
         self.data["knobs"]["zeff"] = local_species.zeff


### PR DESCRIPTION
`omprimfac` was being improperly set; should be default of `1.0` irrespective of the sign of the rotation, given that it is a muliplier that gets applied after the PVG term is calculated. @d7919 will correct me if I have read `GS2`'s source code wrong. 