### PR TITLE
Use OMEGDATA before OMEGA in TRANSP rotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "xmltodict ~= 0.13.0",
     "typing-extensions >= 4.6.0",
     "simplejson >= 3.17.6",
-    "jetto-tools",
+    "jetto-tools <= 2.0.5",
     "setuptools; python_version >= '3.12'", # jetto-tools depends on pkg_resources, removed in 3.12
     "periodictable",
     "toml",

--- a/src/pyrokinetics/kinetics/transp.py
+++ b/src/pyrokinetics/kinetics/transp.py
@@ -60,6 +60,10 @@ class KineticsReaderTRANSP(FileReader, file_type="TRANSP", reads=Kinetics):
                 omega_data = (
                     kinetics_data["OMEG_VTR"][time_index, :].data * units.second**-1
                 )
+            elif "OMEGDATA" in kinetics_data.variables.keys():
+                omega_data = (
+                    kinetics_data["OMEGDATA"][time_index, :].data * units.second**-1
+                )
             elif "OMEGA" in kinetics_data.variables.keys():
                 omega_data = (
                     kinetics_data["OMEGA"][time_index, :].data * units.second**-1


### PR DESCRIPTION
TRANSP has quite a few different "rotations" in the output and the choice of which one to use is not clear to me

The data I personally recognise is `OMEGDATA` which is the data fitted to the rotation data. I have no idea how `OMEGA` is calculated but it is different to the expt. data.

```
        float OMEGA(TIME3, X) ;                                                                                                                           
                OMEGA:units = "RAD/SEC                         " ;                                                                                        
                OMEGA:long_name = "TOROIDAL ANGULAR VELOCITY                                       " ;                                                    
        float OMEGA_NC(TIME3, X) ;                                                                                                                        
                OMEGA_NC:units = "RAD/SEC                         " ;                                                                                     
                OMEGA_NC:long_name = "N.C. TOROIDAL ANGULAR VELOCITY                                  " ;                                                 
        float OMEGDATA(TIME3, X) ;                                                                                                                        
                OMEGDATA:units = "RAD/SEC                         " ;                                                                                     
                OMEGDATA:long_name = "Toroidal Ang.Velocity Data                                      " ; 
```

Given that they are noticeably different I am not sure which is best but `OMEGA` has an odd boundary condition

Here are two examples of a MAST-U shot at different times:

<img width="577" height="433" alt="image" src="https://github.com/user-attachments/assets/e52917cf-7feb-4d28-983a-4a2927667c32" />

<img width="581" height="429" alt="image" src="https://github.com/user-attachments/assets/a5c9f0d9-0273-4d1d-a832-32d57900d0e1" />

I am going to preferentially choose `OMEGDATA` over `OMEGA` because of this. This will have a very large impact on the ExB shearing rate when loading TRANSP data which will likely affect any NL runs done with this.

Any TRANSP experts who would like to weigh in please do.