### PR TITLE
Add to method to metric, force gs2 units for IBM and get_gs2_geometry

### DIFF
--- a/src/pyrokinetics/diagnostics/__init__.py
+++ b/src/pyrokinetics/diagnostics/__init__.py
@@ -268,6 +268,7 @@ class Diagnostics:
         self.pyro.load_metric_terms(theta=theta_even)
 
         metric = self.pyro.metric_terms
+        metric.to(self.pyro.norms.gs2, self.pyro.norms.context)
 
         theta = metric.regulartheta * units.radians
 

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -142,9 +142,16 @@ class MetricTerms:  # CleverDict
 
         # This defines the reference magnetic field as B0:
         # dpsidr / (B0 * a) = <Jacobian * g^zetazeta> * (R0 / a) / q
-        # self.dpsidr = self.Y * local_geometry.Rmaj / self.q * ureg.bref_B0
+        bref_units = local_geometry.B0.units
+
+        # Needs to explicitly be 1 * B0 regardless of units
+        if "Bunit" in str(bref_units):
+            bref_units *= 1.0 / local_geometry.bunit_over_b0
+        elif "B0" not in str(bref_units):
+            raise ValueError("Need to convert to a standard normalisation first")
+
+        self.dpsidr = self.Y * local_geometry.Rmaj / self.q * bref_units
         # dpsidr may not match exactly when loading from global_eq
-        self.dpsidr = local_geometry.dpsidr
 
         # rho is defined as r / a
         self.rho = local_geometry.rho
@@ -866,3 +873,10 @@ class MetricTerms:  # CleverDict
         k_perp = np.sqrt(k_perp2) * ky
 
         return theta, k_perp
+
+    def to(self, norms, context=None):
+        """Thin wrapper for normalise"""
+
+        for key, value in self.__dict__.items():
+            if hasattr(value, "units"):
+                setattr(self, key, value.to(norms, context))

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -142,7 +142,7 @@ class MetricTerms:  # CleverDict
 
         # This defines the reference magnetic field as B0:
         # dpsidr / (B0 * a) = <Jacobian * g^zetazeta> * (R0 / a) / q
-        bref_units = local_geometry.B0.units
+        bref_units = local_geometry.dpsidr.units / local_geometry.rho.units
 
         # Needs to explicitly be 1 * B0 regardless of units
         if "Bunit" in str(bref_units):


### PR DESCRIPTION
The IBM calculation uses `MetricTerms` which will change depending the choice of units. This propagates through to the IBM calc via `get_gs2_geometry`. In the IBM calc itself we drop the units so depending on which code you start from you will get a different answer (scaled by some constant factor). Here I force the units to be in GS2 units so we always get the same value.

We also force the `MetricTerms` calculation to use a completely consistent `dpsidr` calculate with `r`, `q` and `Jacobian` rather than the `dpsidr` that was put into `LocalGeometry` (which is set before things like `q` can be changed). This ensure that changes to `q` are appropriately calculated.