### PR TITLE
Added writing of adiabatic electron flags in .set method

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -859,10 +859,10 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             )
 
             # Set adiabatic flags
-            self.data['AE_FLAG'] = 1
-            self.data['DENS_AE'] = ne
-            self.data['TEMP_AE'] = te
-            self.data['MASS_AE'] = me
+            self.data["AE_FLAG"] = 1
+            self.data["DENS_AE"] = ne
+            self.data["TEMP_AE"] = te
+            self.data["MASS_AE"] = me
 
         self.data["MACH"] = local_species[first_species].omega0 * self.data["RMAJ"]
         self.data["GAMMA_P"] = (

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -858,6 +858,12 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 * (ne / te**1.5 / me**0.5)
             )
 
+            # Set adiabatic flags
+            self.data['AE_FLAG'] = 1
+            self.data['DENS_AE'] = ne
+            self.data['TEMP_AE'] = te
+            self.data['MASS_AE'] = me
+
         self.data["MACH"] = local_species[first_species].omega0 * self.data["RMAJ"]
         self.data["GAMMA_P"] = (
             -local_species[first_species].domega_drho * self.data["RMAJ"]

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1292,7 +1292,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             rho_star = raw_data["equilibrium"][35]
         elif len(raw_data["equilibrium"]) == 54 + 9 * nspecies:
             rho_star = raw_data["equilibrium"][35]
-        elif len(raw_data["equilibrium"]) == 55 + 10 * nspecies:
+        elif len(raw_data["equilibrium"]) == 57 + 9 * nspecies:
             rho_star = raw_data["equilibrium"][35]
         else:
             rho_star = raw_data["equilibrium"][23]

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -177,17 +177,17 @@ class LocalSpecies(CleverDict):
         error_gradient = error_gradient.magnitude
 
         if abs(error) > tol or abs(error_gradient) > tol:
-                if "electron" not in self.names and np.isclose(error, 1.0):
-                    warnings.warn(
-                        f"""No electron species found but remaining local species satisfy quasineutrality"""
-                    )
-                    return True
-                else:
-                    warnings.warn(
-                        f"""Currently local species violates quasi-neutrality in the
+            if "electron" not in self.names and np.isclose(error, 1.0):
+                warnings.warn(
+                    f"""No electron species found but remaining local species satisfy quasineutrality"""
+                )
+                return True
+            else:
+                warnings.warn(
+                    f"""Currently local species violates quasi-neutrality in the
                             density by {error} and density gradient by {error_gradient}"""
-                    )
-                    return False
+                )
+                return False
 
         return True
 

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -177,11 +177,18 @@ class LocalSpecies(CleverDict):
         error_gradient = error_gradient.magnitude
 
         if abs(error) > tol or abs(error_gradient) > tol:
-            warnings.warn(
-                f"""Currently local species violates quasi-neutrality in the
-                    density by {error} and density gradient by {error_gradient}"""
-            )
-            return False
+                if "electron" not in self.names and np.isclose(error, 1.0):
+                    warnings.warn(
+                        f"""No electron species found but remaining local species satisfy quasineutrality"""
+                    )
+                    return True
+                else:
+                    warnings.warn(
+                        f"""Currently local species violates quasi-neutrality in the
+                            density by {error} and density gradient by {error_gradient}"""
+                    )
+                    return False
+
         return True
 
     def enforce_quasineutrality(self, modify_species: str) -> None:


### PR DESCRIPTION
If one was converting input files from other GK codes to `CGYRO`, the `CGYRO`-specific adiabatic electron flags required by `PYRO` were not being set, so I have added these. These changes work on a branch before the implementation of `check_quasineutrality`, which currently causes all adiabatic electron runs/conversions to fail @bpatel2107 . 