### PR TITLE
Bugfix to prevent AttributeError

### DIFF
--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -85,8 +85,6 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
         profiles = data["profiles"]
         species = data["species"]
 
-        print(species)
-
         # Interpolate on psi_n.
         te_psi_n = profiles["te"]["psinorm"] * units.dimensionless
         electron_temp_data = profiles["te"]["data"] * 1e3 * units.eV

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -46,6 +46,8 @@ def ion_species_selector(nucleons, charge):
             return "tritium"
         if charge.m == 2:
             return "helium3"
+    elif nucleons == 6 and charge.m == 3:
+        return "lithium"
     else:
         return "impurity"
 
@@ -82,6 +84,8 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
 
         profiles = data["profiles"]
         species = data["species"]
+
+        print(species)
 
         # Interpolate on psi_n.
         te_psi_n = profiles["te"]["psinorm"] * units.dimensionless

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -48,6 +48,8 @@ def ion_species_selector(nucleons, charge):
             return "helium3"
     elif nucleons == 6 and charge.m == 3:
         return "lithium"
+    elif np.isclose(nucleons, 2.5) and charge.m == 1:
+        return "DT_5050"
     else:
         return "impurity"
 

--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -179,17 +179,14 @@ class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):
 
                 impurity_dens_func = UnitSpline(nz_psi_n, impurity_dens_data)
 
-                impurity_charge = UnitSpline(
-                    ne_psi_n,
-                    species[ion_it]["Z"] * unit_charge_array * units.elementary_charge,
-                )
+                impurity_charge = species[ion_it]["Z"] * units.elementary_charge
                 impurity_nucleons = species[ion_it]["A"]
                 impurity_mass = impurity_nucleons * deuterium_mass / 2.0
 
                 species_name = ion_species_selector(impurity_nucleons, impurity_charge)
                 result[species_name] = Species(
                     species_type=species_name,
-                    charge=impurity_charge,
+                    charge=UnitSpline(ne_psi_n, impurity_charge * unit_charge_array),
                     mass=impurity_mass,
                     dens=impurity_dens_func,
                     temp=ion_temp_func,


### PR DESCRIPTION
Loading a pfile with impurity species was leading to an `AttributeError` as it was trying to call `charge.m` on a `UnitSpline` object. Changed to be the same format as the other species as I didn't see some fundamental reason why the `UnitSpline` construction was done before calling `ion_species_selector`.