### PR TITLE
Use correct rho when setting domega_drho from GENE

### DIFF
--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -1281,6 +1281,12 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         if code_normalisation == "pyrokinetics":
             self.data["geometry"]["minor_r"] = 1.0
+        elif code_normalisation == "gene":
+            if local_geometry.a_minor is not None:
+                self.data["geometry"]["minor_r"] = local_geometry.a_minor
+            else:
+                if "minor_r" in self.data["geometry"].keys():
+                    self.data["geometry"].pop("minor_r")
 
         self.data["geometry"]["major_r"] = local_geometry.Rmaj
         self.data["geometry"]["major_z"] = local_geometry.Z0

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -758,13 +758,12 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             "external_contr", {"exbrate": 0.0, "omega0_tor": 0.0, "pfsrate": 0.0}
         )
 
+        if external_contr["pfsrate"] == -1111:
+            external_contr["pfsrate"] = external_contr["exbrate"]
+
         trpeps = self.get_trpeps()
 
-        rho = (
-            trpeps
-            * self.data["geometry"].get("major_r", 1.0)
-            / self.data["geometry"].get("minor_r", 1.0)
-        )
+        rho = trpeps * self.data["geometry"].get("major_r", 1.0)
         if rho == 0.0:
             domega_drho = 0.0
         else:
@@ -1205,9 +1204,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
         # TODO Find way to get norm_convention = pyrokinetics if we find minor_radius as lref
         if code_normalisation is None:
-            if self.data["geometry"]["minor_r"] == 1.0:
+            if np.isclose(self.data["geometry"]["minor_r"], 1.0):
                 code_normalisation = "pyrokinetics"
-            elif self.data["geometry"]["major_R"] == 1.0:
+            elif np.isclose(self.data["geometry"]["major_R"], 1.0):
                 code_normalisation = "gene"
 
         convention = getattr(local_norm, code_normalisation)
@@ -1341,7 +1340,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                     "omega0_tor": local_species.electron.omega0,
                     "pfsrate": -local_species.electron.domega_drho
                     * local_geometry.rho
-                    / self.data["geometry"]["q0"],
+                    / local_geometry.q,
                 }
             )
         else:
@@ -1349,7 +1348,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             self.data["external_contr"]["pfsrate"] = (
                 -local_species.electron.domega_drho
                 * local_geometry.rho
-                / self.data["geometry"]["q0"]
+                / local_geometry.q
             )
 
         self.data["general"]["zeff"] = local_species.zeff

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -515,3 +515,73 @@ def test_compare_roundtrip_mxh(setup_roundtrip_mxh, gk_code_a, gk_code_b):
             code_b.local_geometry[key],
             pyro.norms,
         )
+
+
+@pytest.fixture(scope="module")
+def setup_roundtrip_pvg(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("roundtrip_pvg")
+    eq_file = template_dir / "test.geqdsk"
+    kinetics_file = template_dir / "pfile.txt"
+    pyro = Pyro(eq_file=eq_file, kinetics_file=kinetics_file)
+    pyro.load_local(psi_n=0.5)
+
+    pyro.gk_code = "CGYRO"
+    pyro.write_gk_file(tmp_path / "test_pvg.cgyro")
+    pyro.write_gk_file(
+        tmp_path / "test_pvg.gene", gk_code="GENE", code_normalisation="gene"
+    )
+
+    cgyro = Pyro(gk_file=tmp_path / "test_pvg.cgyro", gk_code="CGYRO")
+    gene = Pyro(gk_file=tmp_path / "test_pvg.gene", gk_code="GENE")
+
+    return {
+        "pyro": pyro,
+        "cgyro": cgyro,
+        "gene": gene,
+    }
+
+
+@pytest.mark.parametrize(
+    "gk_code_a, gk_code_b",
+    [
+        ["gene", "cgyro"],
+        ["cgyro", "gene"],
+    ],
+)
+def test_compare_roundtrip_pvg(setup_roundtrip_pvg, gk_code_a, gk_code_b):
+    pyro = setup_roundtrip_pvg["pyro"]
+    code_a = setup_roundtrip_pvg[gk_code_a]
+    code_b = setup_roundtrip_pvg[gk_code_b]
+
+    assert np.isclose(pyro.numerics.gamma_exb.m, -0.08743732140255926, atol=1e-4)
+    assert np.isclose(
+        pyro.local_species.electron.domega_drho.m, 0.5490340792538756, atol=1e-4
+    )
+
+    assert_close_or_equal(
+        f"{code_a.gk_code} gamma_exb",
+        pyro.numerics.gamma_exb,
+        code_a.numerics.gamma_exb,
+        pyro.norms,
+    )
+
+    assert_close_or_equal(
+        f"{code_a.gk_code} gamma_exb",
+        code_a.numerics.gamma_exb,
+        code_b.numerics.gamma_exb,
+        pyro.norms,
+    )
+
+    assert_close_or_equal(
+        f"{code_a.gk_code} pvg",
+        pyro.local_species.electron.domega_drho,
+        code_b.local_species.electron.domega_drho,
+        pyro.norms,
+    )
+
+    assert_close_or_equal(
+        f"{code_a.gk_code} pvg",
+        code_a.local_species.electron.domega_drho,
+        code_b.local_species.electron.domega_drho,
+        pyro.norms,
+    )


### PR DESCRIPTION
When loading `local_species.domega_drho` (used to set PVG term) we were using the wrong definition of `rho= r / Lref`. Originally we had

`rho = trpeps * major_R / minor_r`
where 
`trpeps = r / R`
`major_R = R/Lref`
`minor_r = a/ Lref`

We should have had

`rho = trpeps * major_R`

So this would only become an issue when `a != Lref` (using GENE's default convention). This would mean that the PVG term when loading in a GENE input file with `minor_r !=1` would be incorrect, which doesn't get covered by the integrated testing. We could add this in?
