### PR TITLE
Removed setting of FIELD_PRINT_FLAG and MOMENT_PRINT_FLAG in cgyro.py

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -931,9 +931,6 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         self.data["N_ENERGY"] = numerics.nenergy
         self.data["N_XI"] = numerics.npitch
 
-        self.data["FIELD_PRINT_FLAG"] = 1
-        self.data["MOMENT_PRINT_FLAG"] = 1
-
         if not local_norm:
             return
 


### PR DESCRIPTION
The previous behaviour was to set both `MOMENT_PRINT_FLAG` and `FIELD_PRINT_FLAG` in `cgyro.py`, which would overwrite any values that were specified by the user. 

Given that the `'input.cgyro` template has `MOMENT_PRINT_FLAG = 1` and `FIELD_PRINT_FLAG = 1`, the only case where this may cause `pyro` to give unexpected behaviour is if the user supplies an input template that does not specify these flags (the `CGYRO` default is `0`). 