### PR TITLE
Add context to normalisation deepcopy and to consistent_beta_prime wi…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "freeqdsk ~= 0.5.0",
     "cleverdict >= 1.9.1",
     "xarray >= 2024.10.0, <=2024.11.0",
-    "pint ~= 0.23",
+    "pint >= 0.23, <=0.24.4",
     "pint-xarray == 0.4",
     "contourpy ~= 1.0",
     "xrft >= 1.0.0",

--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -366,6 +366,7 @@ class SimulationNormalisation(Normalisation):
         new_object = SimulationNormalisation("COPY")
         new_object.name = self.name
         new_object.units = self.units
+        new_object.context = self.context
         new_object._conventions = copy.deepcopy(self._conventions, memodict)
         new_object.default_convention = self.default_convention.name
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1125,13 +1125,9 @@ class Pyro:
         Force LocalGeometry attribute beta_prime to be consistent
         with Numerics and LocalSpecies object
         """
-        if (
-            self.local_geometry is None
-            or self.local_species is None
-            or self.numerics is None
-        ):
+        if self.local_geometry is None or self.local_species is None:
             raise ValueError(
-                "Please load local_species, local_geometry and numerics before calling enforce_consistent_beta_prime"
+                "Please load local_species and local_geometry before calling enforce_consistent_beta_prime"
             )
 
         beta_prime_units = self.local_geometry.beta_prime.units
@@ -1140,7 +1136,16 @@ class Pyro:
             1 * self.norms.pyrokinetics.bref**2 / self.norms.pyrokinetics.lref
         ).to(beta_prime_units, self.norms.context)
 
-        beta = self.numerics.beta if self.numerics.beta is not None else self.norms.beta
+        beta = (
+            self.numerics.beta
+            if getattr(self.numerics, "beta", None) is not None
+            else self.norms.beta
+        )
+
+        if beta is None:
+            raise ValueError(
+                "Please ensure beta is set either via Numerics or Normalisation"
+            )
 
         self.local_geometry.beta_prime = (
             -(
@@ -1939,8 +1944,11 @@ class Pyro:
             self.norms.set_betaref(local_geometry=self.local_geometry)
 
         # If we have both kinetics and eq file we should set beta/gamma_exb from there
-        if self.numerics and set_beta:
-            self.numerics.beta = None
+        if self.numerics:
+            if set_beta:
+                self.numerics.beta = self.norms.beta
+            else:
+                self.numerics.beta = None
 
             self._check_beta_consistency()
 

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -620,7 +620,7 @@ class Pyro:
         # Switch context and overwrite everything
         self._switch_gk_context(gk_code, template_file, force_overwrite=True)
 
-    def add_template_file(self, gk_code: str, template_file: PathLike = None) -> None:
+    def load_template_file(self, gk_code: str, template_file: PathLike = None) -> None:
         """
         Load a template file into the current gyrokinetics context creating a gk_input,
         gk_file, file_name, run_directory already associated with it.

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -620,6 +620,54 @@ class Pyro:
         # Switch context and overwrite everything
         self._switch_gk_context(gk_code, template_file, force_overwrite=True)
 
+    def add_template_file(self, gk_code: str, template_file: PathLike = None) -> None:
+        """
+        Load a template file into the current gyrokinetics context creating a gk_input,
+        gk_file, file_name, run_directory already associated with it.
+
+        Will create a new context if one is not already present. If provided with a
+        template file, this will be used to create a new GKInput object, which will then
+        be modified by the current ``local_geometry``, ``local_species``, and
+        ``numerics`` (if present). If no template file is specified, the default
+        template corresponding to ``gk_code`` is used instead.
+
+        If you don't wish to use the current ``local_geometry``, ``local_species`` and
+        ``numerics``, it is recommended to use the function ``read_gk_file`` instead.
+
+        Parameters
+        ----------
+        gk_code: str
+            The gyrokinetics code to convert to. Must be a value in
+            ``supported_gk_inputs``.
+        template_file: PathLike, default ``None``
+            The template file used to populate the new GKInput created. Note that some
+            inputs in the template file will be overwritten with the contents of the
+            current ``local_geometry``, ``local_species`` and ``numerics``. If ``None``,
+            uses the default template file corresponding to ``gk_code``
+
+        Returns
+        -------
+        ``None``
+
+        Raises
+        ------
+        ValueError
+            Provided gk_code is not in ``supported_gk_inputs``.
+        RuntimeError
+            If ``check_gk_code()`` fails.
+        Exception
+            A large variety of errors could occur when building a GKInput from a
+            template file, or setting its values using the current ``local_geometry``,
+            ``local_species``, and ``numerics``.
+
+        """
+        # Ensure gk_code is valid
+        if gk_code not in self.supported_gk_inputs:
+            raise ValueError(f"Pyro: Cannot convert to gk_code '{gk_code}'")
+
+        # Switch context and overwrite everything
+        self._switch_gk_context(gk_code, template_file, force_overwrite=True)
+
     def add_flags(self, flags: Dict[str, Any]) -> None:
         """
         Adds flags to ``gk_input``. Sets ``local_geometry``, ``local_species`` and

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1992,8 +1992,8 @@ class Pyro:
             self.norms.set_betaref(local_geometry=self.local_geometry)
 
         # If we have both kinetics and eq file we should set beta/gamma_exb from there
-        if self.numerics:
-            if set_beta:
+        if self.numerics and set_beta:
+            if self.norms.beta.m != 0:
                 self.numerics.beta = self.norms.beta
             else:
                 self.numerics.beta = None

--- a/src/pyrokinetics/pyro.py
+++ b/src/pyrokinetics/pyro.py
@@ -1135,9 +1135,10 @@ class Pyro:
             )
 
         beta_prime_units = self.local_geometry.beta_prime.units
+
         beta_prime_units = (
             1 * self.norms.pyrokinetics.bref**2 / self.norms.pyrokinetics.lref
-        ).to(beta_prime_units)
+        ).to(beta_prime_units, self.norms.context)
 
         beta = self.numerics.beta if self.numerics.beta is not None else self.norms.beta
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -18,11 +18,29 @@ def default_pyro():
     return pyro
 
 
+@pytest.fixture
+def default_pyro_gk_file():
+    pyro = Pyro(
+        gk_file=template_dir / "input.cgyro",
+    )
+    return pyro
+
+
 def get_from_dict(data_dict, map_list):
     """
     Gets item in dict given location as a list of string
     """
     return reduce(operator.getitem, map_list, data_dict)
+
+
+def test_deepcopy_pyro_norm(tmp_path, default_pyro_gk_file):
+    pyro = default_pyro_gk_file
+    copy_pyro = deepcopy(pyro)
+
+    pyro.enforce_consistent_beta_prime()
+    copy_pyro.enforce_consistent_beta_prime()
+
+    assert pyro.local_geometry.beta_prime == copy_pyro.local_geometry.beta_prime
 
 
 def test_deepcopy_pyro(tmp_path, default_pyro):


### PR DESCRIPTION
…th test


Previously using `deepcopy` on the `Pyro` object would go through and copy over all the contained objects but when copying over  the `Normalisation` `Context` was not being included in the copy so converting between `bref_B0` and `bref_Bunit` for example was not working.

Also adds in a missing context for `enforce_consistent_beta_prime`