### PR TITLE
Multiple bugfixes addressing issues #472, #473, and #475

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -156,7 +156,9 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         3: "Fourier",
     }
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads CGYRO input file into a dictionary
         """

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -156,27 +156,27 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
         3: "Fourier",
     }
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads CGYRO input file into a dictionary
         """
         with open(filename) as f:
-            self.data = self.parse_cgyro(f)
-        return self.data
+            data_dict = self.parse_cgyro(f)
+        return super().read_dict(data_dict, detect_norm=detect_norm)
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads CGYRO input file given as string
         """
-        self.data = self.parse_cgyro(input_string.split("\n"))
-        return self.data
+        data_dict = self.parse_cgyro(input_string.split("\n"))
+        return super().read_dict(data_dict, detect_norm=detect_norm)
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
-        Reads CGYRO input file given as dict
+        Reads GENE input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
     @staticmethod
     def parse_cgyro(lines):
@@ -1198,7 +1198,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         input_str = raw_data["input"]
         gk_input = GKInputCGYRO()
         gk_input.read_str(input_str)
-        gk_input._detect_normalisation()
 
         return raw_data, gk_input, input_str
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -335,18 +335,11 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         major_R = self.data["geometry"].get("major_r", 1.0)
         major_Z = self.data["geometry"].get("major_z", 0.0)
 
-        if minor_r == 1.0:
-            self.norm_convention = "pyrokinetics"
-        elif major_R == 1.0:
-            self.norm_convention = "gene"
-        else:
-            raise ValueError(
-                f"Pyrokinetics can only handle GENE simulations with either minor_r=1.0 (got {minor_r}) or major_R = 1.0 (got {major_R})"
-            )
-
         local_geometry_data["Rmaj"] = major_R
-        local_geometry_data["aspect_ratio"] = major_R / minor_r
         local_geometry_data["Z0"] = major_Z
+
+        if not minor_r == 0.0:
+            local_geometry_data["aspect_ratio"] = major_R / minor_r
 
         trpeps = self.get_trpeps()
 
@@ -1490,16 +1483,17 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
 
         # Determine normalisation used
         nml = gk_input.data
-        if nml["geometry"].get("minor_r", 0.0) == 1.0:
-            convention = norm.pyrokinetics
-            norm.default_convention = output_convention.lower()
-        elif gk_input.data["geometry"].get("major_R", 1.0) == 1.0:
+        if gk_input.data["geometry"].get("major_R", 1.0) == 1.0:
             convention = norm.gene
             norm.default_convention = "gene"
+        elif nml["geometry"].get("minor_r", 0.0) == 1.0:
+            convention = norm.pyrokinetics
+            norm.default_convention = output_convention.lower()
         else:
             raise NotImplementedError(
                 "Pyro does not handle GENE cases where neither major_R and minor_r are 1.0"
             )
+
         # Assign units and return GKOutput
         convention = getattr(norm, gk_input.norm_convention)
         norm.default_convention = output_convention.lower()

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -188,7 +188,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         "inverse_ln": "omn",
     }
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads GENE input file into a dictionary
         Uses default read, which assumes input is a Fortran90 namelist

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -188,7 +188,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         "inverse_ln": "omn",
     }
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GENE input file into a dictionary
         Uses default read, which assumes input is a Fortran90 namelist
@@ -211,21 +211,21 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         if read_str:
             return self.read_str(filedata)
         else:
-            return super().read_from_file(filename)
+            return super().read_from_file(filename, detect_norm=detect_norm)
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GENE input file given as string
         Uses default read_str, which assumes input is a Fortran90 namelist
         """
-        return super().read_str(input_string)
+        return super().read_str(input_string, detect_norm=detect_norm)
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GENE input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
     def verify_file_type(self, filename: PathLike):
         """
@@ -1481,23 +1481,6 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(filename)
 
-        # Determine normalisation used
-        nml = gk_input.data
-        if gk_input.data["geometry"].get("major_R", 1.0) == 1.0:
-            convention = norm.gene
-            norm.default_convention = "gene"
-        elif nml["geometry"].get("minor_r", 0.0) == 1.0:
-            convention = norm.pyrokinetics
-            norm.default_convention = output_convention.lower()
-        else:
-            raise NotImplementedError(
-                "Pyro does not handle GENE cases where neither major_R and minor_r are 1.0"
-            )
-
-        # Assign units and return GKOutput
-        convention = getattr(norm, gk_input.norm_convention)
-        norm.default_convention = output_convention.lower()
-
         coords = self._get_coords(raw_data, gk_input, downsize)
         fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
         fluxes = self._get_fluxes(raw_data, gk_input, coords) if load_fluxes else None
@@ -1696,7 +1679,6 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         gk_input = GKInputGENE()
         gk_input.read_str(input_str)
         gk_input.original_filename = filename
-        gk_input._detect_normalisation()
 
         species_names = [species["name"] for species in gk_input.data["species"]]
         geometry_type = gk_input.data["geometry"]["magn_geometry"]

--- a/src/pyrokinetics/gk_code/gk_input.py
+++ b/src/pyrokinetics/gk_code/gk_input.py
@@ -57,7 +57,9 @@ class GKInput(AbstractFileReader, ReadableFromFile):
             self._detect_normalisation()
 
     @abstractmethod
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads in GK input file to store as internal dictionary.
         Sets self.data and also returns a dict

--- a/src/pyrokinetics/gk_code/gk_input.py
+++ b/src/pyrokinetics/gk_code/gk_input.py
@@ -57,7 +57,7 @@ class GKInput(AbstractFileReader, ReadableFromFile):
             self._detect_normalisation()
 
     @abstractmethod
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads in GK input file to store as internal dictionary.
         Sets self.data and also returns a dict
@@ -65,10 +65,12 @@ class GKInput(AbstractFileReader, ReadableFromFile):
         Default version assumes a Fortran90 namelist
         """
         self.data = f90nml.read(filename)
+        if detect_norm:
+            self._detect_normalisation()
         return self.data.todict()
 
     @abstractmethod
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads in GK input file as a string, stores as internal dictionary.
         Sets self.data and also returns a dict
@@ -76,10 +78,12 @@ class GKInput(AbstractFileReader, ReadableFromFile):
         Default version assumes a Fortran90 namelist
         """
         self.data = f90nml.reads(input_string)
+        if detect_norm:
+            self._detect_normalisation()
         return self.data.todict()
 
     @abstractmethod
-    def read_dict(self, gk_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, gk_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads in dictionary equivalent of a GK input file and stores as internal dictionary.
         Sets self.data and also returns a dict
@@ -87,6 +91,8 @@ class GKInput(AbstractFileReader, ReadableFromFile):
         Default version assumes a dict
         """
         self.data = gk_dict
+        if detect_norm:
+            self._detect_normalisation()
         return self.data
 
     @classmethod
@@ -131,7 +137,7 @@ class GKInput(AbstractFileReader, ReadableFromFile):
         """
         # Create new class to read, prevents overwriting self.data
         try:
-            data = cls().read_from_file(filename)
+            data = cls().read_from_file(filename, detect_norm=False)
         except Exception as exc:
             raise RuntimeError(
                 f"Couldn't read {cls.file_type} file. Is the format correct?"
@@ -426,5 +432,4 @@ def read_gk_input(path: PathLike, file_type: Optional[str] = None, **kwargs) -> 
     """
     gk_input = GKInput._factory(file_type if file_type is not None else path)
     gk_input.read_from_file(path, **kwargs)
-    gk_input._detect_normalisation()
     return gk_input

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -666,12 +666,28 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
                 "GKOutput does not have 'growth rate'. Only results associated with "
                 "linear gyrokinetics runs will have this."
             )
+
+        # Check accuracy of frequency, starting at time_range*final_time
+        time = self["time"]
+        final_time = time.isel(time=-1)
+
+        mode_frequency = self["mode_frequency"]
+        mode_frequency = mode_frequency.where(
+            mode_frequency["time"] > time_range * final_time, drop=True
+        )
+
+        max_freq = np.pi / np.mean(np.diff(time))
+
+        if np.any(np.abs(mode_frequency.data.m) / max_freq > 0.5):
+            warnings.warn(
+                "Mode frequency may not be accurate due to low temporal resolution"
+            )
+
+        # Calculate growth rate tolerance
         growth_rate = self["growth_rate"]
         final_growth_rate = growth_rate.isel(time=-1)
 
         difference = ((growth_rate - final_growth_rate) / final_growth_rate) ** 2
-
-        final_time = self["time"].isel(time=-1)
 
         # Average over the end of the simulation, starting at time_range*final_time
         difference = difference.where(
@@ -687,7 +703,9 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
 
     @staticmethod
     def _eigenvalues_from_fields(
-        fields: Fields, theta: ArrayLike, time: ArrayLike
+        fields: Fields,
+        theta: ArrayLike,
+        time: ArrayLike,
     ) -> Eigenvalues:
         """
         Call during __init__ after converting to pyro normalisations

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -103,26 +103,26 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         "domega_drho": "uprim",
     }
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GKW input file into a dictionary
         Uses default read, which assumes input is a Fortran90 namelist
         """
-        return super().read_from_file(filename)
+        return super().read_from_file(filename, detect_norm=detect_norm)
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GKW input file given as string
         Uses default read_str, which assumes input_string is a Fortran90 namelist
         """
-        return super().read_str(input_string)
+        return super().read_str(input_string, detect_norm=detect_norm)
 
-    def read_dict(self, input_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def read_dict(self, input_dict: Dict[str, Any], detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GKW input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
     def verify_file_type(self, filename: PathLike):
         """
@@ -1054,7 +1054,6 @@ class GKOutputReaderGKW(FileReader, file_type="GKW", reads=GKOutput):
         # Read as GKInputGKW and into plain string
         gk_input = GKInputGKW()
         gk_input.read_str(input_str)
-        gk_input._detect_normalisation()
 
         cls._get_gkw_field_files(dirname, raw_data)
         cls._get_gkw_field_spc_files(dirname, raw_data)

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -103,7 +103,9 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         "domega_drho": "uprim",
     }
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads GKW input file into a dictionary
         Uses default read, which assumes input is a Fortran90 namelist
@@ -117,7 +119,9 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         """
         return super().read_str(input_string, detect_norm=detect_norm)
 
-    def read_dict(self, input_dict: Dict[str, Any], detect_norm: bool = True) -> Dict[str, Any]:
+    def read_dict(
+        self, input_dict: Dict[str, Any], detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads GKW input file given as dict
         Uses default read_dict, which assumes input is a dict

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -104,7 +104,9 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         "inverse_ln": "fprim",
     }
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads GS2 input file into a dictionary
         """

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -104,35 +104,35 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         "inverse_ln": "fprim",
     }
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GS2 input file into a dictionary
         """
-        result = super().read_from_file(filename)
+        result = super().read_from_file(filename, detect_norm=detect_norm)
         if self.is_nonlinear() and self.data["knobs"].get("wstar_units", False):
             raise RuntimeError(
                 "GKInputGS2: Cannot be nonlinear and set knobs.wstar_units"
             )
         return result
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GS2 input file given as string
         Uses default read_str, which assumes input_string is a Fortran90 namelist
         """
-        result = super().read_str(input_string)
+        result = super().read_str(input_string, detect_norm=detect_norm)
         if self.is_nonlinear() and self.data["knobs"].get("wstar_units", False):
             raise RuntimeError(
                 "GKInputGS2: Cannot be nonlinear and set knobs.wstar_units"
             )
         return result
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GS2 input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
     def verify_file_type(self, filename: PathLike):
         """
@@ -1211,7 +1211,6 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
                 )
         gk_input = GKInputGS2()
         gk_input.read_str(input_str)
-        gk_input._detect_normalisation()
 
         return raw_data, gk_input, input_str
 

--- a/src/pyrokinetics/gk_code/gx.py
+++ b/src/pyrokinetics/gk_code/gx.py
@@ -126,7 +126,9 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
 
         return three_smooth_numbers
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads GX input file into a dictionary
         """

--- a/src/pyrokinetics/gk_code/gx.py
+++ b/src/pyrokinetics/gk_code/gx.py
@@ -126,16 +126,17 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
 
         return three_smooth_numbers
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GX input file into a dictionary
         """
         with open(filename, "r") as f:
             self.data = toml.load(f)
-
+        if detect_norm:
+            self._detect_normalisation()
         return self.data
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GX input file given as string
         Uses default read_str, which assumes input_string is a Fortran90 namelist
@@ -149,10 +150,11 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
 
         cleaned_toml = "\n".join(cleaned_lines)
         self.data = toml.loads(cleaned_toml)
-
+        if detect_norm:
+            self._detect_normalisation()
         return self.data
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads GX input file given as dict
         Uses default read_dict, which assumes input is a dict
@@ -164,6 +166,8 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
             except ValueError:
                 continue
         self.data = input_dict
+        if detect_norm:
+            self._detect_normalisation()
         return self.data
 
     def verify_file_type(self, filename: PathLike):
@@ -1059,7 +1063,6 @@ class GKOutputReaderGX(FileReader, file_type="GX", reads=GKOutput):
 
         gk_input = GKInputGX()
         gk_input.read_str(input_str)
-        gk_input._detect_normalisation()
 
         return {"out": raw_data_out, "big": raw_data_big}, gk_input, input_str
 

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -85,7 +85,9 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             self._parameters_params = "parameters_physics"
             self._parameters_physics = "parameters_physics"
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads STELLA input file into a dictionary
         """

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -85,11 +85,11 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             self._parameters_params = "parameters_physics"
             self._parameters_physics = "parameters_physics"
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads STELLA input file into a dictionary
         """
-        result = super().read_from_file(filename)
+        result = super().read_from_file(filename, detect_norm=detect_norm)
         if {"knobs", "parameters", "physics_flags"}.intersection(result.keys()):
             warnings.warn(
                 "The keys 'knobs'/'parameters'/'physics_flags' were found in the input file suggesting this is a "
@@ -99,12 +99,12 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
 
         return result
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads STELLA input file given as string
         Uses default read_str, which assumes input_string is a Fortran90 namelist
         """
-        result = super().read_str(input_string)
+        result = super().read_str(input_string, detect_norm=detect_norm)
         if {"knobs", "parameters", "physics_flags"}.intersection(result.keys()):
             warnings.warn(
                 "The keys 'knobs'/'parameters'/'physics_flags' were found in the input file suggesting this is a "
@@ -114,12 +114,12 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
 
         return result
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads STELLA input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
     def verify_file_type(self, filename: PathLike):
         """

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from ast import literal_eval
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -148,7 +148,9 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             "inverse_ln": f"rlns_{iSp}",
         }
 
-    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
+    def read_from_file(
+        self, filename: PathLike, detect_norm: bool = True
+    ) -> Dict[str, Any]:
         """
         Reads TGLF input file into a dictionary
         """

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from ast import literal_eval
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -147,35 +148,58 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
             "inverse_ln": f"rlns_{iSp}",
         }
 
-    def read_from_file(self, filename: PathLike) -> Dict[str, Any]:
+    def read_from_file(self, filename: PathLike, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads TGLF input file into a dictionary
         """
         with open(filename) as f:
-            contents = f.read()
+            data_dict = self.parse_tglf(f)
+        return super().read_dict(data_dict, detect_norm=detect_norm)
 
-        return self.read_str(contents)
+    def read_str(self, input_string: str, detect_norm: bool = True) -> Dict[str, Any]:
+        """
+        Reads TGLF input file given as string
+        """
+        data_dict = self.parse_tglf(input_string.split("\n"))
+        return super().read_dict(data_dict, detect_norm=detect_norm)
 
-    def read_dict(self, input_dict: dict) -> Dict[str, Any]:
+    def read_dict(self, input_dict: dict, detect_norm: bool = True) -> Dict[str, Any]:
         """
         Reads TGLF input file given as dict
         Uses default read_dict, which assumes input is a dict
         """
-        return super().read_dict(input_dict)
+        return super().read_dict(input_dict, detect_norm=detect_norm)
 
-    def read_str(self, input_string: str) -> Dict[str, Any]:
+    @staticmethod
+    def parse_tglf(lines):
         """
-        Reads TGLF input file given as string
+        Given lines of a tglf file or a string split by '/n', return a dict of
+        TGLF input data
         """
-        # TGLF input files are _almost_ Fortran namelists, so if we
-        # change the comments to use '!' instead of '#', and wrap it
-        # in a namelist syntax, we can just use the base `read_str`
-        as_namelist = f"&nml\n{input_string.replace('#', '!')}\n/"
+        results = {}
+        for line in lines:
+            # Get line before comments, remove trailing whitespace
+            line = line.split("#")[0].strip()
+            # Skip empty lines (this will also skip comment lines)
+            if not line:
+                continue
 
-        # We need to strip off our fake namelist wrapper when we store
-        # it internally
-        self.data = super().read_str(as_namelist)["nml"]
-        return self.data
+            # Splits by =, remove whitespace, store as (key,value) pair
+            key, value = (token.strip() for token in line.split("="))
+            key = key.lower()
+
+            if value == "T":
+                value = True
+            elif value == "F":
+                value = False
+
+            # Use literal_eval to convert value to int/float/list etc
+            # If it fails, assume value should be a string
+            try:
+                results[key] = literal_eval(value)
+            except Exception:
+                results[key] = value
+        return results
 
     def verify_file_type(self, filename: PathLike):
         """
@@ -909,7 +933,6 @@ class GKOutputReaderTGLF(FileReader, file_type="TGLF", reads=GKOutput):
         input_str = raw_data["input"]
         gk_input = GKInputTGLF()
         gk_input.read_str(input_str)
-        gk_input._detect_normalisation()
 
         return raw_data, gk_input, input_str
 

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -565,7 +565,7 @@ def get_basic_gk_input(
     else:
         raise ValueError(f"Code {code} not yet supported in testing")
 
-    gk_input.read_dict(dict)
+    gk_input.read_dict(dict, detect_norm=False)
     return gk_input
 
 


### PR DESCRIPTION
Have addressed multiple outstanding issues, as follows:

- #472 : PYRO was checking for `minor_r` (in order to calculate `aspect_ratio`) in more places than it needed to, and so would fail if `minor_r` was not specified consistently. This is now fixed
- #473 : Added checking of `mode_frequency` when calculating the growth rate tolerance; it will now warn if there is poor frequency data over the last portion of the simulation time.
- #475 : This was due to some legacy code resetting the `self.norm_convention` inside `get_local_geometry`, which has now been removed. 

I think this means that PYRO should once-again interact well with the GENE edge cases reported in the bug reports.