### PR TITLE
Bugfix/pfile divide by zero

### DIFF
--- a/src/pyrokinetics/kinetics/pfile.py
+++ b/src/pyrokinetics/kinetics/pfile.py
@@ -59,7 +59,7 @@ def np_to_T(n, p):
     n is in m^{-3}, T is in eV, p is in Pascals.
     Returns temperature in eV.
     """
-    return np.divide(p, n).to("eV")
+    return np.divide(p, n, out=np.zeros_like(p), where=(n != 0)).to("eV")
 
 
 class KineticsReaderpFile(FileReader, file_type="pFile", reads=Kinetics):

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -13,6 +13,8 @@ import pint
 
 from .gk_code import GKInput
 from .pyro import Pyro
+from .units import PyroQuantity as Quantity
+from .normalisation import ConventionNormalisation
 
 
 class PyroScan:
@@ -296,7 +298,16 @@ class PyroScan:
         import xarray as xr
 
         # xarray DataSet to store data
-        ds = xr.Dataset(self.parameter_dict)
+        dimensionless_parameter_dict = {
+            key: Quantity(value).m for key, value in self.parameter_dict.items()
+        }
+        ds = xr.Dataset(dimensionless_parameter_dict)
+
+        coord_units = {
+            coord: Quantity(value).units for coord, value in self.parameter_dict.items()
+        }
+        for coord, units in coord_units.items():
+            ds[coord] = ds[coord].assign_attrs(units=units)
 
         # TODO Need to add property to GKCode checking if it is an eigensolver
         # or initial value run and then set nmodes accordingly
@@ -304,6 +315,7 @@ class PyroScan:
             nmode = self.base_pyro.gk_input.data.get("nmodes", 2)
             nmode_coords = {"nmode": list(range(1, 1 + nmode))}
             ds = ds.assign_coords(nmode_coords)
+            ds["nmode"] = ds["nmode"].assign_attrs(units="dimensionless")
         else:
             nmode = np.nan
 
@@ -412,13 +424,18 @@ class PyroScan:
                 output_shape.append(nmode)
                 coords.append("mode")
 
-            growth_rate = np.reshape(growth_rate, output_shape)
-            mode_frequency = np.reshape(mode_frequency, output_shape)
+            def units_reshape(array, shape):
+                return np.reshape(array, shape) * array[-1].data.units
+
+            growth_rate = units_reshape(growth_rate, output_shape)
+            mode_frequency = units_reshape(mode_frequency, output_shape)
             ds["growth_rate"] = (coords, growth_rate)
             ds["mode_frequency"] = (coords, mode_frequency)
 
             if growth_rate_tolerance:
-                growth_rate_tolerance = np.reshape(growth_rate_tolerance, output_shape)
+                growth_rate_tolerance = units_reshape(
+                    growth_rate_tolerance, output_shape
+                )
                 ds["growth_rate_tolerance"] = (
                     coords,
                     growth_rate_tolerance,
@@ -427,10 +444,14 @@ class PyroScan:
             # Add eigenfunctions
             eig_coords = eigenfunctions[-1].coords
             ds = ds.assign_coords(coords=eig_coords)
+            for coord in eig_coords:
+                if hasattr(eigenfunctions[-1][coord], "units"):
+                    units = eigenfunctions[-1][coord].units
+                    ds[coord] = ds[coord].assign_attrs(units=units)
 
             # Reshape eigenfunctions and generate new coordinates
             eigenfunction_shape = self.value_size + list(np.shape(eigenfunctions[-1]))
-            eigenfunctions = np.reshape(eigenfunctions, eigenfunction_shape)
+            eigenfunctions = units_reshape(eigenfunctions, eigenfunction_shape)
             eigenfunctions_coords = tuple(self.parameter_dict.keys()) + eig_coords.dims
 
             ds["eigenfunctions"] = (eigenfunctions_coords, eigenfunctions)
@@ -442,7 +463,7 @@ class PyroScan:
 
                 # Reshape particle and generate new coordinates
                 particle_shape = output_shape + list(np.shape(particle[-1]))
-                particle = np.reshape(particle, particle_shape)
+                particle = units_reshape(particle, particle_shape)
                 particle_coords = tuple(coords) + particle_coords.dims
 
                 ds["particle"] = (particle_coords, particle)
@@ -452,12 +473,42 @@ class PyroScan:
 
                 # Reshape heat and generate new coordinates
                 heat_shape = output_shape + list(np.shape(heat[-1]))
-                heat = np.reshape(heat, heat_shape)
+                heat = units_reshape(heat, heat_shape)
                 heat_coords = tuple(coords) + heat_coords.dims
 
                 ds["heat"] = (heat_coords, heat)
 
         self.gk_output = ds
+
+    def to(self, norms: ConventionNormalisation):
+        """
+
+        Parameters
+        ----------
+        norms : ConventionNormalisation
+            Normalisation convention to convert to
+
+        Returns
+        -------
+        GKOutput with units from norms
+        """
+        for data_var in self.gk_output.data_vars:
+            self.gk_output[data_var].data = self.gk_output[data_var].data.to(norms)
+
+        # Coordinates with units not supported in xarray need to manually change
+        new_coords = {}
+        for coord in self.gk_output.coords:
+            if hasattr(self.gk_output[coord], "units"):
+                new_coord = (
+                    self.gk_output[coord].data * self.gk_output[coord].units
+                ).to(norms)
+                new_coords[coord] = (
+                    coord,
+                    new_coord.m,
+                    {"units": new_coord.units},
+                )
+
+        self.gk_output = self.gk_output.assign_coords(coords=new_coords)
 
     @property
     def gk_code(self):

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -12,9 +12,9 @@ import numpy as np
 import pint
 
 from .gk_code import GKInput
+from .normalisation import ConventionNormalisation
 from .pyro import Pyro
 from .units import PyroQuantity as Quantity
-from .normalisation import ConventionNormalisation
 
 
 class PyroScan:

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -4,13 +4,13 @@ import copy
 import json
 import os
 import pathlib
+import warnings
 from contextlib import contextmanager
 from functools import reduce
 from itertools import product
 
 import numpy as np
 import pint
-import warnings
 import xarray as xr
 
 from .gk_code import GKInput

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -10,10 +10,11 @@ from itertools import product
 
 import numpy as np
 import pint
+import warnings
+import xarray as xr
 
 from .gk_code import GKInput
 from .pyro import Pyro
-from .units import PyroQuantity as Quantity
 from .normalisation import ConventionNormalisation
 
 
@@ -109,6 +110,28 @@ class PyroScan:
 
         # Used to overwrite default pyro method of reading files
         self.runfile_dict = runfile_dict
+
+        # Recreate parameter_dict with units
+        self._dimensional_parameter_dict = {}
+        for param, value in self.parameter_dict.items():
+            # Get attribute name and keys where param is stored in Pyro
+            if hasattr(value, "units"):
+                self._dimensional_parameter_dict[param] = value
+            else:
+                (attr_name, keys_to_param) = self.parameter_map[param]
+                # Get attribute in Pyro storing the parameter
+                pyro_attr = getattr(pyro, attr_name)
+                units = getattr(
+                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
+                    "units",
+                    1,
+                )
+                if units != 1:
+                    warnings.warn(
+                        f"Adding units [{units}] to {param} as it has not been "
+                        "specified. To suppress this warning please add units"
+                    )
+                self._dimensional_parameter_dict[param] = value * units
 
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
@@ -295,17 +318,19 @@ class PyroScan:
         -------
         self.gk_output : xarray DataSet of data
         """
-        import xarray as xr
 
         # xarray DataSet to store data
-        dimensionless_parameter_dict = {
-            key: Quantity(value).m for key, value in self.parameter_dict.items()
-        }
+        dimensionless_parameter_dict = {}
+        coord_units = {}
+        for key, value in self._dimensional_parameter_dict.items():
+            if hasattr(value, "units"):
+                dimensionless_parameter_dict[key] = value.m
+                coord_units[key] = value.units
+            else:
+                dimensionless_parameter_dict[key] = value
+
         ds = xr.Dataset(dimensionless_parameter_dict)
 
-        coord_units = {
-            coord: Quantity(value).units for coord, value in self.parameter_dict.items()
-        }
         for coord, units in coord_units.items():
             ds[coord] = ds[coord].assign_attrs(units=units)
 
@@ -425,7 +450,8 @@ class PyroScan:
                 coords.append("mode")
 
             def units_reshape(array, shape):
-                return np.reshape(array, shape) * array[-1].data.units
+                reshape_array = [arr.data.m for arr in array]
+                return np.reshape(reshape_array, shape) * array[-1].data.units
 
             growth_rate = units_reshape(growth_rate, output_shape)
             mode_frequency = units_reshape(mode_frequency, output_shape)
@@ -478,37 +504,7 @@ class PyroScan:
 
                 ds["heat"] = (heat_coords, heat)
 
-        self.gk_output = ds
-
-    def to(self, norms: ConventionNormalisation):
-        """
-
-        Parameters
-        ----------
-        norms : ConventionNormalisation
-            Normalisation convention to convert to
-
-        Returns
-        -------
-        GKOutput with units from norms
-        """
-        for data_var in self.gk_output.data_vars:
-            self.gk_output[data_var].data = self.gk_output[data_var].data.to(norms)
-
-        # Coordinates with units not supported in xarray need to manually change
-        new_coords = {}
-        for coord in self.gk_output.coords:
-            if hasattr(self.gk_output[coord], "units"):
-                new_coord = (
-                    self.gk_output[coord].data * self.gk_output[coord].units
-                ).to(norms)
-                new_coords[coord] = (
-                    coord,
-                    new_coord.m,
-                    {"units": new_coord.units},
-                )
-
-        self.gk_output = self.gk_output.assign_coords(coords=new_coords)
+        self.gk_output = PyroScanGKOutput(ds)
 
     @property
     def gk_code(self):
@@ -618,3 +614,53 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, pint.Quantity):
             return obj.m
         return json.JSONEncoder.default(self, obj)
+
+
+class PyroScanGKOutput:
+    def __init__(self, dataset: xr.Dataset):
+        self._dataset = dataset
+
+    def __getattr__(self, name):
+        # Delegate attribute access to the underlying dataset
+        return getattr(self._dataset, name)
+
+    def __getitem__(self, key):
+        return self._dataset[key]
+
+    def __setitem__(self, key, value):
+        self._dataset[key] = value
+
+    def __repr__(self):
+        return repr(self._dataset)
+
+    def to(self, norms: ConventionNormalisation):
+        """
+
+        Parameters
+        ----------
+        norms : ConventionNormalisation
+            Normalisation convention to convert to
+
+        Returns
+        -------
+        GKOutput with units from norms
+        """
+        for data_var in self.data_vars:
+            self[data_var].data = self[data_var].data.to(norms)
+
+        # Coordinates with units not supported in xarray need to manually change
+        new_coords = {}
+        for coord in self.coords:
+            if hasattr(self[coord], "units"):
+                new_coord = (self[coord].data * self[coord].units).to(norms)
+                new_coords[coord] = (
+                    coord,
+                    new_coord.m,
+                    {"units": new_coord.units},
+                )
+
+        self._dataset = self.assign_coords(coords=new_coords)
+
+    def unwrap(self):
+        """Return the underlying xarray.Dataset."""
+        return self._dataset

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -111,28 +111,6 @@ class PyroScan:
         # Used to overwrite default pyro method of reading files
         self.runfile_dict = runfile_dict
 
-        # Recreate parameter_dict with units
-        self._dimensional_parameter_dict = {}
-        for param, value in self.parameter_dict.items():
-            # Get attribute name and keys where param is stored in Pyro
-            if hasattr(value, "units"):
-                self._dimensional_parameter_dict[param] = value
-            else:
-                (attr_name, keys_to_param) = self.parameter_map[param]
-                # Get attribute in Pyro storing the parameter
-                pyro_attr = getattr(pyro, attr_name)
-                units = getattr(
-                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
-                    "units",
-                    1,
-                )
-                if units != 1:
-                    warnings.warn(
-                        f"Adding units [{units}] to {param} as it has not been "
-                        "specified. To suppress this warning please add units"
-                    )
-                self._dimensional_parameter_dict[param] = value * units
-
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
         )
@@ -207,6 +185,12 @@ class PyroScan:
                         "units",
                         1,
                     )
+                    if units != 1:
+                        warnings.warn(
+                            f"Adding units [{units}] to {param} as it has not been "
+                            "specified. To suppress this warning please add units"
+                        )
+
                     dimensional_value = value * units
 
                 # Set the value given the Pyro attribute and location of parameter
@@ -322,12 +306,22 @@ class PyroScan:
         # xarray DataSet to store data
         dimensionless_parameter_dict = {}
         coord_units = {}
-        for key, value in self._dimensional_parameter_dict.items():
+        for param, value in self.parameter_dict.items():
+            # Get attribute name and keys where param is stored in Pyro
             if hasattr(value, "units"):
-                dimensionless_parameter_dict[key] = value.m
-                coord_units[key] = value.units
+                dimensionless_parameter_dict[param] = value.m
+                coord_units[param] = value.units
             else:
-                dimensionless_parameter_dict[key] = value
+                (attr_name, keys_to_param) = self.parameter_map[param]
+                # Get attribute in Pyro storing the parameter
+                pyro_attr = getattr(self.base_pyro, attr_name)
+                units = getattr(
+                    get_from_dict(pyro_attr, keys_to_param[:-1])[keys_to_param[-1]],
+                    "units",
+                    None,
+                )
+                dimensionless_parameter_dict[param] = value
+                coord_units[param] = units
 
         ds = xr.Dataset(dimensionless_parameter_dict)
 


### PR DESCRIPTION
Minor change to allow for proper handling of cases where the density of a species is zero due to the finite precision of the pfile data (was leading to the temperature being all `nan` even if the density was only zero at, e.g., the edge). 