### PR TITLE
Correct phase for moments in cgyro.py

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1521,10 +1521,11 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             moment_data = raw_moment[: np.prod(shape)].reshape(shape, order="F")
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
-            mode_sign = np.sign(
-                np.sign(gk_input.data.get("S", 1.0))
-                * gk_input.data.get("BTCCW", -1)
-                * gk_input.data.get("IPCCW", -1)
+
+            bt_ccw = gk_input.data.get("BTCCW", -1)
+            ip_ccw = gk_input.data.get("IPCCW", -1)
+            mode_sign = int(
+                np.sign(np.sign(gk_input.data.get("S", 1.0)) * bt_ccw * ip_ccw)
             )
 
             moment_data = (moment_data[0] + 1j * moment_data[1]) / coords["rho_star"]
@@ -1539,16 +1540,17 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 for i_radial in range(nradial):
                     nx = -nradial // 2 + (i_radial - 1)
                     moment_data[i_radial, ...] *= np.exp(
-                        -mode_sign * 2j * pi * mode_sign * (nx + nx0) * q
+                        -2j * pi * (nx + nx0) * np.abs(q)
                     )
-
                 if mode_sign == -1:
                     moment_data = moment_data[:, ::-1, ...]
+                    moments = moment_data.reshape([ntheta, nkx, nspec, nky, full_ntime])
+                    moments = moments[::-1, :, :, :]
+                else:
+                    moments = moment_data.reshape([ntheta, nkx, nspec, nky, full_ntime])
 
-                if gk_input.data.get("IPCCW", -1.0) == -1:
-                    moment_data = np.conj(moment_data)
-
-                moments = moment_data.reshape([ntheta, nkx, nspec, nky, full_ntime])
+            if ip_ccw == -1:
+                moments = np.conj(moments)
 
             moments = moments[:, :, :, :, ::downsize]
             results[moment_name] = moments


### PR DESCRIPTION
Fixes #469 and related to #430

When doing the ballooning transform we need to correctly stitch together the different `kx` in CGYRO and the phase we add on depends on the sign of `B` `Ip` `q` etc. This was fixed for the fields in a previous PR but not for the moments.

This also impacts nonlinear sims as the sign of the phase depends on those signs too.

