### PR TITLE
Add function to set consistent beta_prime and a test

### DIFF
--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1115,6 +1115,37 @@ class Pyro:
         # Switch back to original context
         self._switch_gk_context(prev_gk_code, force_overwrite=False)
 
+    def enforce_consistent_beta_prime(self) -> None:
+        """
+        Force LocalGeometry attribute beta_prime to be consistent
+        with Numerics and LocalSpecies object
+        """
+        if (
+            self.local_geometry is None
+            or self.local_species is None
+            or self.numerics is None
+        ):
+            raise ValueError(
+                "Please load local_species, local_geometry and numerics before calling enforce_consistent_beta_prime"
+            )
+
+        beta_prime_units = self.local_geometry.beta_prime.units
+
+        beta = self.numerics.beta if self.numerics.beta is not None else self.norms.beta
+
+        self.local_geometry.beta_prime = (
+            -(
+                beta.to(self.norms.pyrokinetics, self.norms.context)
+                * self.local_species.inverse_lp.to(
+                    self.norms.pyrokinetics, self.norms.context
+                )
+                * self.local_species.pressure.to(
+                    self.norms.pyrokinetics, self.norms.context
+                )
+            ).m
+            * beta_prime_units
+        )
+
     def load_gk_output(
         self,
         path: Optional[PathLike] = None,

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -5,6 +5,21 @@ import pyrokinetics as pk
 import pytest
 
 
+def test_enforce_beta_prime():
+    """Test that enforcing a consistent beta_prime work correctly."""
+    eq_file = pk.template_dir / "test.geqdsk"
+    kinetics_file = pk.template_dir / "jetto.jsp"
+
+    pyro = pk.Pyro(eq_file=eq_file, kinetics_file=kinetics_file)
+    pyro.load_local(psi_n=0.5)
+    pyro.gk_code = "CGYRO"
+    assert pyro.gk_input.data["BETA_STAR_SCALE"] != 1.0
+
+    pyro.enforce_consistent_beta_prime()
+    pyro.update_gk_code()
+    assert np.isclose(pyro.gk_input.data["BETA_STAR_SCALE"], 1.0)
+
+
 def test_normalise():
     """Test that a local geometry can be renormalised with simulation units."""
     pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])


### PR DESCRIPTION
Add a function `pyro.enforce_consistent_beta_prime()` that ensures that `pyro.local_geometry.beta_prime` is consistent with `numerics.beta` and the `local_species` object. Written a test for this too
