### PR TITLE
Added functionality to store the runfile_dict in a pyroscan in json, and load it back at a later point. no a breaking change but default dictionaty format for runfile_dict is now a string to allow for json saving

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -112,9 +112,7 @@ class PyroScan:
                             value[param_key] = param_value[0] * ureg(param_value[-1])
                         else:
                             value[param_key] = param_value[:]
-                elif key == "runfile_dict":
-                    self.runfile_dict = value  # I think this logic is correct?
-                elif (
+                if (
                     key == "base_directory"
                     and base_directory != "."
                     and base_directory != value
@@ -150,7 +148,10 @@ class PyroScan:
             # Check if the runfile_dict still uses tuple keys
             if key_str not in self.runfile_dict:
                 # Try matching the tuple version if it exists
-                tuple_key = tuple(f"{k}_{v}" for k, v in parameters.items())
+                tuple_key = tuple(
+                    f"{k}_{v.magnitude if isinstance(v, Quantity) else v}"
+                    for k, v in parameters.items()
+                )
                 if tuple_key in self.runfile_dict:
                     # Convert the entire dict to string keys for future use
                     self.runfile_dict = {

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -139,7 +139,7 @@ class PyroScan:
         Concatenate parameter names/values with separator.
         Handles both tuple-style and string-style runfile_dict keys for backward compatibility.
         """
-        if self.runfile_dict is not None:
+        if self.runfile_dict:
             # Generate the string form of the key
             key_str = "_".join(
                 f"{k}_{v.magnitude if isinstance(v, Quantity) else v}"
@@ -161,6 +161,7 @@ class PyroScan:
                     raise KeyError(
                         f"Runfile key not found for parameters: {parameters}. "
                         f"Tried both '{key_str}' and {tuple_key}."
+                        f"This comes from the runfile_dict {self.runfile_dict}."
                     )
 
             # Ensure we always save the runfile_dict into the JSON
@@ -169,8 +170,13 @@ class PyroScan:
             # Return the value (now guaranteed to exist)
             return self.runfile_dict[key_str]
 
-        # If no runfile_dict exists, handle gracefully
-        return None
+        else:
+            return self.parameter_separator.join(
+                (
+                    f"{param}{self.value_separator}{getattr(value, 'magnitude', value):{self.value_fmt}}"
+                    for param, value in parameters.items()
+                )
+            )
 
     def create_single_run(self, parameters: dict):
         """

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -12,6 +12,7 @@ from itertools import product
 import numpy as np
 import pint
 import xarray as xr
+from pint import Quantity
 
 from .dataset_wrapper import DatasetWrapper
 from .gk_code import GKInput
@@ -37,6 +38,7 @@ class PyroScan:
         "parameter_dict",
         "file_name",
         "base_directory",
+        "runfile_dict",
         "p_prime_type",
         "parameter_map",
     ]
@@ -80,7 +82,7 @@ class PyroScan:
         else:
             self.file_name = GKInput._factory[pyro.gk_code].default_file_name
 
-        self.run_directories = None
+        self.runfile_dict = runfile_dict or {}
 
         if isinstance(pyro, Pyro):
             self.base_pyro = pyro
@@ -110,7 +112,9 @@ class PyroScan:
                             value[param_key] = param_value[0] * ureg(param_value[-1])
                         else:
                             value[param_key] = param_value[:]
-                if (
+                elif key == "runfile_dict":
+                    self.runfile_dict = value  # I think this logic is correct?
+                elif (
                     key == "base_directory"
                     and base_directory != "."
                     and base_directory != value
@@ -125,9 +129,6 @@ class PyroScan:
         # Get len of values for each parameter
         self.value_size = [len(value) for value in self.parameter_dict.values()]
 
-        # Used to overwrite default pyro method of reading files
-        self.runfile_dict = runfile_dict
-
         self.pyro_dict = dict(
             self.create_single_run(run) for run in self.outer_product()
         )
@@ -135,18 +136,41 @@ class PyroScan:
 
     def format_single_run_name(self, parameters):
         """
-        Concatenate parameter names/values with separator
+        Concatenate parameter names/values with separator.
+        Handles both tuple-style and string-style runfile_dict keys for backward compatibility.
         """
         if self.runfile_dict is not None:
-            key = tuple(f"{key}_{value}" for key, value in parameters.items())
-            return self.runfile_dict[key]
-        else:
-            return self.parameter_separator.join(
-                (
-                    f"{param}{self.value_separator}{getattr(value, 'magnitude', value):{self.value_fmt}}"
-                    for param, value in parameters.items()
-                )
+            # Generate the string form of the key
+            key_str = "_".join(
+                f"{k}_{v.magnitude if isinstance(v, Quantity) else v}"
+                for k, v in parameters.items()
             )
+            # Since when you load a file parameters are given units you need to remove units before formatting into a string
+            # --- Backward compatibility layer ---
+            # Check if the runfile_dict still uses tuple keys
+            if key_str not in self.runfile_dict:
+                # Try matching the tuple version if it exists
+                tuple_key = tuple(f"{k}_{v}" for k, v in parameters.items())
+                if tuple_key in self.runfile_dict:
+                    # Convert the entire dict to string keys for future use
+                    self.runfile_dict = {
+                        "_".join(k): v if isinstance(k, tuple) else v
+                        for k, v in self.runfile_dict.items()
+                    }
+                else:
+                    raise KeyError(
+                        f"Runfile key not found for parameters: {parameters}. "
+                        f"Tried both '{key_str}' and {tuple_key}."
+                    )
+
+            # Ensure we always save the runfile_dict into the JSON
+            self.pyroscan_json["runfile_dict"] = self.runfile_dict
+
+            # Return the value (now guaranteed to exist)
+            return self.runfile_dict[key_str]
+
+        # If no runfile_dict exists, handle gracefully
+        return None
 
     def create_single_run(self, parameters: dict):
         """
@@ -188,7 +212,6 @@ class PyroScan:
         for parameter, run_dir, pyro in zip(
             self.outer_product(), self.run_directories, self.pyro_dict.values()
         ):
-
             # Write input file
             pyro.write_gk_file(
                 file_name=run_dir / self.file_name, template_file=template_file
@@ -397,7 +420,6 @@ class PyroScan:
             # Load gk_output in copies of pyro
             for pyro in self.pyro_dict.values():
                 try:
-
                     pyro.load_gk_output(output_convention=output_convention)
 
                     if "mode" in pyro.gk_output.dims:
@@ -664,7 +686,6 @@ class NumpyEncoder(json.JSONEncoder):
 
 class PyroScanGKOutput(DatasetWrapper):
     def __init__(self, dataset: xr.Dataset):
-
         data_vars = dataset.data_vars
         coords = dataset.coords
         attrs = dataset.attrs

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 import sys
+import pytest
 
 docs_dir = Path(__file__).parent.parent / "docs"
 sys.path.append(str(docs_dir))
@@ -33,9 +34,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(
-                        left[json_key], right[json_key]
-                    ), f"{left} != {right}"
+                    assert np.allclose(left[json_key], right[json_key]), (
+                        f"{left} != {right}"
+                    )
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -43,20 +44,73 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
             assert np.allclose(left, right), f"{left} != {right}"
 
 
-def test_compare_read_write_pyroscan(tmp_path):
+PYROSCAN_CONFIGS = [
+    # Simple numerics scan
+    {"parameter_dict": {"ky": np.array([0.1, 0.2])}, "runfile_dict": None},
+    # Local geometry scan
+    {"parameter_dict": {"kappa": np.array([0.1, 0.2, 0.3])}, "runfile_dict": None},
+    # Species gradient scan
+    {
+        "parameter_dict": {"electron_temp_gradient": np.array([1.0, 2.0])},
+        "runfile_dict": None,
+    },
+    # Runfile dict with string keys — tests new feature
+    {
+        "parameter_dict": {"beta": np.array([0.005, 0.01])},
+        "runfile_dict": {
+            "beta_0.005": "this_file_has_a_beta_005",
+            "beta_0.01": "this_file_has_a_beta_010",
+        },
+        "parameter_keys": [
+            {"key": "beta", "attr": "numerics", "location": ["beta"]},
+        ],
+    },
+    {
+        "parameter_dict": {
+            # Typical ky unit: 1/rho_ref in GENE/GS2
+            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
+        },
+        "runfile_dict": None,
+    },
+]
+
+
+@pytest.fixture(params=PYROSCAN_CONFIGS)
+def param_pyroscan(request, tmp_path):
+    cfg = request.param
+
     pyro = example_SCENE.main(tmp_path)
 
-    parameter_dict = {"ky": [0.1, 0.2, 0.3]}
+    ps = PyroScan(
+        pyro,
+        parameter_dict=cfg["parameter_dict"],
+        runfile_dict=cfg.get("runfile_dict"),
+        base_directory=tmp_path,
+    )
 
-    initial_pyroscan = PyroScan(pyro, parameter_dict=parameter_dict)
+    # Apply additional parameter key mappings if provided
+    for pk in cfg.get("parameter_keys", []):
+        ps.add_parameter_key(
+            parameter_key=pk["key"],
+            parameter_attr=pk["attr"],
+            parameter_location=pk["location"],
+        )
 
-    initial_pyroscan.write(file_name="test_pyroscan.input", base_directory=tmp_path)
+    return ps
 
-    pyroscan_json = tmp_path / "pyroscan.json"
 
-    new_pyroscan = PyroScan(pyro, pyroscan_json=pyroscan_json)
+def test_read_write_parametrized(param_pyroscan, tmp_path):
+    """Runs read/write comparison on all parametrized PyroScan configurations."""
 
-    comparison_attrs = [
+    ps = param_pyroscan
+
+    # Write the pyroscan
+    ps.write(file_name="param_test.in", base_directory=tmp_path)
+
+    # Read it back
+    loaded = PyroScan(ps.base_pyro, pyroscan_json=tmp_path / "pyroscan.json")
+
+    for attr in [
         "base_directory",
         "file_name",
         "p_prime_type",
@@ -67,9 +121,32 @@ def test_compare_read_write_pyroscan(tmp_path):
         "run_directories",
         "value_fmt",
         "value_size",
-    ]
-    for attrs in comparison_attrs:
-        assert_close_or_equal(attrs, initial_pyroscan, new_pyroscan)
+    ]:
+        assert_close_or_equal(attr, ps, loaded)
+
+
+def test_runfile_dict_tuple_migration(tmp_path):
+    """Ensure tuple keys in runfile_dict are migrated to strings."""
+
+    pyro = example_SCENE.main(tmp_path)
+
+    old_style = {
+        ("ky_0.1",): "dir1",
+        ("ky_0.2",): "dir2",
+    }
+
+    ps = PyroScan(
+        pyro,
+        parameter_dict={"ky": np.array([0.1, 0.2])},
+        runfile_dict=old_style,
+        base_directory=tmp_path,
+    )
+
+    ps.write(file_name="migrate.in", base_directory=tmp_path)
+
+    loaded = PyroScan(pyro, pyroscan_json=tmp_path / "pyroscan.json")
+
+    assert all(isinstance(k, str) for k in loaded.runfile_dict.keys())
 
 
 def test_format_run_name():
@@ -118,9 +195,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[species].inverse_ln = (
-                    pyro.local_species.electron.inverse_ln
-                )
+                pyro.local_species[
+                    species
+                ].inverse_ln = pyro.local_species.electron.inverse_ln
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -34,9 +34,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(left[json_key], right[json_key]), (
-                        f"{left} != {right}"
-                    )
+                    assert np.allclose(
+                        left[json_key], right[json_key]
+                    ), f"{left} != {right}"
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -68,7 +68,8 @@ PYROSCAN_CONFIGS = [
     {
         "parameter_dict": {
             # Typical ky unit: 1/rho_ref in GENE/GS2
-            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
+            "ky": np.array([0.1, 0.2])
+            / units.rhoref_pyro
         },
         "runfile_dict": None,
     },
@@ -195,9 +196,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[
-                    species
-                ].inverse_ln = pyro.local_species.electron.inverse_ln
+                pyro.local_species[species].inverse_ln = (
+                    pyro.local_species.electron.inverse_ln
+                )
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)


### PR DESCRIPTION
Previously if you set a custome runfile_dict for a pyroscan it wouldn't be scanned and therefore the pyroscan wouldn't correctly to the gk outputs. I changed the json saving to save the runfile_dict and load it. Since Json doesn't allow storage of tuples I created code to change the runfile_dict key to a string. This string can be given explicitly or the old tuple style format can be given and it is converted into a string