### PR TITLE
Add check for LCFS a minor in case of divertor legs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "periodictable",
     "toml",
     "sympy",
+    "shapely",
 ]
 
 [project.optional-dependencies]

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -124,13 +124,12 @@ def _flux_surface_contour(
                         ]
                     )
                     intersection = contour_ls.intersection(line)
-
                     if intersection.geom_type == "Point":
                         # Ensure intersection is in original contour
                         if np.isclose(point[1], intersection.x) and np.isclose(
                             point[0], intersection.y
                         ):
-                            new_contour.append([intersection.x, intersection.y])
+                            new_contour.append([intersection.y, intersection.x])
                     elif intersection.geom_type == "MultiPoint":
                         min_distance_idx = np.argmin(
                             [distance(inter, origin) for inter in intersection.geoms]
@@ -141,8 +140,7 @@ def _flux_surface_contour(
                         if np.isclose(point[1], min_distance_R) and np.isclose(
                             point[0], min_distance_Z
                         ):
-                            new_contour.append([min_distance_R, min_distance_Z])
-
+                            new_contour.append([min_distance_Z, min_distance_R])
                 new_contour = np.array(new_contour)
                 new_contours.append(new_contour)
             contours = new_contours

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -7,7 +7,7 @@ import numpy as np
 from contourpy import contour_generator
 from numpy.typing import ArrayLike
 from shapely import distance
-from shapely.geometry import LineString, MultiLineString, MultiPoint, Point
+from shapely.geometry import LineString, Point
 
 from ..dataset_wrapper import DatasetWrapper
 from ..units import ureg as units
@@ -132,7 +132,6 @@ def _flux_surface_contour(
                         ):
                             new_contour.append([intersection.x, intersection.y])
                     elif intersection.geom_type == "MultiPoint":
-                        count = len(intersection.geoms)
                         min_distance_idx = np.argmin(
                             [distance(inter, origin) for inter in intersection.geoms]
                         )

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -6,6 +6,8 @@ from warnings import warn
 import numpy as np
 from contourpy import contour_generator
 from numpy.typing import ArrayLike
+from shapely.geometry import LineString, Point, MultiLineString, MultiPoint
+from shapely import distance
 
 from ..dataset_wrapper import DatasetWrapper
 from ..units import ureg as units
@@ -15,7 +17,11 @@ if TYPE_CHECKING:
     import matplotlib.pyplot as plt
 
 
-@units.wraps(units.meter, [units.m, units.m, units.weber / units.rad] * 2, strict=False)
+@units.wraps(
+    units.meter,
+    [units.m, units.m, units.weber / units.rad] * 2 + [units.weber / units.rad],
+    strict=False,
+)
 def _flux_surface_contour(
     R: ArrayLike,
     Z: ArrayLike,
@@ -23,6 +29,7 @@ def _flux_surface_contour(
     R_axis: float,
     Z_axis: float,
     psi: float,
+    psi_lcfs: float = None,
 ) -> np.ndarray:
     r"""
     Given linearly-spaced RZ coordinates and :math:`\psi` at these positions, returns
@@ -99,6 +106,48 @@ def _flux_surface_contour(
     # procedure may find additional open contours outside the last closed flux surface.
     if len(contours) > 1:
         RZ_axis = np.array([Z_axis, R_axis])
+        if psi == psi_lcfs:
+            new_contours = []
+            for c, contour_line in enumerate(contours):
+                new_contour = []
+
+                contour_ls = LineString(contour_line[:, ::-1])
+                origin = Point(R_axis, Z_axis)
+                for i, point in enumerate(contour_line):
+                    direction = (point[1] - R_axis, point[0] - Z_axis)
+                    line = LineString(
+                        [
+                            origin,
+                            Point(
+                                origin.x + 2 * direction[0], origin.y + 2 * direction[1]
+                            ),
+                        ]
+                    )
+                    intersection = contour_ls.intersection(line)
+
+                    if intersection.geom_type == "Point":
+                        # Ensure intersection is in original contour
+                        if np.isclose(point[1], intersection.x) and np.isclose(
+                            point[0], intersection.y
+                        ):
+                            new_contour.append([intersection.x, intersection.y])
+                    elif intersection.geom_type == "MultiPoint":
+                        count = len(intersection.geoms)
+                        min_distance_idx = np.argmin(
+                            [distance(inter, origin) for inter in intersection.geoms]
+                        )
+                        min_distance_R = intersection.geoms[min_distance_idx].x
+                        min_distance_Z = intersection.geoms[min_distance_idx].y
+                        # Ensure intersection is in original contour
+                        if np.isclose(point[1], min_distance_R) and np.isclose(
+                            point[0], min_distance_Z
+                        ):
+                            new_contour.append([min_distance_R, min_distance_Z])
+
+                new_contour = np.array(new_contour)
+                new_contours.append(new_contour)
+            contours = new_contours
+
         mean_dist = [np.mean(np.linalg.norm(c - RZ_axis, axis=1)) for c in contours]
         contour = contours[np.argmin(mean_dist)]
     else:

--- a/src/pyrokinetics/equilibrium/flux_surface.py
+++ b/src/pyrokinetics/equilibrium/flux_surface.py
@@ -6,8 +6,8 @@ from warnings import warn
 import numpy as np
 from contourpy import contour_generator
 from numpy.typing import ArrayLike
-from shapely.geometry import LineString, Point, MultiLineString, MultiPoint
 from shapely import distance
+from shapely.geometry import LineString, MultiLineString, MultiPoint, Point
 
 from ..dataset_wrapper import DatasetWrapper
 from ..units import ureg as units

--- a/src/pyrokinetics/equilibrium/geqdsk.py
+++ b/src/pyrokinetics/equilibrium/geqdsk.py
@@ -154,7 +154,7 @@ class EquilibriumReaderGEQDSK(FileReader, file_type="GEQDSK", reads=Equilibrium)
         r_minor[0] = 0.0 * units.meter
         Z_mid[0] = data["zmid"] * units.meter
         for idx, psi in enumerate(psi_grid[1:], start=1):
-            Rc, Zc = _flux_surface_contour(R, Z, psi_RZ, R_axis, Z_axis, psi)
+            Rc, Zc = _flux_surface_contour(R, Z, psi_RZ, R_axis, Z_axis, psi, psi_lcfs)
             R_min, R_max = min(Rc), max(Rc)
             Z_min, Z_max = min(Zc), max(Zc)
             R_major[idx] = 0.5 * (R_max + R_min)

--- a/src/pyrokinetics/equilibrium/geqdsk.py
+++ b/src/pyrokinetics/equilibrium/geqdsk.py
@@ -48,6 +48,7 @@ class EquilibriumReaderGEQDSK(FileReader, file_type="GEQDSK", reads=Equilibrium)
         psi_n_lcfs: float = 1.0,
         clockwise_phi: bool = False,
         cocos: Optional[int] = None,
+        a_minor_tolerance: Optional[float] = 0.05,
     ) -> Equilibrium:
         r"""
         Read in G-EQDSK file and populate Equilibrium object. Should not be invoked
@@ -68,7 +69,10 @@ class EquilibriumReaderGEQDSK(FileReader, file_type="GEQDSK", reads=Equilibrium)
             neither ``clockwise_phi`` nor the file contents will be used to identify
             the actual convention in use. The resulting Equilibrium is always converted
             to COCOS 11.
-
+        a_minor_tolerance: Optional[float]
+            Maximum allowed relative tolerance on calculated a minor and the extrapolated
+            a minor from inner surfaces to catch cases where divertor legs are in the
+            contour fit for the LCFS
         Returns
         -------
         Equilibrium
@@ -157,7 +161,16 @@ class EquilibriumReaderGEQDSK(FileReader, file_type="GEQDSK", reads=Equilibrium)
             r_minor[idx] = 0.5 * (R_max - R_min)
             Z_mid[idx] = 0.5 * (Z_max + Z_min)
 
+        extrapolated_a_minor = r_minor[-2] + np.gradient(r_minor[:-1], psi_grid[:-1])[
+            -1
+        ] * (psi_grid[-1] - psi_grid[-2])
         a_minor = r_minor[-1]
+
+        if abs(a_minor - extrapolated_a_minor) / a_minor > a_minor_tolerance:
+            raise ValueError(
+                f"Minor radius of LCFS {a_minor:.3f} not close to extrapolated value {extrapolated_a_minor:.3f} "
+                "likely due to divertor legs being captured in contour fitting, try lowering psi_n_lcfs"
+            )
 
         # Create and return Equilibrium
         return Equilibrium(

--- a/src/pyrokinetics/equilibrium/geqdsk.py
+++ b/src/pyrokinetics/equilibrium/geqdsk.py
@@ -166,7 +166,7 @@ class EquilibriumReaderGEQDSK(FileReader, file_type="GEQDSK", reads=Equilibrium)
         ] * (psi_grid[-1] - psi_grid[-2])
         a_minor = r_minor[-1]
 
-        if abs(a_minor - extrapolated_a_minor) / a_minor > a_minor_tolerance:
+        if not np.isclose(a_minor, extrapolated_a_minor, atol=a_minor_tolerance):
             raise ValueError(
                 f"Minor radius of LCFS {a_minor:.3f} not close to extrapolated value {extrapolated_a_minor:.3f} "
                 "likely due to divertor legs being captured in contour fitting, try lowering psi_n_lcfs"


### PR DESCRIPTION
An attempt to patch (not necessarily fix) an issue raised in #443 

Essentially you can have cases where the contour fitting of the equilibrium finds the divertor legs in the fit to the flux surface. Our current algorithm looks for all connected contour at a fixed value of $\psi$ and then chooses the contour where the summed normalised distance to the magnetic is the smallest. 

Inside the LCFS this works really nicely without issues from the divertor legs as they aren't really connected to the flux surface. Here is an example from MAST-U and pyro will choose the red one by default.
![image](https://github.com/user-attachments/assets/a5be2821-c6f2-473c-a3f9-bc2c1c45600a)


The issue is that on the LCFS if divertor legs are connected according to the contour fit then the algorithm either chooses the wrong contour (in the case below it chooses the blue one) or as in the issue raised it can get $R_{min}$ wrong

![image](https://github.com/user-attachments/assets/209901be-2699-4f8a-a88c-8a136ef38b12)

The work around here essentially extrapolates the minor radius outwards from the second to last point and then checks to see if the calculated $a_{minor}$ is close to this within a specified tolerance. If not a error is raised suggesting `psi_n_lcfs` is lowered a little. Usually setting it to something like `0.999` is fine. See below
![image](https://github.com/user-attachments/assets/8a68f7bb-669e-465b-a40f-549b8d879548)


If someone can think of a better way of getting that contour right then I am open to suggestions.
