### PR TITLE
Downsample CGYRO data before loading into memory

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1024,7 +1024,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
         for key, value in downsample.items():
             if isinstance(value, int):
-                downsample[key] = [value]
+                downsample[key] = slice(value, value + 1)
 
         bunit_over_b0 = (1 * norm.cgyro.bref).to(norm.gs2).m
         coords = self._get_coords(raw_data, gk_input, bunit_over_b0, downsample)
@@ -1397,7 +1397,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         field_names = ["phi", "apar", "bpar"][:nfield]
 
         def _field_downsample(
-            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None
+            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None, **kwargs
         ):
             """
             Extract a subset of a 4D memmap array with custom indices for each dimension.
@@ -1558,7 +1558,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             return results
 
         def _moment_downsample(
-            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None
+            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None, **kwargs
         ):
             """
             Extract a subset of a 4D memmap array with custom indices for each dimension.
@@ -1678,7 +1678,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         #     flux_key = "cflux"
         flux_key = "flux"
 
-        def _flux_downsample(memmap, ky_idx=None, time_idx=None):
+        def _flux_downsample(memmap, ky_idx=None, time_idx=None, **kwargs):
             """
             Extract a subset of a 4D memmap array with custom indices for each dimension.
 

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1022,9 +1022,13 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         gk_input.convention = convention
         norm.default_convention = output_convention.lower()
 
+        fmt_downsample = {}
         for key, value in downsample.items():
             if isinstance(value, int):
-                downsample[key] = slice(value, value + 1)
+                fmt_downsample[key + "_idx"] = slice(value, value + 1)
+            else:
+                fmt_downsample[key + "_idx"] = value
+        downsample = fmt_downsample
 
         bunit_over_b0 = (1 * norm.cgyro.bref).to(norm.gs2).m
         coords = self._get_coords(raw_data, gk_input, bunit_over_b0, downsample)

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1013,6 +1013,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         load_fields=True,
         load_fluxes=True,
         load_moments=False,
+        downsample: Dict[str, Any] = {},
     ) -> GKOutput:
         raw_data, gk_input, input_str = self._get_raw_data(
             filename, load_fields, load_moments
@@ -1022,9 +1023,19 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         gk_input.convention = convention
         norm.default_convention = output_convention.lower()
 
+        for key, value in downsample.items():
+            if isinstance(value, int):
+                downsample[key] = [value]
+
         bunit_over_b0 = (1 * norm.cgyro.bref).to(norm.gs2).m
-        coords = self._get_coords(raw_data, gk_input, downsize, bunit_over_b0)
-        fields = self._get_fields(raw_data, gk_input, coords) if load_fields else None
+        coords = self._get_coords(
+            raw_data, gk_input, downsize, bunit_over_b0, downsample
+        )
+        fields = (
+            self._get_fields(raw_data, gk_input, coords, downsample)
+            if load_fields
+            else None
+        )
         fluxes = self._get_fluxes(raw_data, gk_input, coords) if load_fluxes else None
         moments = (
             self._get_moments(raw_data, gk_input, coords) if load_moments else None
@@ -1194,9 +1205,11 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             if cgyro_file.fmt == "bin":
                 # Promote to 64 bit float here, as with older NumPy versions this
                 # can lock us into low precision computation throughout
-                raw_data[key] = np.asarray(
-                    np.fromfile(cgyro_file.path, dtype=np.float32), dtype=float
-                )
+                # raw_data[key] = np.asarray(
+                #     np.fromfile(cgyro_file.path, dtype=np.float32), dtype=float
+                # )
+                raw_data[key] = np.asarray(np.memmap(cgyro_file.path, dtype=np.float32))
+
         input_str = raw_data["input"]
         gk_input = GKInputCGYRO()
         gk_input.read_str(input_str)
@@ -1209,6 +1222,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         gk_input: GKInputCGYRO,
         downsize: int = 1,
         bunit_over_b0: float = None,
+        downsample: Dict[str, Any] = {},
     ) -> Dict[str, Any]:
         """
         Sets coords and attrs of a Pyrokinetics dataset from a collection of CGYRO
@@ -1275,8 +1289,8 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         else:
             # Output data actually given on theta_plot grid
             ntheta = ntheta_plot
-            theta = (
-                np.array([0.0]) if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta]
+            theta = np.array(
+                ([0.0] if ntheta == 1 else theta_grid[:: ntheta_grid // ntheta])
             )
             kx = (
                 2
@@ -1327,12 +1341,26 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         if len(ky) == 1:
             w_theta = np.tile(w_theta, nradial)
 
+        full_ky = ky
+        full_kx = kx
+        full_theta = theta
+        full_time = time
+        if downsample:
+            ky = ky[downsample.get("ky_idx", slice(None))]
+            kx = kx[downsample.get("kx_idx", slice(None))]
+            theta = theta[downsample.get("theta_idx", slice(None))]
+            time = time[downsample.get("time_idx", slice(None))]
+
         # Store grid data as xarray DataSet
         return {
             "time": time,
             "kx": kx,
             "ky": ky,
             "theta": theta,
+            "full_time": full_time,
+            "full_kx": full_kx,
+            "full_ky": full_ky,
+            "full_theta": full_theta,
             "energy": energy,
             "pitch": pitch,
             "ntheta_plot": ntheta_plot,
@@ -1354,6 +1382,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         raw_data: Dict[str, Any],
         gk_input: GKInputCGYRO,
         coords: Dict[str, Any],
+        downsample: Dict[str, Any],
     ) -> Dict[str, np.ndarray]:
         """
         Sets 3D fields over time.
@@ -1363,6 +1392,10 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         nradial = coords["nradial"]
         nky = len(coords["ky"])
         ntheta = len(coords["theta"])
+        full_nkx = len(coords["full_kx"])
+        full_ntime = len(coords["full_time"])
+        full_nky = len(coords["full_ky"])
+        full_ntheta = len(coords["full_theta"])
         ntheta_plot = coords["ntheta_plot"]
         ntheta_grid = coords["ntheta_grid"]
         ntime = len(coords["time"])
@@ -1370,8 +1403,40 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         downsize = coords["downsize"]
         residual = coords["residual"]
 
-        full_ntime = ntime * downsize + residual
+        # full_ntime = ntime * downsize + residual
         field_names = ["phi", "apar", "bpar"][:nfield]
+
+        def _field_downsample(
+            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None
+        ):
+            """
+            Extract a subset of a 4D memmap array with custom indices for each dimension.
+
+            Parameters
+            ----------
+            memmap_arr : np.memmap
+                The 4D memmap array with shape (kx, ky, theta, time).
+            kx_idx, ky_idx, theta_idx, time_idx : slice, int, list, or ndarray, optional
+                Indices for each dimension. Can be:
+                - None (means ':')
+                - int
+                - slice (e.g., slice(0, 10, 2))
+                - list or np.ndarray of indices
+
+            Returns
+            -------
+            np.ndarray
+                A normal NumPy array with the requested subset.
+                (This will load the selected data into memory.)
+            """
+            # replace None with full slices
+            kx_idx = slice(None) if kx_idx is None else kx_idx
+            ky_idx = slice(None) if ky_idx is None else ky_idx
+            theta_idx = slice(None) if theta_idx is None else theta_idx
+            time_idx = slice(None) if time_idx is None else time_idx
+
+            # fancy indexing happens here
+            return memmap[:, kx_idx, theta_idx, ky_idx, time_idx]
 
         raw_field_data = {f: raw_data.get(f"field_{f}", None) for f in field_names}
 
@@ -1395,9 +1460,10 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             if gk_input.is_linear() and nky == 1:
                 shape = (2, nradial, ntheta_plot, nky, full_ntime)
             else:
-                shape = (2, nkx, ntheta, nky, full_ntime)
+                shape = (2, full_nkx, full_ntheta, full_nky, full_ntime)
 
-            field_data = raw_field[: np.prod(shape)].reshape(shape, order="F")
+            field_data = raw_field.reshape(shape, order="F")
+            field_data = _field_downsample(field_data, **downsample).astype(np.float64)
 
             # Downsize data before further processing
             field_data = field_data[..., ::downsize]

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -1009,7 +1009,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         filename: PathLike,
         norm: Normalisation,
         output_convention: str = "pyrokinetics",
-        downsize: int = 1,
         load_fields=True,
         load_fluxes=True,
         load_moments=False,
@@ -1028,17 +1027,21 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                 downsample[key] = [value]
 
         bunit_over_b0 = (1 * norm.cgyro.bref).to(norm.gs2).m
-        coords = self._get_coords(
-            raw_data, gk_input, downsize, bunit_over_b0, downsample
-        )
+        coords = self._get_coords(raw_data, gk_input, bunit_over_b0, downsample)
         fields = (
             self._get_fields(raw_data, gk_input, coords, downsample)
             if load_fields
             else None
         )
-        fluxes = self._get_fluxes(raw_data, gk_input, coords) if load_fluxes else None
+        fluxes = (
+            self._get_fluxes(raw_data, gk_input, coords, downsample)
+            if load_fluxes
+            else None
+        )
         moments = (
-            self._get_moments(raw_data, gk_input, coords) if load_moments else None
+            self._get_moments(raw_data, gk_input, coords, downsample)
+            if load_moments
+            else None
         )
 
         if coords["linear"] and (
@@ -1220,7 +1223,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
     def _get_coords(
         raw_data: Dict[str, Any],
         gk_input: GKInputCGYRO,
-        downsize: int = 1,
         bunit_over_b0: float = None,
         downsample: Dict[str, Any] = {},
     ) -> Dict[str, Any]:
@@ -1238,13 +1240,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
 
         # Process time data
         time = raw_data["time"][:, 0]
-
-        if len(time) % downsize != 0:
-            residual = len(time) % downsize - downsize
-        else:
-            residual = 0
-
-        time = time[::downsize]
 
         # Process grid data
         grid_data = raw_data["grids"]
@@ -1372,8 +1367,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             "flux": fluxes,
             "species": species,
             "linear": gk_input.is_linear(),
-            "downsize": downsize,
-            "residual": residual,
             "w_theta": w_theta,
         }
 
@@ -1400,10 +1393,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         ntheta_grid = coords["ntheta_grid"]
         ntime = len(coords["time"])
         nfield = len(coords["field"])
-        downsize = coords["downsize"]
-        residual = coords["residual"]
 
-        # full_ntime = ntime * downsize + residual
         field_names = ["phi", "apar", "bpar"][:nfield]
 
         def _field_downsample(
@@ -1458,15 +1448,12 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             # If linear, convert from kx to ballooning space.
             # Use nradial instead of nkx, ntheta_plot instead of ntheta
             if gk_input.is_linear() and nky == 1:
-                shape = (2, nradial, ntheta_plot, nky, full_ntime)
+                shape = (2, nradial, ntheta_plot, full_nky, full_ntime)
             else:
                 shape = (2, full_nkx, full_ntheta, full_nky, full_ntime)
 
             field_data = raw_field.reshape(shape, order="F")
             field_data = _field_downsample(field_data, **downsample).astype(np.float64)
-
-            # Downsize data before further processing
-            field_data = field_data[..., ::downsize]
 
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
@@ -1498,7 +1485,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
                     eig_data = raw_eig_data[: np.prod(eig_shape)].reshape(
                         eig_shape, order="F"
                     )
-                    eig_data = eig_data[..., ::downsize]
+
                     eig_data = eig_data[0] + 1j * eig_data[1]
                     # Get field amplitude
                     middle_kx = (nradial // 2) + 1
@@ -1540,6 +1527,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         raw_data: Dict[str, Any],
         gk_input: GKInputCGYRO,
         coords: Dict[str, Any],
+        downsample: Dict,
     ) -> Dict[str, np.ndarray]:
         """
         Sets 3D moments over time.
@@ -1554,9 +1542,10 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         ntheta_plot = coords["ntheta_plot"]
         ntime = len(coords["time"])
         nspec = len(coords["species"])
-        residual = coords["residual"]
-        downsize = coords["downsize"]
-        full_ntime = ntime * downsize + residual
+        full_nkx = len(coords["full_kx"])
+        full_ntime = len(coords["full_time"])
+        full_nky = len(coords["full_ky"])
+        full_ntheta = len(coords["full_theta"])
 
         raw_moment_data = {
             value: raw_data.get(f"moment_{key}", None)
@@ -1567,6 +1556,38 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         # Check to see if there's anything to do
         if not raw_moment_data:
             return results
+
+        def _moment_downsample(
+            memmap, kx_idx=None, ky_idx=None, theta_idx=None, time_idx=None
+        ):
+            """
+            Extract a subset of a 4D memmap array with custom indices for each dimension.
+
+            Parameters
+            ----------
+            memmap_arr : np.memmap
+                The 4D memmap array with shape (kx, theta, species, ky, time).
+            kx_idx, ky_idx, theta_idx, time_idx : slice, int, list, or ndarray, optional
+                Indices for each dimension. Can be:
+                - None (means ':')
+                - int
+                - slice (e.g., slice(0, 10, 2))
+                - list or np.ndarray of indices
+
+            Returns
+            -------
+            np.ndarray
+                A normal NumPy array with the requested subset.
+                (This will load the selected data into memory.)
+            """
+            # replace None with full slices
+            kx_idx = slice(None) if kx_idx is None else kx_idx
+            ky_idx = slice(None) if ky_idx is None else ky_idx
+            theta_idx = slice(None) if theta_idx is None else theta_idx
+            time_idx = slice(None) if time_idx is None else time_idx
+
+            # fancy indexing happens here
+            return memmap[:, kx_idx, theta_idx, :, ky_idx, time_idx]
 
         # Loop through all moments and add moment in if it exists
         for imoment, (moment_name, raw_moment) in enumerate(raw_moment_data.items()):
@@ -1582,12 +1603,12 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             if gk_input.is_linear() and nky == 1:
                 shape = (2, nradial, ntheta_plot, nspec, nky, full_ntime)
             else:
-                shape = (2, nkx, ntheta, nspec, nky, full_ntime)
+                shape = (2, full_nkx, full_ntheta, nspec, full_nky, full_ntime)
 
-            moment_data = raw_moment[: np.prod(shape)].reshape(shape, order="F")
-
-            # Downsize data before further processing
-            moment_data = moment_data[..., ::downsize]
+            moment_data = raw_moment.reshape(shape, order="F")
+            moment_data = _moment_downsample(moment_data, **downsample).astype(
+                np.float64
+            )
 
             # Adjust sign to match pyrokinetics frequency convention
             # (-ve is electron direction)
@@ -1640,6 +1661,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         raw_data: Dict[str, Any],
         gk_input: Dict,
         coords: Dict,
+        downsample: Dict,
     ) -> Dict[str, np.ndarray]:
         """
         Set flux data over time.
@@ -1647,9 +1669,6 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         """
 
         results = {}
-        ntime = len(coords["time"])
-        downsize = coords["downsize"]
-        residual = coords["residual"]
         # cflux is more appropriate for CGYRO simulations
         # with GAMMA_E > 0 and SHEAR_METHOD = 2.
         # However, for cross-code consistency, gflux is used for now.
@@ -1659,11 +1678,39 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
         #     flux_key = "cflux"
         flux_key = "flux"
 
+        def _flux_downsample(memmap, ky_idx=None, time_idx=None):
+            """
+            Extract a subset of a 4D memmap array with custom indices for each dimension.
+
+            Parameters
+            ----------
+            memmap_arr : np.memmap
+                The 5D memmap array with shape (species, flux, field, ky, time).
+            ky_idx, time_idx : slice, int, list, or ndarray, optional
+                Indices for each dimension. Can be:
+                - None (means ':')
+                - int
+                - slice (e.g., slice(0, 10, 2))
+                - list or np.ndarray of indices
+
+            Returns
+            -------
+            np.ndarray
+                A normal NumPy array with the requested subset.
+                (This will load the selected data into memory.)
+            """
+            # replace None with full slices
+            ky_idx = slice(None) if ky_idx is None else ky_idx
+            time_idx = slice(None) if time_idx is None else time_idx
+
+            # fancy indexing happens here
+            return memmap[:, :, :, ky_idx, time_idx]
+
         if flux_key in raw_data:
-            coord_names = ["species", "flux", "field", "ky"]
+            coord_names = ["species", "flux", "field", "full_ky", "full_time"]
             shape = [len(coords[coord_name]) for coord_name in coord_names]
-            shape.append(ntime * downsize + residual)
-            fluxes = raw_data[flux_key][: np.prod(shape)].reshape(shape, order="F")
+            raw_fluxes = raw_data[flux_key].reshape(shape, order="F")
+            fluxes = _flux_downsample(raw_fluxes, **downsample)
 
         fluxes = np.swapaxes(fluxes, 0, 2)
 
@@ -1679,7 +1726,7 @@ class GKOutputReaderCGYRO(FileReader, file_type="CGYRO", reads=GKOutput):
             flux_norm = 1.0
 
         for iflux, flux in enumerate(coords["flux"]):
-            results[flux] = (fluxes[:, iflux, :, :, ::downsize]) / flux_norm
+            results[flux] = (fluxes[:, iflux, :, :, :]) / flux_norm
 
         return results
 

--- a/tests/gk_code/test_gk_code_output.py
+++ b/tests/gk_code/test_gk_code_output.py
@@ -57,7 +57,7 @@ def test_gk_codes_output():
     assert_eigenvalue_close_tglf(tglf, tglf_expected)
 
 
-@pytest.mark.parametrize("downsample", ({"time_idx": slice(None, None, 3)},))
+@pytest.mark.parametrize("downsample", ({"time": slice(None, None, 3)},))
 def test_cgyro_linear_output_downsample(downsample):
     # Test time values from linear CGYRO (can't do fields due to normalisation)
     pyro = Pyro(
@@ -68,9 +68,9 @@ def test_cgyro_linear_output_downsample(downsample):
     sel_dict = {}
     for key, value in downsample.items():
         if isinstance(value, int):
-            sel_dict[key[:-4]] = [value]
+            sel_dict[key] = [value]
         else:
-            sel_dict[key[:-4]] = value
+            sel_dict[key] = value
 
     full_data = pyro.gk_output.data.isel(**sel_dict)
 
@@ -98,9 +98,9 @@ def test_cgyro_linear_output_downsample(downsample):
 @pytest.mark.parametrize(
     "downsample",
     (
-        {"time_idx": slice(None, None, 2), "theta_idx": 8},
-        {"kx_idx": slice(None, None, 4), "theta_idx": slice(2, 14, 2)},
-        {"ky_idx": 4, "kx_idx": 16},
+        {"time": slice(None, None, 2), "theta": 8},
+        {"kx": slice(None, None, 4), "theta": slice(2, 14, 2)},
+        {"ky": 4, "kx": 16},
     ),
 )
 def test_cgyro_nonlinear_output_downsample(downsample):
@@ -112,9 +112,9 @@ def test_cgyro_nonlinear_output_downsample(downsample):
     sel_dict = {}
     for key, value in downsample.items():
         if isinstance(value, int):
-            sel_dict[key[:-4]] = [value]
+            sel_dict[key] = [value]
         else:
-            sel_dict[key[:-4]] = value
+            sel_dict[key] = value
 
     full_data = pyro.gk_output.data.isel(**sel_dict)
 

--- a/tests/gk_code/test_gk_code_output.py
+++ b/tests/gk_code/test_gk_code_output.py
@@ -57,48 +57,97 @@ def test_gk_codes_output():
     assert_eigenvalue_close_tglf(tglf, tglf_expected)
 
 
-@pytest.mark.parametrize("downsize", (2, 3, 4))
-def test_cgyro_linear_output_downsize(downsize):
+@pytest.mark.parametrize("downsample", ({"time_idx": slice(None, None, 3)},))
+def test_cgyro_linear_output_downsample(downsample):
     # Test time values from linear CGYRO (can't do fields due to normalisation)
     pyro = Pyro(
         gk_file=template_dir / "outputs/CGYRO_linear/input.cgyro", gk_code="CGYRO"
     )
     pyro.load_gk_output()
-    full_data = pyro.gk_output
 
-    pyro.load_gk_output(downsize=downsize)
-    downsize_data = pyro.gk_output
+    sel_dict = {}
+    for key, value in downsample.items():
+        if isinstance(value, int):
+            sel_dict[key[:-4]] = [value]
+        else:
+            sel_dict[key[:-4]] = value
+
+    full_data = pyro.gk_output.data.isel(**sel_dict)
+
+    ds_pyro = Pyro(
+        gk_file=template_dir / "outputs/CGYRO_linear/input.cgyro", gk_code="CGYRO"
+    )
+    ds_pyro.load_gk_output(downsample=downsample)
+    downsample_data = ds_pyro.gk_output
 
     np.testing.assert_allclose(
-        ureg.Quantity(full_data["time"][::downsize].data).magnitude,
-        ureg.Quantity(downsize_data["time"].data).magnitude,
+        ureg.Quantity(full_data["time"].data).magnitude,
+        ureg.Quantity(downsample_data["time"].data).magnitude,
+        atol=1e-8,
+        rtol=1e-5,
+    )
+
+    np.testing.assert_allclose(
+        ureg.Quantity(full_data["phi"].data).magnitude,
+        ureg.Quantity(downsample_data["phi"].data).magnitude,
         atol=1e-8,
         rtol=1e-5,
     )
 
 
-@pytest.mark.parametrize("downsize", (2, 3, 4))
-def test_cgyro_nonlinear_output_downsize(downsize):
+@pytest.mark.parametrize(
+    "downsample",
+    (
+        {"time_idx": slice(None, None, 2), "theta_idx": 8},
+        {"kx_idx": slice(None, None, 4), "theta_idx": slice(2, 14, 2)},
+        {"ky_idx": 4, "kx_idx": 16},
+    ),
+)
+def test_cgyro_nonlinear_output_downsample(downsample):
     # Test time/phi values from nonlinear CGYRO
     pyro = Pyro(
         gk_file=template_dir / "outputs/CGYRO_nonlinear/input.cgyro", gk_code="CGYRO"
     )
-    pyro.load_gk_output()
-    full_data = pyro.gk_output
+    pyro.load_gk_output(load_moments=True)
+    sel_dict = {}
+    for key, value in downsample.items():
+        if isinstance(value, int):
+            sel_dict[key[:-4]] = [value]
+        else:
+            sel_dict[key[:-4]] = value
 
-    pyro.load_gk_output(downsize=downsize)
-    downsize_data = pyro.gk_output
+    full_data = pyro.gk_output.data.isel(**sel_dict)
+
+    ds_pyro = Pyro(
+        gk_file=template_dir / "outputs/CGYRO_nonlinear/input.cgyro", gk_code="CGYRO"
+    )
+    ds_pyro.load_gk_output(load_moments=True, downsample=downsample)
+    downsample_data = ds_pyro.gk_output.data
 
     np.testing.assert_allclose(
-        ureg.Quantity(full_data["time"][::downsize].data).magnitude,
-        ureg.Quantity(downsize_data["time"].data).magnitude,
+        ureg.Quantity(full_data["time"].data).magnitude,
+        ureg.Quantity(downsample_data["time"].data).magnitude,
         atol=1e-8,
         rtol=1e-5,
     )
 
     np.testing.assert_allclose(
-        ureg.Quantity(full_data["phi"][..., ::downsize].data).magnitude,
-        ureg.Quantity(downsize_data["phi"].data).magnitude,
+        ureg.Quantity(full_data["phi"].data).magnitude,
+        ureg.Quantity(downsample_data["phi"].data).magnitude,
+        atol=1e-8,
+        rtol=1e-5,
+    )
+
+    np.testing.assert_allclose(
+        ureg.Quantity(full_data["heat"].data).magnitude,
+        ureg.Quantity(downsample_data["heat"].data).magnitude,
+        atol=1e-8,
+        rtol=1e-5,
+    )
+
+    np.testing.assert_allclose(
+        ureg.Quantity(full_data["density"].data).magnitude,
+        ureg.Quantity(downsample_data["density"].data).magnitude,
         atol=1e-8,
         rtol=1e-5,
     )


### PR DESCRIPTION
Previously Pyro would try to load all the data in the binary files using `np.fromfile`. When working with nonlinear simulations where the output can be 100GB you can often run out of memory and the process will fail.

This PR switches to using `np.memmap` in CGYRO which just puts the location of the data in memory. This allows for downsampling before the data is loaded, which significantly reduces the time taken to read in the data.

To do this you need to add a dictionary `downsample` as a `kwargs` when calling `pyro.load_gk_output`

```python
from pyrokinetics import Pyro

gk_file = "input.cgyro"
pyro = Pyro(gk_file=gk_file)

downsample = {
"time_idx": slice(-100, None, None),
"ky_idx": slice(1, 10, None),
"theta_idx":  16,
"kx_idx": None,
}
pyro.load_gk_output(downsample=downsample)
```

The above example will only load the final 100 timeslices, the kys going from index 1 to 10,  the 16th theta and all the kx. One can specify a single index using an integer or a range of indices using `slice`

I've added a unit test for this which seems to work. Note I have remove the option `downsize` when loading CGYRO output as that is now redundant.

We could try and implement this for other codes. GKW does use `numpy.fromfile` so a similar strategy could be followed but I am not sure about the other codes. Lazy loading of netCDF files (GS2/STELLA) is possible but I am not sure if we do that. GENE output is quite messy so this could be a bit more difficult to implement. Not sure if we just implement as we go?

Also should we change the keys in the downsample dict from `time_idx` to `time`? Its less clear but cleaner...