### PR TITLE
Changed the assigned units for nmode in tglf from dimensionless to none. This solved an error with reading tglf pyroscans

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -349,7 +349,7 @@ class PyroScan:
             nmode = self.base_pyro.gk_input.data.get("nmodes", 2)
             nmode_coords = {"nmode": list(range(1, 1 + nmode))}
             ds = ds.assign_coords(nmode_coords)
-            ds["nmode"] = ds["nmode"].assign_attrs(units="dimensionless")
+            ds["nmode"] = ds["nmode"].assign_attrs(units=None)
         else:
             nmode = np.nan
 


### PR DESCRIPTION
In line 668 of the Pyroscan file, the "to" function in the PyroScanGkOutput object checks if the coord's units is None. If it is not None it attempts to multiply the data by the correct unit which isn't possible with dimensionless. Therefore the code throws the error:  
`new_coord = (self[coord].data * self[coord].units).to(norms)
                 ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
TypeError: The 'out' kwarg is necessary. Use numpy.strings.multiply without it.`
Setting the unit type to None bypasses this steps and prevents the error being thrown
