### PR TITLE
Writing of reference values

### DIFF
--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -303,7 +303,7 @@ def pyro_to_imas_mapping(
     code = gkids.Code(**code)
 
     if reference_values:
-        pyro.set_reference_values(**reference_values)
+        pyro.set_reference_values(**reference_values, convert_pyro=False)
 
     try:
         normalizing_quantities = {
@@ -440,7 +440,6 @@ def pyro_to_imas_mapping(
 
             data["linear"] = gkids.GyrokineticsLinear(**linear)
         else:
-
             non_linear = {
                 "binormal_wavevector_norm": gk_output["ky"].data / k_factor,
                 "radial_wavevector_norm": gk_output["kx"].data / k_factor,

--- a/src/pyrokinetics/databases/imas.py
+++ b/src/pyrokinetics/databases/imas.py
@@ -16,6 +16,7 @@ from ..gk_code.gk_output import GKOutput
 from ..local_geometry import MetricTerms
 from ..normalisation import convert_dict
 from ..pyro import Pyro
+from ..units import PyroContextError
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -301,23 +302,18 @@ def pyro_to_imas_mapping(
 
     code = gkids.Code(**code)
 
+    if reference_values:
+        pyro.set_reference_values(**reference_values)
+
     try:
         normalizing_quantities = {
-            "r": (1.0 * norms.gene.lref).to("meter").m,
-            "b_field_tor": (1.0 * norms.bref).to("tesla").m,
-            "n_e": (1.0 * norms.nref).to("meter**-3").m,
-            "t_e": (1.0 * norms.tref).to("eV").m,
+            "r": (1.0 * norms.gene.lref).to("meter", norms.context).m,
+            "b_field_tor": (1.0 * norms.bref).to("tesla", norms.context).m,
+            "n_e": (1.0 * norms.nref).to("meter**-3", norms.context).m,
+            "t_e": (1.0 * norms.tref).to("eV", norms.context).m,
         }
-    except pint.DimensionalityError:
-        if reference_values:
-            normalizing_quantities = {
-                "r": reference_values["lref_major_radius"].to("meter").m,
-                "b_field_tor": reference_values["bref_B0"].to("tesla").m,
-                "n_e": reference_values["nref_electron"].to("meter**-3").m,
-                "t_e": reference_values["tref_electron"].to("eV").m,
-            }
-        else:
-            normalizing_quantities = {}
+    except (pint.DimensionalityError, PyroContextError):
+        normalizing_quantities = {}
 
     normalizing_quantities = gkids.InputNormalizing(**normalizing_quantities)
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional, Tuple
 import f90nml
 import h5py
 import numpy as np
-import pint
 from cleverdict import CleverDict
 
 from ..constants import deuterium_mass, electron_mass, pi
@@ -33,6 +32,7 @@ from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
 from ..templates import gk_templates
 from ..typing import PathLike
+from ..units import PyroContextError
 from .gk_input import GKInput
 from .gk_output import Coords, Eigenvalues, Fields, Fluxes, GKOutput, Moments
 
@@ -1424,7 +1424,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
         try:
             (1 * convention.tref).to("keV")
             si_units = True
-        except pint.errors.DimensionalityError:
+        except PyroContextError:
             si_units = False
 
         if si_units:

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -891,7 +891,7 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
 
         data.pint.dequantify().to_netcdf(*args, **kwargs)
 
-    def to(self, norms: ConventionNormalisation, context=None):
+    def to(self, norms: ConventionNormalisation, *contexts):
         """
 
         Parameters
@@ -904,14 +904,14 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         GKOutput with units from norms
         """
         for data_var in self.data_vars:
-            self.data[data_var].data = self.data[data_var].data.to(norms, context)
-
+            self.data[data_var].data = self.data[data_var].data.to(norms, *contexts)
         # Coordinates with units not supported in xarray need to manually change
         new_coords = {}
+
         for coord in self.coords:
             if hasattr(self.data[coord], "units"):
                 new_coord = (self.data[coord].data * self.data[coord].units).to(
-                    norms, context
+                    norms, *contexts
                 )
                 new_coords[coord] = (
                     coord,

--- a/src/pyrokinetics/gk_code/gk_output.py
+++ b/src/pyrokinetics/gk_code/gk_output.py
@@ -891,7 +891,7 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
 
         data.pint.dequantify().to_netcdf(*args, **kwargs)
 
-    def to(self, norms: ConventionNormalisation):
+    def to(self, norms: ConventionNormalisation, context=None):
         """
 
         Parameters
@@ -904,13 +904,15 @@ class GKOutput(DatasetWrapper, ReadableFromFile):
         GKOutput with units from norms
         """
         for data_var in self.data_vars:
-            self.data[data_var].data = self.data[data_var].data.to(norms)
+            self.data[data_var].data = self.data[data_var].data.to(norms, context)
 
         # Coordinates with units not supported in xarray need to manually change
         new_coords = {}
         for coord in self.coords:
             if hasattr(self.data[coord], "units"):
-                new_coord = (self.data[coord].data * self.data[coord].units).to(norms)
+                new_coord = (self.data[coord].data * self.data[coord].units).to(
+                    norms, context
+                )
                 new_coords[coord] = (
                     coord,
                     new_coord.m,

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import f90nml
 import numpy as np
-import pint
 from cleverdict import CleverDict
 from scipy.integrate import cumulative_trapezoid, trapezoid
 
@@ -38,6 +37,7 @@ from .gk_output import (
     GKOutput,
     Moments,
 )
+from ..units import PyroContextError
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -985,7 +985,7 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         try:
             (1 * convention.tref).to("keV")
             si_units = True
-        except pint.errors.DimensionalityError:
+        except PyroContextError:
             si_units = False
 
         if si_units:

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -27,6 +27,7 @@ from ..normalisation import convert_dict
 from ..numerics import Numerics
 from ..templates import gk_templates
 from ..typing import PathLike
+from ..units import PyroContextError
 from .gk_input import GKInput
 from .gk_output import (
     Coords,
@@ -37,7 +38,6 @@ from .gk_output import (
     GKOutput,
     Moments,
 )
-from ..units import PyroContextError
 
 if TYPE_CHECKING:
     import xarray as xr

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import f90nml
 import numpy as np
-import pint
 from cleverdict import CleverDict
 
 from ..constants import deuterium_mass, electron_mass, pi
@@ -19,6 +18,7 @@ from ..normalisation import convert_dict, ureg
 from ..numerics import Numerics
 from ..templates import gk_templates
 from ..typing import PathLike
+from ..units import PyroContextError
 from .gk_input import GKInput
 from .gk_output import Coords, Eigenvalues, Fields, Fluxes, GKOutput, Moments
 
@@ -801,7 +801,7 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
         try:
             (1 * convention.tref).to("keV")
             si_units = True
-        except pint.errors.DimensionalityError:
+        except PyroContextError:
             si_units = False
 
         if si_units:

--- a/src/pyrokinetics/local_geometry/local_geometry.py
+++ b/src/pyrokinetics/local_geometry/local_geometry.py
@@ -330,7 +330,11 @@ class LocalGeometry:
 
         return local_geometry
 
-    def normalise(self, norms):
+    def to(self, norms, context=None):
+        """Thin wrapper for normalise"""
+        self.normalise(norms, context)
+
+    def normalise(self, norms, context=None):
         """
         Convert LocalGeometry Parameters to current NormalisationConvention
         Note this creates the attribute unit_mapping which is used to apply
@@ -343,6 +347,9 @@ class LocalGeometry:
         """
         self._generate_local_geometry_units(norms)
 
+        if context is None:
+            context = norms.context
+
         for key, val in self.unit_mapping.items():
             if val is None:
                 continue
@@ -353,11 +360,14 @@ class LocalGeometry:
             attribute = getattr(self, key)
 
             if hasattr(attribute, "units"):
-                new_attr = attribute.to(val, norms.context)
+                new_attr = attribute.to(val, context)
             elif attribute is not None:
                 new_attr = attribute * val
+            else:
+                new_attr = None
 
-            setattr(self, key, new_attr)
+            if new_attr is not None:
+                setattr(self, key, new_attr)
 
     def _generate_local_geometry_units(self, norms):
         """

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -240,17 +240,21 @@ class LocalSpecies(CleverDict):
 
         pressure = 0.0
         inverse_lp = 0.0
+        pressure_unit = 0.0
+
         for name in self.names:
             species = self[name]
             # Total pressure
-            pressure += species["temp"] * species["dens"]
+            pressure += species["temp"].m * species["dens"].m
+
             inverse_lp += (
-                species["temp"]
-                * species["dens"]
+                species["temp"].m
+                * species["dens"].m
                 * (species["inverse_lt"].m + species["inverse_ln"].m)
             )
 
-        self["pressure"] = pressure
+            pressure_unit = species["temp"].units * species["dens"].units
+        self["pressure"] = pressure * pressure_unit
 
         if pressure != 0.0:
             inverse_lp = inverse_lp / pressure * species["inverse_lt"].units
@@ -259,34 +263,39 @@ class LocalSpecies(CleverDict):
 
         self["inverse_lp"] = inverse_lp
 
-    def normalise(self, norms=None):
+    def to(self, norms, context=None):
+        """Thin wrapper for normalise"""
+        self.normalise(norms, context)
+
+    def normalise(self, norms=None, context=None):
         """Normalise to pyrokinetics normalisations and calculate total pressure gradient"""
 
         if norms is None:
             norms = Normalisation("local_species")
 
+        if context is None:
+            context = norms.context
+
         for name in self.names:
             species_data = self[name]
-            species_data["mass"] = species_data["mass"].to(norms.mref, norms.context)
-            species_data["z"] = species_data["z"].to(norms.qref, norms.context)
-            species_data["dens"] = species_data["dens"].to(norms.nref, norms.context)
-            species_data["temp"] = species_data["temp"].to(norms.tref, norms.context)
+            species_data["mass"] = species_data["mass"].to(norms.mref, context)
+            species_data["z"] = species_data["z"].to(norms.qref, context)
+            species_data["dens"] = species_data["dens"].to(norms.nref, context)
+            species_data["temp"] = species_data["temp"].to(norms.tref, context)
             species_data["omega0"] = species_data["omega0"].to(
-                norms.vref / norms.lref, norms.context
+                norms.vref / norms.lref, context
             )
-            species_data["nu"] = species_data["nu"].to(
-                norms.vref / norms.lref, norms.context
-            )
+            species_data["nu"] = species_data["nu"].to(norms.vref / norms.lref, context)
 
             # Gradients use lref_minor_radius -> Need to switch to this norms lref using context
             species_data["inverse_lt"] = species_data["inverse_lt"].to(
-                norms.lref**-1, norms.context
+                norms.lref**-1, context
             )
             species_data["inverse_ln"] = species_data["inverse_ln"].to(
-                norms.lref**-1, norms.context
+                norms.lref**-1, context
             )
             species_data["domega_drho"] = species_data["domega_drho"].to(
-                norms.vref * norms.lref**-2, norms.context
+                norms.vref * norms.lref**-2, context
             )
 
             # Avoid floating point errors

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -130,6 +130,7 @@ import copy
 from typing import Dict, Optional
 
 import pint
+import warnings
 
 from pyrokinetics.kinetics import Kinetics
 from pyrokinetics.local_geometry import LocalGeometry
@@ -853,6 +854,29 @@ class SimulationNormalisation(Normalisation):
         lref_minor_radius=None,
         lref_major_radius=None,
     ):
+        # Check if references values are already set
+        reference_names = [
+            "tref_electron",
+            "nref_electron",
+            "bref_B0",
+            "lref_minor_radius",
+            "lref_major_radius",
+        ]
+
+        already_set = [
+            name
+            for name in reference_names
+            if hasattr(self.units, f"{name}_{self.name}")
+        ]
+
+        if already_set:
+            formatted_names = ", ".join(f"'{name}'" for name in already_set)
+            warnings.warn(
+                f"Reference values {formatted_names} are already set for '{self.name}'. ",
+                UserWarning,
+            )
+
+        # Set references
         self.define(f"tref_electron_{self.name} = {tref_electron}", units=True)
         self.define(f"nref_electron_{self.name} = {nref_electron}", units=True)
 

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -127,10 +127,10 @@ normalisations.
 """
 
 import copy
+import warnings
 from typing import Dict, Optional
 
 import pint
-import warnings
 
 from pyrokinetics.kinetics import Kinetics
 from pyrokinetics.local_geometry import LocalGeometry

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -129,6 +129,7 @@ normalisations.
 import copy
 import warnings
 from typing import Dict, Optional
+from numpy import nan
 
 import pint
 
@@ -262,7 +263,7 @@ class Convention:
             f"    rhoref = {self.rhoref},\n"
             f"    lref = {self.lref},\n"
             f"    bref = {self.bref},\n"
-            f"    betaref = {self.beta_ref}\n"
+            f"    beta_ref = {self.beta_ref}\n"
             f")"
         )
 
@@ -495,7 +496,7 @@ class SimulationNormalisation(Normalisation):
             "tref_species",
             "mref_species",
             "nref_species",
-            "betaref",
+            "beta_ref",
             "rhoref",
         ]
         convention_dict = {k: v for k, v in convention_dict.items() if k in ref_keys}
@@ -664,42 +665,101 @@ class SimulationNormalisation(Normalisation):
         if local_geometry:
             bunit_over_b0 = local_geometry.bunit_over_b0.m
 
-        self.define(
-            f"rhoref_pyro_{self.name} = {self.vref} / ({self.bref} / {self.mref} * qref)",
-            units=True,
-        )
+        rhoref = 1.0 * self.vref / (self.bref / self.mref * self.qref)
 
-        self.define(
-            f"rhoref_gs2_{self.name} = (2 ** 0.5) * rhoref_pyro_{self.name}", units=True
-        )
-
-        self.define(
-            f"rhoref_unit_{self.name} = {bunit_over_b0}**-1 * rhoref_pyro_{self.name}",
-            units=True,
-        )
-
-        if "rhoref_custom" in self.units:
-            custom_multiplier = (
-                (1 * self.units.rhoref_custom).to(self.units.rhoref_pyro).m
-            )
+        if rhoref._is_physical_or_simulation_unit() == "physical":
             self.define(
-                f"rhoref_custom_{self.name} = {custom_multiplier} * rhoref_pyro_{self.name}",
+                f"rhoref_pyro_{self.name} = {self.vref} / ({self.bref} / {self.mref} * qref)",
                 units=True,
             )
 
-        # Update the individual convention normalisations
-        for convention in self._conventions.values():
-            convention.set_rhoref()
+            self.define(
+                f"rhoref_gs2_{self.name} = (2 ** 0.5) * rhoref_pyro_{self.name}",
+                units=True,
+            )
 
-        self._update_references()
+            self.define(
+                f"rhoref_unit_{self.name} = {bunit_over_b0}**-1 * rhoref_pyro_{self.name}",
+                units=True,
+            )
 
-        self.context.add_transformation(
-            "[rhoref]",
-            self.pyrokinetics.rhoref.dimensionality,
-            lambda ureg, x: x.to(ureg.rhoref_pyro).m * self.pyrokinetics.rhoref,
-        )
+            if "rhoref_custom" in self.units:
+                custom_multiplier = (
+                    (1 * self.units.rhoref_custom).to(self.units.rhoref_pyro).m
+                )
+                self.define(
+                    f"rhoref_custom_{self.name} = {custom_multiplier} * rhoref_pyro_{self.name}",
+                    units=True,
+                )
 
-        self.units._build_cache()
+            # Update the individual convention normalisations
+            for convention in self._conventions.values():
+                convention.set_rhoref()
+
+            self._update_references()
+
+            self.context.add_transformation(
+                "[rhoref]",
+                self.pyrokinetics.rhoref.dimensionality,
+                lambda ureg, x: x.to(ureg.rhoref_pyro).m * self.pyrokinetics.rhoref,
+            )
+
+            self.units._build_cache()
+
+    def set_betaref(
+        self,
+        local_geometry: Optional[LocalGeometry] = None,
+    ):
+        """Set the gyroradius reference values for all the conventions
+        from the local geometry and kinetics
+
+        """
+
+        if local_geometry:
+            bunit_over_b0 = local_geometry.bunit_over_b0.m
+
+        beta_check = (
+            1.0 * (self.nref * self.tref) / self.bref**2
+        )._is_physical_or_simulation_unit()
+
+        if beta_check == "physical":
+            bref_type = str(self.bref).split("_")[1]
+            nref_type = str(self.nref).split("_")[1][0]
+            tref_type = str(self.tref).split("_")[1][0]
+            beta_ref_name = f"beta_ref_{nref_type}{tref_type}_{bref_type}_{self.name}"
+
+            self.define(
+                f"{beta_ref_name} = 2.0 * {self.units.mu0} * {self.nref} * {self.tref} / {self.bref}**2",
+                units=True,
+            )
+
+            if bref_type == "B0":
+                beta_ref_new_name = f"beta_ref_{nref_type}{tref_type}_Bunit_{self.name}"
+                self.define(
+                    f"{beta_ref_new_name} = {bunit_over_b0}**2 * {beta_ref_name}",
+                    units=True,
+                )
+            elif bref_type == "Bunit":
+                beta_ref_new_name = f"beta_ref_{nref_type}{tref_type}_B0_{self.name}"
+                self.define(
+                    f"{beta_ref_new_name} = {bunit_over_b0}**-2 * {beta_ref_name}",
+                    units=True,
+                )
+
+            # Update the individual convention normalisations
+            for convention in self._conventions.values():
+                convention.set_betaref()
+
+            self._update_references()
+
+            self.context.add_transformation(
+                "[beta_ref]",
+                self.pyrokinetics.beta_ref.dimensionality,
+                lambda ureg, x: x.to(ureg.beta_ref_ee_B0).m
+                * self.pyrokinetics.beta_ref,
+            )
+
+            self.units._build_cache()
 
     def set_ref_ratios(
         self,
@@ -847,7 +907,8 @@ class SimulationNormalisation(Normalisation):
 
     def set_all_references(
         self,
-        pyro,
+        aspect_ratio=None,
+        bunit_over_b0=None,
         tref_electron=None,
         nref_electron=None,
         bref_B0=None,
@@ -883,24 +944,25 @@ class SimulationNormalisation(Normalisation):
         self.define(f"mref_deuterium_{self.name} = mref_deuterium", units=True)
 
         if lref_minor_radius and lref_major_radius:
-            if (
-                lref_major_radius
-                != pyro.local_geometry.Rmaj.to(self.pyrokinetics.lref, self.context).m
-                * lref_minor_radius
-            ):
+            if aspect_ratio is None:
+                aspect_ratio = lref_major_radius / lref_minor_radius
+        elif lref_minor_radius and aspect_ratio:
+            lref_major_radius = lref_minor_radius * aspect_ratio
+        elif lref_major_radius and aspect_ratio:
+            lref_minor_radius = lref_major_radius / aspect_ratio
+
+        if aspect_ratio:
+            if lref_major_radius / lref_minor_radius != aspect_ratio:
                 raise ValueError(
-                    "Specified major radius and minor radius do not match, please check the data"
+                    "Specified major radius, minor radius and aspect ratio do not match"
+                    ", please check the data"
                 )
-        elif lref_minor_radius:
-            lref_major_radius = (
-                lref_minor_radius
-                * pyro.local_geometry.Rmaj.to(self.pyrokinetics.lref, self.context).m
-            )
-        elif lref_major_radius:
-            lref_minor_radius = (
-                lref_major_radius
-                / pyro.local_geometry.Rmaj.to(self.pyrokinetics.lref, self.context).m
-            )
+        else:
+            # Only option is to set conversion to NaN
+            if lref_minor_radius:
+                lref_major_radius = nan * lref_minor_radius
+            elif lref_major_radius:
+                lref_minor_radius = nan * lref_major_radius
 
         self.define(f"lref_minor_radius_{self.name} = {lref_minor_radius}", units=True)
         self.define(f"lref_major_radius_{self.name} = {lref_major_radius}", units=True)
@@ -914,7 +976,7 @@ class SimulationNormalisation(Normalisation):
             )
 
         # Physical units
-        bunit = bref_B0 * pyro.local_geometry.bunit_over_b0.m
+        bunit = bref_B0 * bunit_over_b0
         self.define(f"bref_B0_{self.name} = {bref_B0}", units=True)
         self.define(f"bref_Bunit_{self.name} = {bunit}", units=True)
         if hasattr(self.units, "bref_Bgeo"):
@@ -925,9 +987,25 @@ class SimulationNormalisation(Normalisation):
             self.define(f"bref_Bgeo_{self.name} = {bref_Bgeo}", units=True)
 
         self.define(
-            f"beta_ref_ee_Bunit = {pyro.local_geometry.bunit_over_b0.m}**2 beta_ref_ee_B0",
+            f"beta_ref_ee_Bunit = {bunit_over_b0}**2 beta_ref_ee_B0",
             context=True,
         )
+
+        self.define(
+            f"beta_ref_ee_B0_{self.name} = beta_ref_ee_B0",
+            units=True,
+        )
+        self.define(
+            f"beta_ref_ee_Bunit_{self.name} = {bunit_over_b0}**2 beta_ref_ee_B0_{self.name}",
+            units=True,
+        )
+
+        if hasattr(self.units, "bref_Bgeo"):
+            bref_Bgeo = (1.0 * self.units.bref_Bgeo).to("bref_B0", self.context).m
+            self.define(
+                f"beta_ref_ee_Bgeo_{self.name} = {bref_Bgeo}**-2 beta_ref_ee_B0_{self.name}",
+                units=True,
+            )
 
         self.define(
             f"vref_nrl_{self.name} = (tref_electron_{self.name} / mref_deuterium_{self.name})**(0.5)",
@@ -948,7 +1026,7 @@ class SimulationNormalisation(Normalisation):
         )
 
         self.define(
-            f"rhoref_unit_{self.name} = {pyro.local_geometry.bunit_over_b0.m}**-1 * rhoref_pyro_{self.name}",
+            f"rhoref_unit_{self.name} = {bunit_over_b0}**-1 * rhoref_pyro_{self.name}",
             units=True,
         )
 
@@ -961,6 +1039,7 @@ class SimulationNormalisation(Normalisation):
         # Update the individual convention normalisations
         for convention in self._conventions.values():
             convention.set_all_references()
+
         self._update_references()
 
         # Transformations between simulation and physical units
@@ -998,6 +1077,12 @@ class SimulationNormalisation(Normalisation):
             "[rhoref]",
             self.pyrokinetics.rhoref.dimensionality,
             lambda ureg, x: x.to(ureg.rhoref_pyro).m * self.pyrokinetics.rhoref,
+        )
+
+        self.context.add_transformation(
+            "[beta_ref]",
+            self.pyrokinetics.beta_ref.dimensionality,
+            lambda ureg, x: x.to(ureg.beta_ref_ee_B0).m * self.pyrokinetics.beta_ref,
         )
 
         self.units._build_cache()
@@ -1133,6 +1218,13 @@ class ConventionNormalisation(Normalisation):
             # nref/tref/bref, so we can't compute the beta.
             return 0.0 * self._registry.dimensionless
 
+    def set_betaref(self):
+        """Set the reference beta to the physical value"""
+        self.beta_ref = getattr(
+            self._registry, f"{self.convention.beta_ref}_{self.run_name}"
+        )
+        self._update_system()
+
     def set_bref(self):
         """Set the reference magnetic field to the physical value"""
         self.bref = getattr(self._registry, f"{self.convention.bref}_{self.run_name}")
@@ -1168,6 +1260,9 @@ class ConventionNormalisation(Normalisation):
         self.bref = getattr(self._registry, f"{self.convention.bref}_{self.run_name}")
         self.rhoref = getattr(
             self._registry, f"{self.convention.rhoref}_{self.run_name}"
+        )
+        self.beta_ref = getattr(
+            self._registry, f"{self.convention.beta_ref}_{self.run_name}"
         )
         self._update_system()
 

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -129,9 +129,9 @@ normalisations.
 import copy
 import warnings
 from typing import Dict, Optional
-from numpy import nan
 
 import pint
+from numpy import nan
 
 from pyrokinetics.kinetics import Kinetics
 from pyrokinetics.local_geometry import LocalGeometry

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -894,7 +894,7 @@ class SimulationNormalisation(Normalisation):
         elif lref_minor_radius:
             lref_major_radius = (
                 lref_minor_radius
-                * pyro.local_geometry.Rmaj.to(self.gene.lref, self.context).m
+                * pyro.local_geometry.Rmaj.to(self.pyrokinetics.lref, self.context).m
             )
         elif lref_major_radius:
             lref_minor_radius = (

--- a/src/pyrokinetics/numerics.py
+++ b/src/pyrokinetics/numerics.py
@@ -242,7 +242,16 @@ class Numerics:
             return c.beta_ref
         return units.dimensionless
 
-    def with_units(self, c: ConventionNormalisation):
+    def to(self, norms, context=None):
+        """Convert Numerics to specified convention"""
+        for key, val in self.items():
+            if val is None:
+                continue
+            if key in self._has_normalised_units:
+                if hasattr(val, "units"):
+                    setattr(self, key, val.to(norms, context))
+
+    def with_units(self, c: ConventionNormalisation, context=None):
         """
         Apply units to each quantity in turn and return a new ``Coords``.
         If units are already applied, renormalises according to the convention supplied.
@@ -254,13 +263,13 @@ class Numerics:
                 continue
             if key in self._has_normalised_units:
                 if hasattr(val, "units"):
-                    kwargs[key] = val.to(c)
+                    kwargs[key] = val.to(c, context)
                 else:
                     kwargs[key] = val * self.units(key, c)
                 continue
             if key in self._has_physical_units:
                 if hasattr(val, "units"):
-                    kwargs[key] = val.to(self.units(key, c))
+                    kwargs[key] = val.to(self.units(key, c), context)
                 else:
                     kwargs[key] = val * self.units(key, c)
                 continue

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -14,12 +14,12 @@ the following objects:
 from __future__ import annotations
 
 import copy
+import json
 import warnings
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-import json
 import f90nml
 import numpy as np
 
@@ -1969,17 +1969,17 @@ class Pyro:
             magnetic-field reference (tesla), and minor-radius scale (m); the
             major-radius entry is returned as None when unavailable.
         """
-        
+
         reference_dict = {
             "tref_electron": (1.0 * self.norms.tref).to(self.norms.units.eV),
             "nref_electron": (1.0 * self.norms.nref).to(self.norms.units.m**-3),
             "bref_B0": (1.0 * self.norms.bref).to(self.norms.units.tesla),
             "lref_minor_radius": (1.0 * self.norms.lref).to(self.norms.units.m),
-            "lref_major_radius": None
+            "lref_major_radius": None,
         }
 
         return reference_dict
-    
+
     def write_reference_values(
         self,
         filename: PathLike,
@@ -2040,7 +2040,7 @@ class Pyro:
             if magnitude is None or unit_str is None:
                 kwargs[name] = None
                 continue
-            kwargs[name]  = np.asarray(magnitude).squeeze() * units(unit_str)
+            kwargs[name] = np.asarray(magnitude).squeeze() * units(unit_str)
 
         self.set_reference_values(**kwargs)
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1971,10 +1971,10 @@ class Pyro:
         """
 
         reference_dict = {
-            "tref_electron": (1.0 * self.norms.tref).to(self.norms.units.eV),
-            "nref_electron": (1.0 * self.norms.nref).to(self.norms.units.m**-3),
-            "bref_B0": (1.0 * self.norms.bref).to(self.norms.units.tesla),
-            "lref_minor_radius": (1.0 * self.norms.lref).to(self.norms.units.m),
+            "tref_electron": (1.0 * self.norms.pyrokinetics.tref).to("eV"),
+            "nref_electron": (1.0 * self.norms.pyrokinetics.nref).to("m**-3"),
+            "bref_B0": (1.0 * self.norms.pyrokinetics.bref).to("tesla"),
+            "lref_minor_radius": (1.0 * self.norms.pyrokinetics.lref).to("m"),
             "lref_major_radius": None,
         }
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -49,7 +49,7 @@ from .normalisation import SimulationNormalisation
 from .numerics import Numerics
 from .templates import gk_templates
 from .typing import PathLike
-from .units import PyroQuantity, PyroNormalisationError
+from .units import PyroNormalisationError, PyroQuantity
 
 if TYPE_CHECKING:
     import xarray as xr

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1975,7 +1975,11 @@ class Pyro:
             "nref_electron": (1.0 * self.norms.pyrokinetics.nref).to("m**-3"),
             "bref_B0": (1.0 * self.norms.pyrokinetics.bref).to("tesla"),
             "lref_minor_radius": (1.0 * self.norms.pyrokinetics.lref).to("m"),
-            "lref_major_radius": None,
+            "lref_major_radius": (
+                (1.0 * self.local_geometry.Rmaj).to("m")
+                if hasattr(self, "local_geometry")
+                else None
+            ),
         }
 
         return reference_dict

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1955,6 +1955,8 @@ class Pyro:
             Minor radius of last closed flux surface
         lref_major_radius: [meter] pint.Quantity
             Major radius of local flux surface
+        convert_pyro: bool default True
+           Flag to convert the whole pyro object to specified Convention
 
         Returns
         -------
@@ -1988,7 +1990,7 @@ class Pyro:
         convention: Normalisation,
     ):
         """
-        Converts the LocalGeometry, LocalSpecies and Numerics objects
+        Converts the LocalGeometry, LocalSpecies, Numerics an GKOutput objects
         to the specified Convetion
 
         Parameters
@@ -2004,6 +2006,8 @@ class Pyro:
         self.local_species.to(convention, self.norms.context)
         self.local_geometry.to(convention, self.norms.context)
         self.numerics.to(convention, self.norms.context)
+        if self.gk_output:
+            self.gk_output.to(convention, self.norms.context)
 
     def get_reference_values(
         self,

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -19,6 +19,7 @@ from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import json
 import f90nml
 import numpy as np
 
@@ -1954,6 +1955,94 @@ class Pyro:
             lref_minor_radius=lref_minor_radius,
             lref_major_radius=lref_major_radius,
         )
+
+    def get_reference_values(
+        self,
+    ):
+        """
+        Collect the current normalisation reference quantities.
+
+        Returns
+        -------
+        dict
+            Mapping containing the electron temperature (eV), density (m**-3),
+            magnetic-field reference (tesla), and minor-radius scale (m); the
+            major-radius entry is returned as None when unavailable.
+        """
+        
+        reference_dict = {
+            "tref_electron": (1.0 * self.norms.tref).to(self.norms.units.eV),
+            "nref_electron": (1.0 * self.norms.nref).to(self.norms.units.m**-3),
+            "bref_B0": (1.0 * self.norms.bref).to(self.norms.units.tesla),
+            "lref_minor_radius": (1.0 * self.norms.lref).to(self.norms.units.m),
+            "lref_major_radius": None
+        }
+
+        return reference_dict
+    
+    def write_reference_values(
+        self,
+        filename: PathLike,
+    ):
+        """
+        Write the current normalisation reference quantities to a JSON file.
+
+        Parameters
+        ----------
+        filename: PathLike
+            Path to the file where the reference values will be written.
+
+        Returns
+        -------
+        ``None``
+        """
+
+        # Format values for .json file
+        values = {}
+        for name, value in self.get_reference_values().items():
+            if value is None:
+                values[name] = [None, None]
+                continue
+            values[name] = [[np.asarray(value.magnitude).tolist()], str(value.units)]
+
+        # Create directories if they don't exist already
+        filename = Path(filename)
+        filename.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write to file
+        with open(filename, "w", encoding="utf-8") as file:
+            json.dump(values, file, indent=4)
+
+    def read_reference_values(
+        self,
+        filename: PathLike,
+    ):
+        """
+        Load normalisation reference quantities from a JSON file.
+
+        Parameters
+        ----------
+        filename : PathLike
+            Path to the JSON file written by ``write_reference_values``.
+
+        Returns
+        -------
+        ``None``
+        """
+
+        with open(filename, "r", encoding="utf-8") as file:
+            values = json.load(file)
+
+        units = self.norms.units
+
+        kwargs = {}
+        for name, (magnitude, unit_str) in values.items():
+            if magnitude is None or unit_str is None:
+                kwargs[name] = None
+                continue
+            kwargs[name]  = np.asarray(magnitude).squeeze() * units(unit_str)
+
+        self.set_reference_values(**kwargs)
 
     # Utility for copying Pyro object
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -49,7 +49,7 @@ from .normalisation import SimulationNormalisation
 from .numerics import Numerics
 from .templates import gk_templates
 from .typing import PathLike
-from .units import PyroQuantity
+from .units import PyroQuantity, PyroNormalisationError
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -898,7 +898,6 @@ class Pyro:
             self.gk_input.convention = getattr(
                 self.norms, self.gk_input.norm_convention
             )
-
         # Set LocalGeometry, LocalSpecies, Numerics, unless told not to.
         if "local_geometry" not in no_process:
             self.local_geometry = self.gk_input.get_local_geometry()
@@ -907,6 +906,11 @@ class Pyro:
             self.local_species = self.gk_input.get_local_species()
         if "numerics" not in no_process:
             self.numerics = self.gk_input.get_numerics()
+
+        if self.local_geometry and self.local_species:
+            self._load_local_geometry_species_dependency(
+                set_gamma_exb=False, set_beta=False
+            )
 
         if norms:
             reference_dict = self.gk_input.get_reference_values(norms)
@@ -1717,6 +1721,9 @@ class Pyro:
             self.eq, psi_n=psi_n, norms=self.norms, show_fit=show_fit, **kwargs
         )
 
+        # Reset this
+        self._local_geometry_species_dependency = False
+
     def load_metric_terms(
         self, ntheta: Optional[int] = None, theta: Optional[List] = None
     ):
@@ -1810,6 +1817,9 @@ class Pyro:
         local_species.from_kinetics(self.kinetics, psi_n=psi_n, norm=self.norms)
         self.local_species = local_species
 
+        # Reset this
+        self._local_geometry_species_dependency = False
+
     def load_local(
         self,
         psi_n: float,
@@ -1866,7 +1876,7 @@ class Pyro:
         self._load_local_geometry_species_dependency()
 
     def _load_local_geometry_species_dependency(
-        self, set_rhoref=True, set_beta=True, set_gamma_exb=True
+        self, set_rhoref=True, set_beta=True, set_gamma_exb=True, set_beta_ref=True
     ):
         """
         Load data that requires both LocalGeometry and LocalSpecies to be present
@@ -1903,6 +1913,9 @@ class Pyro:
         if set_rhoref:
             self.norms.set_rhoref(local_geometry=self.local_geometry)
 
+        if set_beta_ref:
+            self.norms.set_betaref(local_geometry=self.local_geometry)
+
         # If we have both kinetics and eq file we should set beta/gamma_exb from there
         if self.numerics and set_beta:
             self.numerics.beta = None
@@ -1925,6 +1938,7 @@ class Pyro:
         bref_B0=None,
         lref_minor_radius=None,
         lref_major_radius=None,
+        convert_pyro=True,
     ):
         """
         Manually set the reference values used in normalisations
@@ -1946,15 +1960,50 @@ class Pyro:
         -------
         ``None``
         """
+        try:
+            aspect_ratio = self.local_geometry.Rmaj.to(
+                self.norms.pyrokinetics, self.norms.context
+            ).m
+        except PyroNormalisationError:
+            aspect_ratio = None
+
+        bunit_over_b0 = self.local_geometry.bunit_over_b0.m
 
         self.norms.set_all_references(
-            self,
+            aspect_ratio=aspect_ratio,
+            bunit_over_b0=bunit_over_b0,
             tref_electron=tref_electron,
             nref_electron=nref_electron,
             bref_B0=bref_B0,
             lref_minor_radius=lref_minor_radius,
             lref_major_radius=lref_major_radius,
         )
+
+        if convert_pyro:
+            convention = getattr(self.norms, self.gk_input.norm_convention)
+            self.to(convention)
+
+    def to(
+        self,
+        convention: Normalisation,
+    ):
+        """
+        Converts the LocalGeometry, LocalSpecies and Numerics objects
+        to the specified Convetion
+
+        Parameters
+        ----------
+        convention: ConventionNormalisation
+            ConventionNormalisation to convert all objects to
+
+        Returns
+        -------
+        ``None``
+
+        """
+        self.local_species.to(convention, self.norms.context)
+        self.local_geometry.to(convention, self.norms.context)
+        self.numerics.to(convention, self.norms.context)
 
     def get_reference_values(
         self,

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -26,6 +26,18 @@ class PyroNormalisationError(Exception):
         )
 
 
+class PyroContextError(Exception):
+    """Exception raised when trying to convert simulation units
+    requires physical reference values"""
+
+    def __init__(self, error_msg):
+        super().__init__()
+        self.error_msg = error_msg
+
+    def __str__(self):
+        return self.error_msg
+
+
 class Normalisation:
     """
     Base class for SimulationNormalisation and ConventionNormalisation.
@@ -97,6 +109,54 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
                 return base
         return None
 
+    def _is_physical_or_simulation_unit(self):
+        """If ``unit`` is a physical unit, return the type of base unit, else return None"""
+        base_dimensionality = [
+            "[beta_ref]",
+            "[bref]",
+            "[lref]",
+            "[mref]",
+            "[nref]",
+            "[qref]",
+            "[tref]",
+            "[vref]",
+            "[rhoref]",
+        ]
+        unit_dimensionality = list(self.dimensionality)
+        unit_match = list(set(unit_dimensionality) & set(base_dimensionality))
+
+        n_dimensionality = len(unit_dimensionality)
+        n_match = len(unit_match)
+        # Return dimensionless
+        if n_dimensionality == 0:
+            return "dimensionless"
+
+        # Check if any simulation units
+        if n_match > 0:
+            simulation = True
+        else:
+            simulation = False
+
+        # Check if any physical units
+        if n_match != n_dimensionality:
+            physical = True
+        else:
+            physical = False
+
+        # Edge case where elementary_charge is being used
+        if n_match == n_dimensionality - 2 and "elementary_charge" in str(self.units):
+            physical = False
+            simulation = True
+
+        if physical and simulation:
+            return "mixture"
+        elif physical:
+            return "physical"
+        elif simulation:
+            return "simulation"
+        else:
+            raise ValueError(f"Somehow {self} is not physical or simulation unit")
+
     def _convert_base_units(self, norm):
         """Replace base units with those for other normalisation"""
         units = dict()
@@ -125,10 +185,26 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
                 as_physical = self._convert_simulation_units(other)
                 value = as_physical.to(self._convert_base_units(other))
                 return self._replace_nan(value, other)
-        elif contexts and other != self.units:
-            with self._REGISTRY.context(*contexts, **ctx_kwargs):
-                as_physical = self._convert_simulation_units(*contexts)
-                return as_physical.to(other, **ctx_kwargs)
+        else:
+            unit_type = self._is_physical_or_simulation_unit()
+            output_type = self._REGISTRY.Quantity(
+                1, other
+            )._is_physical_or_simulation_unit()
+            if output_type != unit_type:
+                unit_type = "mixture"
+            if unit_type == "mixture":
+                if contexts:
+                    with self._REGISTRY.context(*contexts, **ctx_kwargs):
+                        as_physical = self._convert_simulation_units(*contexts)
+                        return as_physical.to(other, **ctx_kwargs)
+                else:
+                    try:
+                        return super().to(other, **ctx_kwargs)
+                    except pint.errors.DimensionalityError:
+                        raise PyroContextError(
+                            f"Trying to convert between physical and simulation units "
+                            f"'{self}' -> '{other}' without context. Please use a context here"
+                        )
 
         return super().to(other, *contexts, **ctx_kwargs)
 

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -71,7 +71,11 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
         for unit, power in self._units.items():
             if (new_unit := f"{unit}_{name}") in self._REGISTRY:
                 unit = new_unit
-            units[unit] = power
+            if unit not in units.keys():
+                units[unit] = power
+            else:
+                units[unit] += power
+        units = {k: v for k, v in units.items() if v != 0}
         return self._REGISTRY.Quantity(self._magnitude, pint.util.UnitsContainer(units))
 
     @staticmethod
@@ -99,7 +103,11 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
         for unit, power in self._units.items():
             if new_unit := self._is_base_unit(unit):
                 unit = str(getattr(norm, new_unit))
-            units[unit] = power
+            if unit not in units.keys():
+                units[unit] = power
+            else:
+                units[unit] += power
+        units = {k: v for k, v in units.items() if v != 0}
         return pint.util.UnitsContainer(units)
 
     def to(self, other=None, *contexts, **ctx_kwargs):
@@ -117,6 +125,10 @@ class PyroQuantity(pint.UnitRegistry.Quantity):
                 as_physical = self._convert_simulation_units(other)
                 value = as_physical.to(self._convert_base_units(other))
                 return self._replace_nan(value, other)
+        elif contexts and other != self.units:
+            with self._REGISTRY.context(*contexts, **ctx_kwargs):
+                as_physical = self._convert_simulation_units(*contexts)
+                return as_physical.to(other, **ctx_kwargs)
 
         return super().to(other, *contexts, **ctx_kwargs)
 

--- a/tests/gk_code/test_gk_code_output.py
+++ b/tests/gk_code/test_gk_code_output.py
@@ -31,6 +31,8 @@ def test_gk_codes_output():
     gs2.load_gk_output()
     gs2_expected = 0.05033878 + 0.03802604j
     assert_eigenvalue_close(gs2, gs2_expected)
+    gs2.to(gs2.norms.gs2)
+    assert_eigenvalue_close(gs2, gs2_expected / np.sqrt(2))
 
     # Test eigenvalue from CGYRO
     cgyro = Pyro(
@@ -39,6 +41,8 @@ def test_gk_codes_output():
     cgyro.load_gk_output()
     cgyro_expected = 1.164639 - 4.683715j
     assert_eigenvalue_close(cgyro, cgyro_expected)
+    cgyro.to(cgyro.norms.gs2)
+    assert_eigenvalue_close(cgyro, cgyro_expected / np.sqrt(2))
 
     # Test eigenvalue from GENE
     gene = Pyro(
@@ -48,6 +52,8 @@ def test_gk_codes_output():
     # TODO Is this correct?
     gene_expected = -12.93966796 + 1.93411654j
     assert_eigenvalue_close(gene, gene_expected)
+    gene.to(gene.norms.gs2)
+    assert_eigenvalue_close(gene, gene_expected / np.sqrt(2))
 
     # Test eigenvalue from TGLF
     tglf = Pyro(gk_file=template_dir / "outputs/TGLF_linear/input.tglf", gk_code="TGLF")
@@ -55,6 +61,8 @@ def test_gk_codes_output():
     # TODO Is this correct?
     tglf_expected = 0.048426 + 0.056637j
     assert_eigenvalue_close_tglf(tglf, tglf_expected)
+    tglf.to(tglf.norms.gs2)
+    assert_eigenvalue_close_tglf(tglf, tglf_expected / np.sqrt(2))
 
 
 @pytest.mark.parametrize("downsample", ({"time": slice(None, None, 3)},))

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -133,7 +133,12 @@ def test_set_all_references():
         "bref_B0": 2.0 * norm.units.tesla,
     }
 
-    norm.set_all_references(pyro, **reference_values)
+    aspect_ratio = pyro.local_geometry.Rmaj.to(
+        pyro.norms.pyrokinetics, pyro.norms.context
+    ).m
+    bunit_over_b0 = pyro.local_geometry.bunit_over_b0.m
+
+    norm.set_all_references(aspect_ratio, bunit_over_b0, **reference_values)
 
     assert np.isclose(1 * norm.tref, reference_values["tref_electron"])
     assert np.isclose(1 * norm.lref, reference_values["lref_minor_radius"])
@@ -170,11 +175,15 @@ def test_set_all_references_overwrite():
         "bref_B0": 2.0 * norm.units.tesla,
     }
 
-    norm.set_all_references(pyro, **reference_values)
-
     # Change all references and set again
     reference_values = {k: 2.0 * v for k, v in reference_values.items()}
-    norm.set_all_references(pyro, **reference_values)
+
+    aspect_ratio = pyro.local_geometry.Rmaj.to(
+        pyro.norms.pyrokinetics, pyro.norms.context
+    ).m
+    bunit_over_b0 = pyro.local_geometry.bunit_over_b0.m
+
+    norm.set_all_references(aspect_ratio, bunit_over_b0, **reference_values)
 
     assert np.isclose(1 * norm.tref, reference_values["tref_electron"])
     assert np.isclose(1 * norm.lref, reference_values["lref_minor_radius"])
@@ -779,7 +788,7 @@ def test_non_standard_normalisation_b(gk_code, geometry_sim_units):
         else:
             assert gk_input._convention_dict["bref"] == b_field
 
-            norm = SimulationNormalisation("nonstandard_b")
+            norm = SimulationNormalisation(f"nonstandard_b_{gk_code}")
             norm.add_convention_normalisation(
                 name="nonstandard", convention_dict=gk_input._convention_dict
             )
@@ -795,6 +804,21 @@ def test_non_standard_normalisation_b(gk_code, geometry_sim_units):
                     norm.nonstandard.rhoref, norm.context
                 ),
             )
+
+            reference_values = {
+                "tref_electron": 1000.0 * norm.units.eV,
+                "nref_electron": 1e19 * norm.units.meter**-3,
+                "lref_minor_radius": 1.5 * norm.units.meter,
+                "bref_B0": 2.0 * norm.units.tesla,
+            }
+
+            aspect_ratio = 3.0
+            bunit_over_b0 = 1.0
+
+            norm.set_all_references(aspect_ratio, bunit_over_b0, **reference_values)
+            assert np.isclose(1 * norm.tref, reference_values["tref_electron"])
+            assert np.isclose(1 * norm.lref, reference_values["lref_minor_radius"])
+            assert np.isclose(1 * norm.bref, reference_values["bref_B0"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -78,7 +78,7 @@ def test_beta_with_all_inputs(gk_file, gk_code):
     pyro.load_local(psi_n=0.5)
 
     beta = getattr(pyro.norms, gk_code.lower()).beta.to(pyro.norms.gs2)
-    assert np.isclose(beta, 0.006809175863428214 * ureg.beta_ref_ee_B0)
+    assert np.isclose(beta, 0.006809175863428214 * pyro.norms.gs2.beta_ref)
 
 
 @pytest.mark.parametrize(
@@ -155,6 +155,28 @@ def test_pyro_convert_gk_code(start_gk_code, end_gk_code):
     end_class_name = pyro.gk_input.__class__.__name__
     assert end_gk_code in end_class_name
     assert start_gk_code not in end_class_name
+
+
+@pytest.mark.parametrize(
+    "gk_file,gk_convention",
+    [
+        *product([gk_templates["GS2"]], ["pyrokinetics", "cgyro"]),
+        *product([gk_templates["CGYRO"]], ["gs2", "stella"]),
+        *product([gk_templates["GENE"]], ["gkw", "tglf"]),
+    ],
+)
+def test_pyro_to_convention(gk_file, gk_convention):
+    pyro = Pyro(gk_file=gk_file)
+
+    convention = getattr(pyro.norms, gk_convention)
+    pyro.to(convention)
+
+    assert pyro.local_geometry.B0.units == convention.bref
+    assert pyro.local_geometry.Rmaj.units == convention.lref
+    assert pyro.local_species.electron.nu.units == convention.vref / convention.lref
+    assert pyro.local_species.electron.dens.units == convention.nref
+    assert pyro.local_species.electron.temp.units == convention.tref
+    assert pyro.numerics.gamma_exb.units == convention.vref / convention.lref
 
 
 @pytest.mark.parametrize("eq_type", ["GEQDSK", "TRANSP"])

--- a/tests/test_pyro.py
+++ b/tests/test_pyro.py
@@ -24,6 +24,7 @@ from pyrokinetics.gk_code import (
 
 import xarray as xr
 import f90nml
+import json
 import pytest
 from itertools import product, permutations, combinations_with_replacement
 from pathlib import Path
@@ -742,3 +743,88 @@ def test_supported_kinetics_types():
     pyro = Pyro()
     assert isinstance(pyro.supported_kinetics_types, list)
     assert np.array_equal(pyro.supported_kinetics_types, supported_kinetics_types())
+
+
+@pytest.fixture(params=["GS2", "CGYRO", "GENE", "GX", "STELLA"])
+def pyro_with_reference_values(request):
+    pyro = Pyro(
+        gk_file=gk_templates[request.param],
+        eq_file=eq_templates["TRANSP"],
+        eq_kwargs={"time": 0.10, "neighbors": 64},
+        kinetics_file=kinetics_templates["TRANSP"],
+    )
+    pyro.load_local(psi_n=0.5, local_geometry="Miller")
+    return pyro
+
+
+def test_pyro_get_reference_values(pyro_with_reference_values):
+    ref_vals = pyro_with_reference_values.get_reference_values()
+    assert isinstance(ref_vals, dict)
+
+    # Check keys
+    assert "tref_electron" in ref_vals
+    assert "nref_electron" in ref_vals
+    assert "bref_B0" in ref_vals
+    assert "lref_minor_radius" in ref_vals
+    assert "lref_major_radius" in ref_vals
+
+    # Check units
+    assert ref_vals["tref_electron"].units == ureg.eV
+    assert ref_vals["nref_electron"].units == ureg.m**-3
+    assert ref_vals["bref_B0"].units == ureg.tesla
+    assert ref_vals["lref_minor_radius"].units == ureg.m
+
+
+def test_pyro_write_reference_values(pyro_with_reference_values, tmp_path):
+    pyro = pyro_with_reference_values
+    gk_code = pyro.gk_code
+
+    output_dir = tmp_path / "pyrokinetics_write_reference_values_text"
+    output_dir.mkdir()
+    output_file = output_dir / f"reference_values.{gk_code}"
+
+    pyro.write_reference_values(output_file)
+
+    assert output_file.exists()
+    with open(output_file, "r") as file:
+        data = json.load(file)
+
+    # Check all expected keys are present
+    expected_keys = [
+        "tref_electron",
+        "nref_electron",
+        "bref_B0",
+        "lref_minor_radius",
+        "lref_major_radius",
+    ]
+    assert all(key in data for key in expected_keys)
+
+
+def test_pyro_read_reference_values(pyro_with_reference_values, tmp_path):
+    pyro = pyro_with_reference_values
+    gk_code = pyro_with_reference_values.gk_code
+
+    output_dir = tmp_path / "pyrokinetics_write_reference_values_text"
+    output_dir.mkdir()
+    output_file = output_dir / f"reference_values.{gk_code}"
+
+    # Save and write initial reference values
+    ref_vals_initial = pyro.get_reference_values()
+    pyro.write_reference_values(output_file)
+
+    # Set to arbitrary values
+    pyro.set_reference_values(
+        tref_electron=2000.0 * ureg.eV,
+        nref_electron=4.50 * 1e19 * ureg.m**-3,
+        bref_B0=1.91 * ureg.tesla,
+        lref_minor_radius=0.60 * ureg.m,
+        lref_major_radius=None,
+    )
+
+    # Read and overwrite new values
+    pyro.read_reference_values(output_file)
+    ref_vals_final = pyro.get_reference_values()
+
+    # Check that the initial and final reference values are the same
+    for key in ref_vals_initial:
+        assert ref_vals_initial[key] == ref_vals_final[key]


### PR DESCRIPTION
I added some basic functionality to allow for the writing of local reference values to an external file. This, along with a `gk_input` file, will mean that one has complete information about the local surface, and so can convert local reference values to physical units. 

I am sure my implementation of `get_reference_values` is quite primitive, as I struggled to find a nice way of doing this that didn't lead to "cyclic dependencies" between units. I am sure you can do something better @bpatel2107. Also, is it worth adding in some round-trip tests to ensure this is working properly?