### PR TITLE
Use correct defn of Cy

### DIFF
--- a/src/pyrokinetics/diagnostics/saturation_rules.py
+++ b/src/pyrokinetics/diagnostics/saturation_rules.py
@@ -70,7 +70,6 @@ class SaturationRules:
             theta0s = [0.0]
 
         shat = pyro.local_geometry.shat
-        bunit_over_b0 = pyro.local_geometry.bunit_over_b0.m
 
         theta = data["theta"].data
         eigenfunctions = data["eigenfunctions"]
@@ -142,7 +141,7 @@ class SaturationRules:
             k_perp_interp = np.interp(theta, theta_long, k_perp_long)
             for iky, ky in enumerate(kys.data):
                 # Technically k_perp / ky
-                k_perp[iky, itheta0, :, :] = k_perp_interp.m * ky * bunit_over_b0
+                k_perp[iky, itheta0, :, :] = k_perp_interp.m * ky
 
         bmag = pyro.metric_terms.B_magnitude
 

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -811,9 +811,10 @@ class MetricTerms:  # CleverDict
             Perpendicular wavevector along the field line
         """
 
-        Cy = self.rho / self.q
+        B0 = self.B_magnitude.units
+        Cy = self.dpsidr / B0
 
-        shat = Cy * self.dqdr
+        shat = self.rho / self.q * self.dqdr
 
         # The total number of poloidal turns is 2*nperiod-1
         m = np.linspace(-(nperiod - 1), nperiod - 1, 2 * nperiod - 1)
@@ -844,7 +845,7 @@ class MetricTerms:  # CleverDict
         g_yy = np.tile(g_aa, 2 * nperiod - 1) * Cy**2
 
         # Actually kx / ky
-        kx = shat * (theta0 + m * 2.0 * np.pi)
+        kx = Cy * self.dqdr * (theta0 + m * 2.0 * np.pi)
 
         k_perp2 = g_xx * kx**2 + 2.0 * g_xy * kx + g_yy
 

--- a/tests/local_geometry/test_metric_terms.py
+++ b/tests/local_geometry/test_metric_terms.py
@@ -197,12 +197,8 @@ def test_k_perp(tmp_path, nperiod):
 
     gs2_output = Dataset(gs2_file.with_suffix(".out.nc"))
 
-    bunit_over_b0 = pyro.local_geometry.bunit_over_b0
     theta_gs2 = gs2_output["theta"][:].data
-    k_perp_gs2 = (
-        np.sqrt(gs2_output["kperp2"][0, 0, :].data / pyro.norms.gs2.rhoref**2)
-        / bunit_over_b0
-    )
+    k_perp_gs2 = np.sqrt(gs2_output["kperp2"][0, 0, :].data / pyro.norms.gs2.rhoref**2)
 
     pyro.load_metric_terms(ntheta=pyro.numerics.ntheta)
 


### PR DESCRIPTION
The calc of `k_perp` was using a slightly incorrect defn of $C_y = r/q$ where $y = C_y \alpha$, which is not consistent with what we assume which is $C_y= \frac{\partial \psi}{\partial r} \frac{1}{B_0}$ which led to factors of $B_{unit}/B_0$ all over the place where it shouldn't be so here we correct that. This comes up in the use of the MG saturation rule.