### PR TITLE
Add fix for gs2_bespoke beta_prime and multiple loads

### DIFF
--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -400,7 +400,6 @@ class SimulationNormalisation(Normalisation):
 
         """
         # Create instances of each convention we know about
-
         te = convention_dict["te"]
         ne = convention_dict["ne"]
         rgeo_rmaj = convention_dict["rgeo_rmaj"]
@@ -408,8 +407,7 @@ class SimulationNormalisation(Normalisation):
 
         beta_ref_name = f"beta_ref_{convention_dict['nref_species'][0]}{convention_dict['tref_species'][0]}_{convention_dict['bref']}"
 
-        if beta_ref_name not in self.units:
-
+        if beta_ref_name not in ["beta_ref_ee_B0", "beta_ref_ee_Bunit"]:
             if convention_dict["bref"] in ["B0", "Bgeo"]:
                 self.define(
                     f"{beta_ref_name} = {ne * te / rgeo_rmaj ** 2} beta_ref_ee_B0",

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1130,6 +1130,7 @@ class Pyro:
             )
 
         beta_prime_units = self.local_geometry.beta_prime.units
+        beta_prime_units = (1 * self.norms.pyrokinetics.bref**2 / self.norms.pyrokinetics.lref).to(beta_prime_units)
 
         beta = self.numerics.beta if self.numerics.beta is not None else self.norms.beta
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1130,7 +1130,9 @@ class Pyro:
             )
 
         beta_prime_units = self.local_geometry.beta_prime.units
-        beta_prime_units = (1 * self.norms.pyrokinetics.bref**2 / self.norms.pyrokinetics.lref).to(beta_prime_units)
+        beta_prime_units = (
+            1 * self.norms.pyrokinetics.bref**2 / self.norms.pyrokinetics.lref
+        ).to(beta_prime_units)
 
         beta = self.numerics.beta if self.numerics.beta is not None else self.norms.beta
 


### PR DESCRIPTION
Fixes 2 issues.

Firstly forcing consistent $\beta'$ did not account for the different units. The calculation was done using `pyrokinetics` units and then just stuck on the original units which if different would be wrong.

Secondly when loading multiple GS2 input files with a "bespoke" normalisation, the mapping the bespoke conventions' `beta_ref` to the pyro ones was only being done once due to an iffy `if` statement. For example when `bref = bref_Bgeo` and `tref = tref_deuterium` you make a `beta_ref_ed_Bgeo` unit and then that get added to the cache so when you make a new pyro object that already exists so won't get added. Here we just tweak the statement to see if the new `beta_ref` is one of the two pyro default values. 