### PR TITLE
Added missing Bgeo option

### DIFF
--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -145,7 +145,7 @@ class MetricTerms:  # CleverDict
         bref_units = local_geometry.dpsidr.units / local_geometry.rho.units
 
         # Needs to explicitly be 1 * B0 regardless of units
-        if "Bunit" in str(bref_units):
+        if "Bunit" or "Bgeo" in str(bref_units):
             bref_units *= 1.0 / local_geometry.bunit_over_b0
         elif "B0" not in str(bref_units):
             raise ValueError("Need to convert to a standard normalisation first")

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -145,9 +145,9 @@ class MetricTerms:  # CleverDict
         bref_units = local_geometry.dpsidr.units / local_geometry.rho.units
 
         # Needs to explicitly be 1 * B0 regardless of units
-        if "Bunit" or "Bgeo" in str(bref_units):
+        if "Bunit" in str(bref_units):
             bref_units *= 1.0 / local_geometry.bunit_over_b0
-        elif "B0" not in str(bref_units):
+        elif "B0" and "Bgeo" not in str(bref_units):
             raise ValueError("Need to convert to a standard normalisation first")
 
         self.dpsidr = self.Y * local_geometry.Rmaj / self.q * bref_units


### PR DESCRIPTION
This fixes a bug introduced in PR501 that was causing some of my codes to fail.  "Bgeo", in addition to "B0" and "Bunit", is a normalisation that can be available for Bref.

This fixes the bug and I think treats the Bgeo case correctly, but do correct me if I'm wrong on the latter @bpatel2107 .
I'm directing the review to d7919 as bpatel2107 is currently on Leave.