### PR TITLE
PyroScan Error Handling

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -505,7 +505,14 @@ class PyroScan:
                     # Remove GKOutput to conserve memory
                     pyro.gk_output = None
 
-                except (FileNotFoundError, OSError, IndexError, RuntimeError, KeyError, ValueError) as e:
+                except (
+                    FileNotFoundError,
+                    OSError,
+                    IndexError,
+                    RuntimeError,
+                    KeyError,
+                    ValueError,
+                ) as e:
                     warnings.warn(
                         f"Unable to load gk_output for {pyro.gk_file} "
                         f"[{type(e).__name__}: {e}]"

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -505,7 +505,11 @@ class PyroScan:
                     # Remove GKOutput to conserve memory
                     pyro.gk_output = None
 
-                except (FileNotFoundError, OSError, IndexError, RuntimeError, KeyError):
+                except (FileNotFoundError, OSError, IndexError, RuntimeError, KeyError, ValueError) as e:
+                    warnings.warn(
+                        f"Unable to load gk_output for {pyro.gk_file} "
+                        f"[{type(e).__name__}: {e}]"
+                    )
                     growth_rate.append(growth_rate[0] * np.nan)
                     mode_frequency.append(mode_frequency[0] * np.nan)
                     growth_rate_tolerance.append(growth_rate_tolerance[0] * np.nan)
@@ -514,7 +518,6 @@ class PyroScan:
                     eigenfunctions.append(eigenfunctions[0] * np.nan)
 
             # Save eigenvalues
-
             output_shape = copy.deepcopy(self.value_size)
             coords = list(self.parameter_dict.keys())
 


### PR DESCRIPTION
Currently, the loading of pyroscan data may fail due to a `ValueError`, which is encountered if there is an array-size mismatch when, e.g., reshaping data, and is likely due to some I/O failure of the code. To guard against this, I've added handling of `ValueError`, as well an appropriate warning. 