### PR TITLE
Specifying types

### DIFF
--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -196,8 +196,9 @@ class LocalGeometry:
         self.beta_prime = beta_prime
         self.dpsidr = dpsidr
 
-        self.ip_ccw = np.sign(q / B0)
-        self.bt_ccw = np.sign(B0)
+        # Must be int to be parsed for GENE - no danger of truncation to zero of np.sign(x)
+        self.ip_ccw = int(np.sign(q / B0))
+        self.bt_ccw = int(np.sign(B0))
 
         self.R_eq = R
         self.Z_eq = Z


### PR DESCRIPTION
Must specify bt_ccw & it_ccw as int for GENE to be able to parse parameters files.  May want to check this doesn't break other codes if they expect floating point values instead.