### PR TITLE
Add units to PyroScan output

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -16,6 +16,7 @@ import xarray as xr
 from .gk_code import GKInput
 from .normalisation import ConventionNormalisation
 from .pyro import Pyro
+from .units import ureg
 
 
 class PyroScan:
@@ -101,6 +102,12 @@ class PyroScan:
                 self.pyroscan_json = json.load(f)
 
             for key, value in self.pyroscan_json.items():
+                # Add units if stored
+                if key == "parameter_dict":
+                    for param_key, param_value in value.items():
+                        if param_value[-1] in ureg:
+                            value[param_key] = param_value[0] * ureg(param_value[-1])
+
                 setattr(self, key, value)
         else:
             self.pyroscan_json = {attr: getattr(self, attr) for attr in self.JSON_ATTRS}
@@ -606,7 +613,7 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, np.floating):
             return float(obj)
         if isinstance(obj, pint.Quantity):
-            return obj.m
+            return [obj.m, str(obj.units)]
         return json.JSONEncoder.default(self, obj)
 
 

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -13,6 +13,8 @@ import pint
 
 from .gk_code import GKInput
 from .pyro import Pyro
+from .units import PyroQuantity as Quantity
+from .normalisation import ConventionNormalisation
 
 
 class PyroScan:
@@ -296,7 +298,16 @@ class PyroScan:
         import xarray as xr
 
         # xarray DataSet to store data
-        ds = xr.Dataset(self.parameter_dict)
+        dimensionless_parameter_dict = {
+            key: Quantity(value).m for key, value in self.parameter_dict.items()
+        }
+        ds = xr.Dataset(dimensionless_parameter_dict)
+
+        coord_units = {
+            coord: Quantity(value).units for coord, value in self.parameter_dict.items()
+        }
+        for coord, units in coord_units.items():
+            ds[coord] = ds[coord].assign_attrs(units=units)
 
         # TODO Need to add property to GKCode checking if it is an eigensolver
         # or initial value run and then set nmodes accordingly
@@ -304,6 +315,7 @@ class PyroScan:
             nmode = self.base_pyro.gk_input.data.get("nmodes", 2)
             nmode_coords = {"nmode": list(range(1, 1 + nmode))}
             ds = ds.assign_coords(nmode_coords)
+            ds["nmode"] = ds["nmode"].assign_attrs(units="dimensionless")
         else:
             nmode = np.nan
 
@@ -412,13 +424,18 @@ class PyroScan:
                 output_shape.append(nmode)
                 coords.append("mode")
 
-            growth_rate = np.reshape(growth_rate, output_shape)
-            mode_frequency = np.reshape(mode_frequency, output_shape)
+            def units_reshape(array, shape):
+                return np.reshape(array, shape) * array[-1].data.units
+
+            growth_rate = units_reshape(growth_rate, output_shape)
+            mode_frequency = units_reshape(mode_frequency, output_shape)
             ds["growth_rate"] = (coords, growth_rate)
             ds["mode_frequency"] = (coords, mode_frequency)
 
             if growth_rate_tolerance:
-                growth_rate_tolerance = np.reshape(growth_rate_tolerance, output_shape)
+                growth_rate_tolerance = units_reshape(
+                    growth_rate_tolerance, output_shape
+                )
                 ds["growth_rate_tolerance"] = (
                     coords,
                     growth_rate_tolerance,
@@ -427,10 +444,14 @@ class PyroScan:
             # Add eigenfunctions
             eig_coords = eigenfunctions[-1].coords
             ds = ds.assign_coords(coords=eig_coords)
+            for coord in eig_coords:
+                if hasattr(eigenfunctions[-1][coord], "units"):
+                    units = eigenfunctions[-1][coord].units
+                    ds[coord] = ds[coord].assign_attrs(units=units)
 
             # Reshape eigenfunctions and generate new coordinates
             eigenfunction_shape = self.value_size + list(np.shape(eigenfunctions[-1]))
-            eigenfunctions = np.reshape(eigenfunctions, eigenfunction_shape)
+            eigenfunctions = units_reshape(eigenfunctions, eigenfunction_shape)
             eigenfunctions_coords = tuple(self.parameter_dict.keys()) + eig_coords.dims
 
             ds["eigenfunctions"] = (eigenfunctions_coords, eigenfunctions)
@@ -442,7 +463,7 @@ class PyroScan:
 
                 # Reshape particle and generate new coordinates
                 particle_shape = output_shape + list(np.shape(particle[-1]))
-                particle = np.reshape(particle, particle_shape)
+                particle = units_reshape(particle, particle_shape)
                 particle_coords = tuple(coords) + particle_coords.dims
 
                 ds["particle"] = (particle_coords, particle)
@@ -452,12 +473,42 @@ class PyroScan:
 
                 # Reshape heat and generate new coordinates
                 heat_shape = output_shape + list(np.shape(heat[-1]))
-                heat = np.reshape(heat, heat_shape)
+                heat = units_reshape(heat, heat_shape)
                 heat_coords = tuple(coords) + heat_coords.dims
 
                 ds["heat"] = (heat_coords, heat)
 
         self.gk_output = ds
+
+    def to(self, norms: ConventionNormalisation):
+        """
+
+        Parameters
+        ----------
+        norms : ConventionNormalisation
+            Normalisation convention to convert to
+
+        Returns
+        -------
+        GKOutput with units from norms
+        """
+        for data_var in self.gk_output.data_vars:
+            self.gk_output[data_var].data = self.gk_output[data_var].data.to(norms)
+
+        # Coordinates with units not supported in xarray need to manually change
+        new_coords = {}
+        for coord in self.gk_output.coords:
+            if hasattr(self.gk_output[coord], "units"):
+                new_coord = (
+                    self.gk_output[coord].data * self.gk_output[coord].units
+                ).to(norms)
+                new_coords[coord] = (
+                    coord,
+                    new_coord.m,
+                    {"units": new_coord.units},
+                )
+
+        self.gk_output = self.gk_output.assign_coords(coords=new_coords)
 
     @property
     def gk_code(self):

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -12,9 +12,9 @@ import numpy as np
 import pint
 
 from .gk_code import GKInput
+from .normalisation import ConventionNormalisation
 from .pyro import Pyro
 from .units import PyroQuantity as Quantity
-from .normalisation import ConventionNormalisation
 
 
 class PyroScan:

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -79,9 +79,6 @@ class PyroScan:
         else:
             self.file_name = GKInput._factory[pyro.gk_code].default_file_name
 
-        if load_default_parameter_keys:
-            self.load_default_parameter_keys()
-
         self.run_directories = None
 
         if isinstance(pyro, Pyro):
@@ -93,6 +90,9 @@ class PyroScan:
             self.parameter_dict = {}
         else:
             self.parameter_dict = parameter_dict
+
+        if load_default_parameter_keys:
+            self.load_default_parameter_keys()
 
         self.p_prime_type = p_prime_type
 
@@ -184,24 +184,8 @@ class PyroScan:
                 # Get attribute in Pyro storing the parameter
                 pyro_attr = getattr(pyro, attr_name)
 
-                if hasattr(value, "units"):
-                    dimensional_value = value
-                else:
-                    units = getattr(
-                        get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
-                        "units",
-                        1,
-                    )
-                    if units != 1:
-                        warnings.warn(
-                            f"Adding units [{units}] to {param} as it has not been "
-                            "specified. To suppress this warning please add units"
-                        )
-
-                    dimensional_value = value * units
-
                 # Set the value given the Pyro attribute and location of parameter
-                set_in_dict(pyro_attr, keys_to_param, dimensional_value)
+                set_in_dict(pyro_attr, keys_to_param, value)
 
                 if param in self.parameter_func.keys():
                     func, kwargs = self.parameter_func[param]
@@ -233,6 +217,29 @@ class PyroScan:
         dict_item = {parameter_key: [parameter_attr, parameter_location]}
 
         self.parameter_map.update(dict_item)
+
+        # Get attribute name and keys where param is stored in Pyro
+
+        pyro_attr = getattr(self.base_pyro, parameter_attr)
+        if parameter_key in self.parameter_dict:
+            value = self.parameter_dict[parameter_key]
+
+            if not hasattr(value, "units"):
+                units = getattr(
+                    get_from_dict(pyro_attr, parameter_location[:-1])[
+                        parameter_location[-1]
+                    ],
+                    "units",
+                    1,
+                )
+                if units != 1:
+                    warnings.warn(
+                        f"Adding units [{units}] to {parameter_key} as it has not been "
+                        "specified. To suppress this warning please add units"
+                    )
+
+                    self.parameter_dict[parameter_key] = value * units
+
         self.pyroscan_json["parameter_map"] = self.parameter_map
 
     def add_parameter_func(
@@ -319,23 +326,8 @@ class PyroScan:
                 dimensionless_parameter_dict[param] = value.m
                 coord_units[param] = value.units
             else:
-                (attr_name, keys_to_param) = self.parameter_map[param]
-                # Get attribute in Pyro storing the parameter
-                pyro_attr = getattr(self.base_pyro, attr_name)
-                units = getattr(
-                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
-                    "units",
-                    None,
-                )
-
-                if units:
-                    warnings.warn(
-                        f"Adding units [{units}] to {param} as it has not been "
-                        "specified. To suppress this warning please add units"
-                    )
-
                 dimensionless_parameter_dict[param] = value
-                coord_units[param] = units
+                coord_units[param] = None
 
         ds = xr.Dataset(dimensionless_parameter_dict)
 
@@ -513,6 +505,8 @@ class PyroScan:
                 ds["heat"] = (heat_coords, heat)
 
         self.gk_output = PyroScanGKOutput(ds)
+
+        self.gk_output.to(getattr(self.base_pyro.norms, output_convention))
 
     @property
     def gk_code(self):

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -327,6 +327,13 @@ class PyroScan:
                     "units",
                     None,
                 )
+
+                if units:
+                    warnings.warn(
+                        f"Adding units [{units}] to {param} as it has not been "
+                        "specified. To suppress this warning please add units"
+                    )
+
                 dimensionless_parameter_dict[param] = value
                 coord_units[param] = units
 

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -4,13 +4,13 @@ import copy
 import json
 import os
 import pathlib
+import warnings
 from contextlib import contextmanager
 from functools import reduce
 from itertools import product
 
 import numpy as np
 import pint
-import warnings
 import xarray as xr
 
 from .gk_code import GKInput

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -10,10 +10,11 @@ from itertools import product
 
 import numpy as np
 import pint
+import warnings
+import xarray as xr
 
 from .gk_code import GKInput
 from .pyro import Pyro
-from .units import PyroQuantity as Quantity
 from .normalisation import ConventionNormalisation
 
 
@@ -109,6 +110,28 @@ class PyroScan:
 
         # Used to overwrite default pyro method of reading files
         self.runfile_dict = runfile_dict
+
+        # Recreate parameter_dict with units
+        self._dimensional_parameter_dict = {}
+        for param, value in self.parameter_dict.items():
+            # Get attribute name and keys where param is stored in Pyro
+            if hasattr(value, "units"):
+                self._dimensional_parameter_dict[param] = value
+            else:
+                (attr_name, keys_to_param) = self.parameter_map[param]
+                # Get attribute in Pyro storing the parameter
+                pyro_attr = getattr(pyro, attr_name)
+                units = getattr(
+                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
+                    "units",
+                    1,
+                )
+                if units != 1:
+                    warnings.warn(
+                        f"Adding units [{units}] to {param} as it has not been "
+                        "specified. To suppress this warning please add units"
+                    )
+                self._dimensional_parameter_dict[param] = value * units
 
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
@@ -295,17 +318,19 @@ class PyroScan:
         -------
         self.gk_output : xarray DataSet of data
         """
-        import xarray as xr
 
         # xarray DataSet to store data
-        dimensionless_parameter_dict = {
-            key: Quantity(value).m for key, value in self.parameter_dict.items()
-        }
+        dimensionless_parameter_dict = {}
+        coord_units = {}
+        for key, value in self._dimensional_parameter_dict.items():
+            if hasattr(value, "units"):
+                dimensionless_parameter_dict[key] = value.m
+                coord_units[key] = value.units
+            else:
+                dimensionless_parameter_dict[key] = value
+
         ds = xr.Dataset(dimensionless_parameter_dict)
 
-        coord_units = {
-            coord: Quantity(value).units for coord, value in self.parameter_dict.items()
-        }
         for coord, units in coord_units.items():
             ds[coord] = ds[coord].assign_attrs(units=units)
 
@@ -425,7 +450,8 @@ class PyroScan:
                 coords.append("mode")
 
             def units_reshape(array, shape):
-                return np.reshape(array, shape) * array[-1].data.units
+                reshape_array = [arr.data.m for arr in array]
+                return np.reshape(reshape_array, shape) * array[-1].data.units
 
             growth_rate = units_reshape(growth_rate, output_shape)
             mode_frequency = units_reshape(mode_frequency, output_shape)
@@ -478,37 +504,7 @@ class PyroScan:
 
                 ds["heat"] = (heat_coords, heat)
 
-        self.gk_output = ds
-
-    def to(self, norms: ConventionNormalisation):
-        """
-
-        Parameters
-        ----------
-        norms : ConventionNormalisation
-            Normalisation convention to convert to
-
-        Returns
-        -------
-        GKOutput with units from norms
-        """
-        for data_var in self.gk_output.data_vars:
-            self.gk_output[data_var].data = self.gk_output[data_var].data.to(norms)
-
-        # Coordinates with units not supported in xarray need to manually change
-        new_coords = {}
-        for coord in self.gk_output.coords:
-            if hasattr(self.gk_output[coord], "units"):
-                new_coord = (
-                    self.gk_output[coord].data * self.gk_output[coord].units
-                ).to(norms)
-                new_coords[coord] = (
-                    coord,
-                    new_coord.m,
-                    {"units": new_coord.units},
-                )
-
-        self.gk_output = self.gk_output.assign_coords(coords=new_coords)
+        self.gk_output = PyroScanGKOutput(ds)
 
     @property
     def gk_code(self):
@@ -618,3 +614,53 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, pint.Quantity):
             return obj.m
         return json.JSONEncoder.default(self, obj)
+
+
+class PyroScanGKOutput:
+    def __init__(self, dataset: xr.Dataset):
+        self._dataset = dataset
+
+    def __getattr__(self, name):
+        # Delegate attribute access to the underlying dataset
+        return getattr(self._dataset, name)
+
+    def __getitem__(self, key):
+        return self._dataset[key]
+
+    def __setitem__(self, key, value):
+        self._dataset[key] = value
+
+    def __repr__(self):
+        return repr(self._dataset)
+
+    def to(self, norms: ConventionNormalisation):
+        """
+
+        Parameters
+        ----------
+        norms : ConventionNormalisation
+            Normalisation convention to convert to
+
+        Returns
+        -------
+        GKOutput with units from norms
+        """
+        for data_var in self.data_vars:
+            self[data_var].data = self[data_var].data.to(norms)
+
+        # Coordinates with units not supported in xarray need to manually change
+        new_coords = {}
+        for coord in self.coords:
+            if hasattr(self[coord], "units"):
+                new_coord = (self[coord].data * self[coord].units).to(norms)
+                new_coords[coord] = (
+                    coord,
+                    new_coord.m,
+                    {"units": new_coord.units},
+                )
+
+        self._dataset = self.assign_coords(coords=new_coords)
+
+    def unwrap(self):
+        """Return the underlying xarray.Dataset."""
+        return self._dataset

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -111,28 +111,6 @@ class PyroScan:
         # Used to overwrite default pyro method of reading files
         self.runfile_dict = runfile_dict
 
-        # Recreate parameter_dict with units
-        self._dimensional_parameter_dict = {}
-        for param, value in self.parameter_dict.items():
-            # Get attribute name and keys where param is stored in Pyro
-            if hasattr(value, "units"):
-                self._dimensional_parameter_dict[param] = value
-            else:
-                (attr_name, keys_to_param) = self.parameter_map[param]
-                # Get attribute in Pyro storing the parameter
-                pyro_attr = getattr(pyro, attr_name)
-                units = getattr(
-                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
-                    "units",
-                    1,
-                )
-                if units != 1:
-                    warnings.warn(
-                        f"Adding units [{units}] to {param} as it has not been "
-                        "specified. To suppress this warning please add units"
-                    )
-                self._dimensional_parameter_dict[param] = value * units
-
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
         )
@@ -207,6 +185,12 @@ class PyroScan:
                         "units",
                         1,
                     )
+                    if units != 1:
+                        warnings.warn(
+                            f"Adding units [{units}] to {param} as it has not been "
+                            "specified. To suppress this warning please add units"
+                        )
+
                     dimensional_value = value * units
 
                 # Set the value given the Pyro attribute and location of parameter
@@ -322,12 +306,22 @@ class PyroScan:
         # xarray DataSet to store data
         dimensionless_parameter_dict = {}
         coord_units = {}
-        for key, value in self._dimensional_parameter_dict.items():
+        for param, value in self.parameter_dict.items():
+            # Get attribute name and keys where param is stored in Pyro
             if hasattr(value, "units"):
-                dimensionless_parameter_dict[key] = value.m
-                coord_units[key] = value.units
+                dimensionless_parameter_dict[param] = value.m
+                coord_units[param] = value.units
             else:
-                dimensionless_parameter_dict[key] = value
+                (attr_name, keys_to_param) = self.parameter_map[param]
+                # Get attribute in Pyro storing the parameter
+                pyro_attr = getattr(self.base_pyro, attr_name)
+                units = getattr(
+                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
+                    "units",
+                    None,
+                )
+                dimensionless_parameter_dict[param] = value
+                coord_units[param] = units
 
         ds = xr.Dataset(dimensionless_parameter_dict)
 

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -16,10 +16,31 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
     left = getattr(left_pyroscan, attr)
     right = getattr(right_pyroscan, attr)
 
-    if isinstance(left, (str, list, type(None), dict, Path)):
-        assert left == right
+    if attr == "parameter_dict":
+        assert left.keys() == right.keys()
+        for left_value, right_value in zip(left.values(), right.values()):
+            assert np.allclose(left_value, right_value)
+    elif attr == "pyroscan_json":
+        for json_key in left.keys():
+            if json_key == "parameter_dict":
+                assert left[json_key].keys() == right[json_key].keys()
+                for left_value, right_value in zip(
+                    left[json_key].values(), right[json_key].values()
+                ):
+                    assert np.allclose(left_value, right_value)
+            else:
+                assert json_key in right.keys()
+                if isinstance(left[json_key], (str, list, type(None), dict, Path)):
+                    assert np.all(left[json_key] == right[json_key])
+                else:
+                    assert np.allclose(
+                        left[json_key], right[json_key]
+                    ), f"{left} != {right}"
     else:
-        assert np.allclose(left, right), f"{left} != {right}"
+        if isinstance(left, (str, list, type(None), dict, Path)):
+            assert np.all(left == right)
+        else:
+            assert np.allclose(left, right), f"{left} != {right}"
 
 
 def test_compare_read_write_pyroscan(tmp_path):


### PR DESCRIPTION
Adds units and a `to` method to PyroScan output, addresses #445 

This will likely need changing when we update to the latest version to `pint` (requires another release so may be a while) 