### PR TITLE
Bugfix/local geometry b0

### DIFF
--- a/docs/examples/example_gs2.py
+++ b/docs/examples/example_gs2.py
@@ -2,32 +2,9 @@ import pyrokinetics
 
 gs2_template = pyrokinetics.template_dir / "input.gs2"
 
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gs2")
-print(pyro.local_geometry.B0)
+pyro = pyrokinetics.Pyro(gk_file=gs2_template, gk_code="GS2")
 
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.stella")
-print(pyro.local_geometry.B0)
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gx")
-print(pyro.local_geometry.B0)
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gkw")
-print(pyro.local_geometry.B0)
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.cgyro")
-print(pyro.local_geometry.B0)
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gene")
-print(pyro.local_geometry.B0)
-
-pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.tglf")
-print(pyro.local_geometry.B0)
-exit()
 flags = {
-
-
-
     "gs2_diagnostics_knobs": {
         "write_fields": True,
         "write_kpar": True,

--- a/docs/examples/example_gs2.py
+++ b/docs/examples/example_gs2.py
@@ -2,9 +2,32 @@ import pyrokinetics
 
 gs2_template = pyrokinetics.template_dir / "input.gs2"
 
-pyro = pyrokinetics.Pyro(gk_file=gs2_template, gk_code="GS2")
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gs2")
+print(pyro.local_geometry.B0)
 
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.stella")
+print(pyro.local_geometry.B0)
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gx")
+print(pyro.local_geometry.B0)
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gkw")
+print(pyro.local_geometry.B0)
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.cgyro")
+print(pyro.local_geometry.B0)
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.gene")
+print(pyro.local_geometry.B0)
+
+pyro = pyrokinetics.Pyro(gk_file=pyrokinetics.template_dir / "input.tglf")
+print(pyro.local_geometry.B0)
+exit()
 flags = {
+
+
+
     "gs2_diagnostics_knobs": {
         "write_fields": True,
         "write_kpar": True,

--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -292,8 +292,8 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 f"LocalGeometry type {eq_type} not implemented for CGYRO"
             )
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= 1.0 / local_geometry.bunit_over_b0
+        local_geometry.B0 = 1.0 / local_geometry.bunit_over_b0
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 
@@ -322,24 +322,17 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             Te,
         ) = self.get_ne_te_normalisation()
         beta = self.data.get("BETAE_UNIT", 0.0) / (ne * Te)
-        if beta != 0:
-            miller_data["B0"] = 1 / beta**0.5
-        else:
-            miller_data["B0"] = None
 
         # Need species to set up beta_prime
         local_species = self.get_local_species()
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
-        if miller_data["B0"] is not None:
-            miller_data["beta_prime"] = (
-                -local_species.inverse_lp.m
-                * local_species.pressure.m
-                * beta_prime_scale
-                / miller_data["B0"] ** 2
-            )
-        else:
-            miller_data["beta_prime"] = 0.0
+        miller_data["beta_prime"] = (
+            -local_species.inverse_lp.m
+            * local_species.pressure.m
+            * beta_prime_scale
+            * beta
+        )
 
         miller = LocalGeometryMiller.from_gk_data(miller_data)
 
@@ -387,24 +380,17 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             Te,
         ) = self.get_ne_te_normalisation()
         beta = self.data.get("BETAE_UNIT", 0.0) / (ne * Te)
-        if beta != 0:
-            mxh_data["B0"] = 1 / beta**0.5
-        else:
-            mxh_data["B0"] = None
 
         # Need species to set up beta_prime
         local_species = self.get_local_species()
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
-        if mxh_data["B0"] is not None:
-            mxh_data["beta_prime"] = (
-                -local_species.inverse_lp.m
-                * local_species.pressure.m
-                * beta_prime_scale
-                / mxh_data["B0"] ** 2
-            )
-        else:
-            mxh_data["beta_prime"] = 0.0
+        mxh_data["beta_prime"] = (
+            -local_species.inverse_lp.m
+            * local_species.pressure.m
+            * beta_prime_scale
+            * beta
+        )
 
         mxh = LocalGeometryMXH.from_gk_data(mxh_data)
 
@@ -429,24 +415,17 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
             Te,
         ) = self.get_ne_te_normalisation()
         beta = self.data.get("BETAE_UNIT", 0.0) / (ne * Te)
-        if beta != 0:
-            fourier_data["B0"] = 1 / beta**0.5
-        else:
-            fourier_data["B0"] = None
 
         # Need species to set up beta_prime
         local_species = self.get_local_species()
         beta_prime_scale = self.data.get("BETA_STAR_SCALE", 1.0)
 
-        if fourier_data["B0"] is not None:
-            fourier_data["beta_prime"] = (
-                -local_species.inverse_lp.m
-                * local_species.pressure.m
-                * beta_prime_scale
-                / fourier_data["B0"] ** 2
-            )
-        else:
-            fourier_data["beta_prime"] = 0.0
+        fourier_data["beta_prime"] = (
+            -local_species.inverse_lp.m
+            * local_species.pressure.m
+            * beta_prime_scale
+            * beta
+        )
 
         fourier = LocalGeometryFourierCGYRO.from_gk_data(fourier_data)
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -388,10 +388,6 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             Te,
         ) = self.get_ne_te_normalisation()
         beta = self.data["general"].get("beta", 0.0) / ne
-        if beta != 0.0:
-            local_geometry_data["B0"] = np.sqrt(1.0 / beta)
-        else:
-            local_geometry_data["B0"] = None
 
         dpdx = self.data["geometry"].get("dpdx_pm", -2)
         amhd = self.data["geometry"].get("amhd", 0.0)
@@ -402,21 +398,18 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                 local_geometry_data["q"] ** 2 * local_geometry_data["Rmaj"]
             )
         else:
-            if local_geometry_data["B0"] is not None:
-                amhd_beta_prime = (
-                    -local_species.inverse_lp.m
-                    * local_species.pressure.m
-                    / local_geometry_data["B0"] ** 2
-                )
-            else:
-                amhd_beta_prime = 0.0
+            amhd_beta_prime = (
+                -local_species.inverse_lp.m
+                * local_species.pressure.m
+                * beta
+            )
 
         if dpdx == -1:
             if local_geometry_data["B0"] is not None:
                 local_geometry_data["beta_prime"] = (
                     -local_species.inverse_lp.m
                     * local_species.pressure.m
-                    / local_geometry_data["B0"] ** 2
+                    * beta
                 )
             else:
                 local_geometry_data["beta_prime"] = 0.0
@@ -449,9 +442,9 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             norms = Normalisation("get_local_geometry")
             convention = getattr(norms, self.norm_convention)
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
         _, _, rgeo_rmaj = self._get_rgeo_rmaj()
-        local_geometry.dpsidr = local_geometry.dpsidr * rgeo_rmaj
+        local_geometry.B0 = rgeo_rmaj
+        local_geometry.dpsidr = local_geometry.dpsidr * local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -399,17 +399,13 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             )
         else:
             amhd_beta_prime = (
-                -local_species.inverse_lp.m
-                * local_species.pressure.m
-                * beta
+                -local_species.inverse_lp.m * local_species.pressure.m * beta
             )
 
         if dpdx == -1:
             if local_geometry_data["B0"] is not None:
                 local_geometry_data["beta_prime"] = (
-                    -local_species.inverse_lp.m
-                    * local_species.pressure.m
-                    * beta
+                    -local_species.inverse_lp.m * local_species.pressure.m * beta
                 )
             else:
                 local_geometry_data["beta_prime"] = 0.0

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -240,9 +240,7 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
             # Need species to set up beta_prime
             local_species = self.get_local_species()
             local_geometry_data["beta_prime"] = (
-                    -local_species.inverse_lp.m
-                    * local_species.pressure.m
-                    * beta
+                -local_species.inverse_lp.m * local_species.pressure.m * beta
             )
         else:
             raise ValueError(

--- a/src/pyrokinetics/gk_code/gkw.py
+++ b/src/pyrokinetics/gk_code/gkw.py
@@ -231,10 +231,6 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
             beta = self.data["spcgeneral"]["beta_ref"]
         except KeyError:
             beta = self.data["spcgeneral"]["beta"]
-        if beta != 0.0:
-            local_geometry_data["B0"] = np.sqrt(1.0 / beta)
-        else:
-            local_geometry_data["B0"] = None
 
         if self.data["spcgeneral"].get("betaprime_type", "ref") == "ref":
             local_geometry_data["beta_prime"] = self.data["spcgeneral"].get(
@@ -243,12 +239,11 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         elif self.data["spcgeneral"].get("betaprime_type", "ref") == "sp":
             # Need species to set up beta_prime
             local_species = self.get_local_species()
-            if local_geometry_data["B0"] is not None:
-                local_geometry_data["beta_prime"] = (
-                    -local_species.inverse_lp.m / local_geometry_data["B0"] ** 2
-                )
-            else:
-                local_geometry_data["beta_prime"] = 0.0
+            local_geometry_data["beta_prime"] = (
+                    -local_species.inverse_lp.m
+                    * local_species.pressure.m
+                    * beta
+            )
         else:
             raise ValueError(
                 f"betaprime tpye {self.data['spcgeneral']['betaprime_type']} not supported for GKW"
@@ -257,8 +252,8 @@ class GKInputGKW(GKInput, FileReader, file_type="GKW", reads=GKInput):
         # must construct using from_gk_data as we cannot determine bunit_over_b0 here
         local_geometry = local_geometry_class.from_gk_data(local_geometry_data)
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= 1.0
+        local_geometry.B0 = 1.0
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -218,11 +218,11 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         else:
             raise NotImplementedError("GS2 Fourier options are not implemented")
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= (
+        local_geometry.B0 = (
             self.data["theta_grid_parameters"]["r_geo"]
             / self.data["theta_grid_parameters"]["rmaj"]
         )
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 
@@ -269,11 +269,6 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         miller_data["s_delta"] = (
             self.data["theta_grid_parameters"].get("tripri", 0.0) * rho
         )
-
-        beta = self._get_beta()
-
-        # Assume pref*8pi*1e-7 = 1.0
-        miller_data["B0"] = np.sqrt(1.0 / beta) if beta != 0.0 else None
 
         miller_data["ip_ccw"] = 1
         miller_data["bt_ccw"] = 1
@@ -326,10 +321,6 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         mxh_data["s_delta"] = (
             self.data["theta_grid_parameters"].get("tripri", 0.0) * rho
         )
-        beta = self._get_beta()
-
-        # Assume pref*8pi*1e-7 = 1.0
-        mxh_data["B0"] = np.sqrt(1.0 / beta) if beta != 0.0 else None
 
         mxh_data["ip_ccw"] = 1
         mxh_data["bt_ccw"] = 1

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -1234,9 +1234,7 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         raw_theta = raw_data["theta"].data
 
         if gk_input.data["theta_grid_eik_knobs"].get("equal_arc", True):
-            print(gk_input)
             local_geometry = gk_input.get_local_geometry()
-            print("LG after", local_geometry)
             geometric_theta = np.linspace(
                 np.min(raw_theta), np.max(raw_theta), len(raw_theta) * 4
             )

--- a/src/pyrokinetics/gk_code/gs2.py
+++ b/src/pyrokinetics/gk_code/gs2.py
@@ -225,7 +225,6 @@ class GKInputGS2(GKInput, FileReader, file_type="GS2", reads=GKInput):
         local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
-
         local_geometry.Fpsi = local_geometry.get_f_psi()
         local_geometry.FF_prime = local_geometry.get_f_prime() * local_geometry.Fpsi
 
@@ -1235,8 +1234,9 @@ class GKOutputReaderGS2(FileReader, file_type="GS2", reads=GKOutput):
         raw_theta = raw_data["theta"].data
 
         if gk_input.data["theta_grid_eik_knobs"].get("equal_arc", True):
-
+            print(gk_input)
             local_geometry = gk_input.get_local_geometry()
+            print("LG after", local_geometry)
             geometric_theta = np.linspace(
                 np.min(raw_theta), np.max(raw_theta), len(raw_theta) * 4
             )

--- a/src/pyrokinetics/gk_code/gx.py
+++ b/src/pyrokinetics/gk_code/gx.py
@@ -266,7 +266,7 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
         local_geometry = self.get_local_geometry_miller()
 
         local_geometry.B0 = (
-                self.data["Geometry"]["R_geo"] / self.data["Geometry"]["Rmaj"]
+            self.data["Geometry"]["R_geo"] / self.data["Geometry"]["Rmaj"]
         )
         local_geometry.dpsidr *= local_geometry.B0
 

--- a/src/pyrokinetics/gk_code/gx.py
+++ b/src/pyrokinetics/gk_code/gx.py
@@ -265,10 +265,10 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
 
         local_geometry = self.get_local_geometry_miller()
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= (
-            self.data["Geometry"]["R_geo"] / self.data["Geometry"]["Rmaj"]
+        local_geometry.B0 = (
+                self.data["Geometry"]["R_geo"] / self.data["Geometry"]["Rmaj"]
         )
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 
@@ -302,11 +302,6 @@ class GKInputGX(GKInput, FileReader, file_type="GX", reads=GKInput):
             * rho
             / np.sqrt(1 - self.data["Geometry"].get("tri", 0.0) ** 2)
         )
-
-        beta = self._get_beta()
-
-        # Assume pref*8pi*1e-7 = 1.0
-        miller_data["B0"] = np.sqrt(1.0 / beta) if beta != 0.0 else None
 
         miller_data["ip_ccw"] = 1
         miller_data["bt_ccw"] = 1

--- a/src/pyrokinetics/gk_code/stella.py
+++ b/src/pyrokinetics/gk_code/stella.py
@@ -195,11 +195,11 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
 
         local_geometry = self.get_local_geometry_miller()
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= (
+        local_geometry.B0 = (
             self.data["millergeo_parameters"]["rgeo"]
             / self.data["millergeo_parameters"]["rmaj"]
         )
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 
@@ -231,13 +231,8 @@ class GKInputSTELLA(GKInput, FileReader, file_type="STELLA", reads=GKInput):
             self.data["millergeo_parameters"].get("triprim", 0.0) * rho
         )
 
-        beta = self._get_beta()
-
         # convert from stella normalisation to pyrokinetics normalisation of beta_prime
         miller_data["beta_prime"] *= -2.0
-
-        # Assume pref*8pi*1e-7 = 1.0
-        miller_data["B0"] = np.sqrt(1.0 / beta) if beta != 0.0 else None
 
         miller_data["ip_ccw"] = 1
         miller_data["bt_ccw"] = 1

--- a/src/pyrokinetics/gk_code/tglf.py
+++ b/src/pyrokinetics/gk_code/tglf.py
@@ -287,8 +287,8 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
         else:
             local_geometry = self.get_local_geometry_miller()
 
-        # Hacky fix for dpsidr units as calc assumes bref_B0
-        local_geometry.dpsidr *= 1.0 / local_geometry.bunit_over_b0
+        local_geometry.B0 = 1.0 / local_geometry.bunit_over_b0
+        local_geometry.dpsidr *= local_geometry.B0
 
         local_geometry.normalise(norms=convention)
 
@@ -319,9 +319,6 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         miller_data["ip_ccw"] = 1
         miller_data["bt_ccw"] = 1
-
-        beta = self.data.get("betae", 0.0)
-        miller_data["B0"] = 1 / beta**0.5 if beta != 0 else None
 
         miller_data["beta_prime"] = (
             self.data.get("p_prime_loc", 0.0)
@@ -378,9 +375,6 @@ class GKInputTGLF(GKInput, FileReader, file_type="TGLF", reads=GKInput):
 
         mxh_data["ip_ccw"] = 1
         mxh_data["bt_ccw"] = 1
-
-        beta = self.data.get("betae", 0.0)
-        mxh_data["B0"] = 1 / beta**0.5 if beta != 0 else None
 
         mxh_data["beta_prime"] = (
             self.data.get("p_prime_loc", 0.0)

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -142,15 +142,7 @@ class MetricTerms:  # CleverDict
 
         # This defines the reference magnetic field as B0:
         # dpsidr / (B0 * a) = <Jacobian * g^zetazeta> * (R0 / a) / q
-        bref_units = local_geometry.dpsidr.units / local_geometry.rho.units
-
-        # Needs to explicitly be 1 * B0 regardless of units
-        if "Bunit" in str(bref_units):
-            bref_units *= 1.0 / local_geometry.bunit_over_b0
-        elif "B0" not in str(bref_units):
-            raise ValueError("Need to convert to a standard normalisation first")
-
-        self.dpsidr = self.Y * local_geometry.Rmaj / self.q * bref_units
+        self.dpsidr = self.Y * local_geometry.Rmaj / self.q * local_geometry.B0
         # dpsidr may not match exactly when loading from global_eq
 
         # rho is defined as r / a

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -142,7 +142,7 @@ class MetricTerms:  # CleverDict
 
         # This defines the reference magnetic field as B0:
         # dpsidr / (B0 * a) = <Jacobian * g^zetazeta> * (R0 / a) / q
-        self.dpsidr = self.Y * local_geometry.Rmaj / self.q * local_geometry.B0
+        self.dpsidr = self.Y * (local_geometry.Rmaj / self.q) * local_geometry.B0
         # dpsidr may not match exactly when loading from global_eq
 
         # rho is defined as r / a

--- a/tests/gk_code/test_gk_output_reader_gs2.py
+++ b/tests/gk_code/test_gk_output_reader_gs2.py
@@ -287,6 +287,7 @@ def mock_reader(monkeypatch, request):
             geometry = LocalGeometryMiller()
             geometry.Rmaj = 3.0
             geometry.bunit_over_b0 = 1.0205177029353276
+            geometry.B0 = 1.0
             norms = Normalisation("test_gk_mock")
             geometry.normalise(norms)
             return geometry

--- a/tests/local_geometry/test_local_geometry.py
+++ b/tests/local_geometry/test_local_geometry.py
@@ -13,6 +13,12 @@ def test_enforce_beta_prime():
     pyro = pk.Pyro(eq_file=eq_file, kinetics_file=kinetics_file)
     pyro.load_local(psi_n=0.5)
     pyro.gk_code = "CGYRO"
+
+    assert pyro.local_geometry.B0.m == 1.0
+    assert np.isclose(
+        pyro.local_geometry.B0.to(pyro.norms.cgyro).m,
+        (1.0 / pyro.local_geometry.bunit_over_b0.m),
+    )
     assert pyro.gk_input.data["BETA_STAR_SCALE"] != 1.0
 
     pyro.enforce_consistent_beta_prime()

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -83,11 +83,9 @@ def test_compare_roundtrip(setup_roundtrip, gk_code_a, gk_code_b):
     code_b = setup_roundtrip[gk_code_b]
 
     FIXME_ignore_geometry_attrs = [
-        "B0",
         "psi_n",
         "r_minor",
         "a_minor",
-        "Fpsi",
         "FF_prime",
         "R",
         "Z",
@@ -106,7 +104,6 @@ def test_compare_roundtrip(setup_roundtrip, gk_code_a, gk_code_b):
         "dRdr",
         "dZdtheta",
         "dZdr",
-        "bunit_over_b0",
         "jacob",
         "unit_mapping",
     ]
@@ -474,10 +471,8 @@ def test_compare_roundtrip_mxh(setup_roundtrip_mxh, gk_code_a, gk_code_b):
     code_b = setup_roundtrip_mxh[gk_code_b]
 
     FIXME_ignore_geometry_attrs = [
-        "B0",
         "psi_n",
         "a_minor",
-        "Fpsi",
         "FF_prime",
         "R",
         "Z",


### PR DESCRIPTION
The `LocalGeometry` object has a variable `B0` which in the docs is defined as `f/Rmaj` (is a flux function).

However, due to an old implementations of reading `GKInput` from input files, a hacky `B0 = 1 / sqrt(beta)` was used which is not really needed anymore as we handle `beta` separately in `Numerics` (this was implemented before the `Numerics` object properly existed).

This means that the value of `B0` wasn't really `B0`. This is now fixed for each code. This results in the sometimes trivial with a definition of `local_geometr y.B0 = 1.0 bref_B0` but it is useful when using different normalisations and allows `MetricTerms` to work with any normalisation now which requires by `B0` (addressing #508). Added some simple test checking this and including `B0` (and `Fpsi`) in the roundtrip tests.

The value of `B0` wasn't really used anywhere so this won't affect functionality for 99% of cases but essentially makes `MetricTerms` much more robust against choice of normalisation.