### PR TITLE
Bugfix/hydrogenic species

### DIFF
--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -48,8 +48,8 @@ def ion_species_selector(nucleons, charge):
             return "helium3"
     elif nucleons == 6 and charge.m == 3:
         return "lithium"
-    elif np.isclose(nucleons, 2.5) and charge.m == 1:
-        return "DT_5050"
+    elif (1.0 < nucleons < 3.0) and charge.m == 1:
+        return "hydrogenic"
     else:
         return "impurity"
 

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -774,7 +774,10 @@ class SimulationNormalisation(Normalisation):
             base_mass = "hydrogen"
         elif "hydrogenic" in kinetics.species_names:
             add_deuterium = True
-            deuterium_factor = ((1.0 * ureg.mref_deuterium) / kinetics.species_data["hydrogenic"].get_mass()).m
+            deuterium_factor = (
+                (1.0 * ureg.mref_deuterium)
+                / kinetics.species_data["hydrogenic"].get_mass()
+            ).m
             base_mass = "hydrogenic"
         else:
             raise ValueError(

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -774,10 +774,11 @@ class SimulationNormalisation(Normalisation):
             base_mass = "hydrogen"
         elif "hydrogenic" in kinetics.species_names:
             add_deuterium = True
+            hyrogenic_mass = kinetics.species_data["hydrogenic"].get_mass()
             deuterium_factor = (
-                (1.0 * ureg.mref_deuterium)
-                / kinetics.species_data["hydrogenic"].get_mass()
-            ).m
+                ((1.0 * ureg.mref_deuterium) / hyrogenic_mass).to_base_units().m
+            )
+            self.define(f"mref_hydrogenic_{self.name} = {hyrogenic_mass}", units=True)
             base_mass = "hydrogenic"
         else:
             raise ValueError(

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -772,6 +772,10 @@ class SimulationNormalisation(Normalisation):
             add_deuterium = True
             deuterium_factor = 2.0
             base_mass = "hydrogen"
+        elif "hydrogenic" in kinetics.species_names:
+            add_deuterium = True
+            deuterium_factor = ((1.0 * ureg.mref_deuterium) / kinetics.species_data["hydrogenic"].get_mass()).m
+            base_mass = "hydrogenic"
         else:
             raise ValueError(
                 f"Pyrokinetics only supports plasma with at least 1 hydrogenic species, Kinetics oject only has {kinetics.species_names}"

--- a/tests/kinetics/test_kinetics.py
+++ b/tests/kinetics/test_kinetics.py
@@ -510,3 +510,80 @@ def test_compare_gacode_jetto_attrs(kin_gacode, kin_jetto, attr, unit):
             getattr(kin_jetto.species_data[sp2], attr)(0.5).to(unit).magnitude,
             rtol=5e-2,
         )
+
+
+@pytest.fixture(scope="module")
+def setup_hydrogenic_pfile(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("pfile_hydrogenic")
+    with open(template_dir / "pfile.txt", "r") as f:
+        lines = f.readlines()
+    lines[-2] = " 1.000000   1.000000   1.500000\n"
+    print(lines)
+    hydrogenic_pfile = tmp_path / "pfile_hydrogenic.txt"
+    with open(hydrogenic_pfile, "w") as f:
+        f.writelines(lines)
+
+    return hydrogenic_pfile
+
+
+@pytest.mark.parametrize("kinetics_type", ["pFile", None])
+def test_read_pFile_hydrogenic(setup_hydrogenic_pfile, equilibrium, kinetics_type):
+    # Rename the ion species in the original pyro object
+    hydrogenic_pfile = setup_hydrogenic_pfile
+
+    pfile = read_kinetics(hydrogenic_pfile, kinetics_type, eq=equilibrium)
+    assert pfile.kinetics_type == "pFile"
+
+    assert pfile.nspec == 4
+    assert np.array_equal(
+        sorted(pfile.species_names),
+        sorted(["deuterium_fast", "electron", "hydrogenic", "impurity"]),
+    )
+    check_species(
+        pfile.species_data["electron"],
+        "electron",
+        -1,
+        electron_mass,
+        midpoint_density=7.63899297e19,
+        midpoint_density_gradient=1.10742399,
+        midpoint_temperature=770.37876268,
+        midpoint_temperature_gradient=3.1457586490506135,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
+    )
+    check_species(
+        pfile.species_data["hydrogenic"],
+        "hydrogenic",
+        1,
+        deuterium_mass * 0.75,
+        midpoint_density=5.99025662e19,
+        midpoint_density_gradient=1.7807398428788435,
+        midpoint_temperature=742.54533496,
+        midpoint_temperature_gradient=2.410566291534264,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
+    )
+    check_species(
+        pfile.species_data["impurity"],
+        "impurity",
+        6,
+        6 * deuterium_mass,
+        midpoint_density=2.74789247e18,
+        midpoint_density_gradient=-1.3392585682314078,
+        midpoint_temperature=742.54533496,
+        midpoint_temperature_gradient=2.410566291534264,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
+    )
+    check_species(
+        pfile.species_data["deuterium_fast"],
+        "deuterium_fast",
+        1,
+        deuterium_mass,
+        midpoint_density=7.63899297e18,
+        midpoint_density_gradient=1.1074239891222437,
+        midpoint_temperature=1379.36939199,
+        midpoint_temperature_gradient=3.0580150015690317,
+        midpoint_angular_velocity=16882.124102721187,
+        midpoint_angular_velocity_gradient=4.165436791612331,
+    )


### PR DESCRIPTION
Add in ability to reading "hydrogenic" species which have a charge of 1 and a mass between 1 and 3 $m_{proton}$ for the `pFile` format (not sure if any other codes do this).

We label this as hydrogenic and would be used in cases where you have a combined DT, HT, HD main ion mix.

Added a test for this by modifying the template `pFile` as we need to create a new reference mass `mref_hydrogenic`