### PR TITLE
Add eq.upscale() to increase R–Z grid resolution via interpolation

### DIFF
--- a/src/pyrokinetics/equilibrium/equilibrium.py
+++ b/src/pyrokinetics/equilibrium/equilibrium.py
@@ -311,7 +311,6 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
 
         # Create bivariate spline and partial derivatives over psi_RZ
         self._psi_RZ_spline = UnitSpline2D(R, Z, psi_RZ)
-
         # Check the psi grids
         psi = np.asarray(psi, dtype=float) * cocos_factors.psi * eq_units["psi"]
         F = np.asarray(F, dtype=float) * cocos_factors.f * eq_units["F"]
@@ -1077,6 +1076,60 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
         for key, value in vars(self).items():
             setattr(new_equilibrium, key, deepcopy(value, memodict))
         return new_equilibrium
+
+    
+    def upscale(self, R_upscale: int, Z_upscale: int):
+        ds = self.data
+    
+        # Get original 1D coordinates and their dimension names
+        R_old = ds["R"].data
+        Z_old = ds["Z"].data
+        R_dim = ds["R"].dims[0]  # expected "R_dim"
+        Z_dim = ds["Z"].dims[0]  # expected "Z_dim"
+        
+        # Build new (uniform) upscaled coordinate arrays
+        R_new = np.linspace(np.min(R_old), np.max(R_old), R_upscale * len(R_old))
+        Z_new = np.linspace(np.min(Z_old), np.max(Z_old), Z_upscale * len(Z_old))
+    
+        # Evaluate the spline on the new grid
+        # Prefer passing 1D arrays if your spline follows RectBivariateSpline semantics:
+        # psi_new = self._psi_RZ_spline(R_new, Z_new)  # shape (len(R_new), len(Z_new))
+    
+        # If your UnitSpline2D expects mesh inputs, keep this (ensure 'ij' indexing):
+        RR, ZZ = np.meshgrid(R_new, Z_new, indexing="ij")
+        psi_new = self._psi_RZ_spline(RR, ZZ)          # shape (len(R_new), len(Z_new))
+
+
+        # --- Detach old indexes/coords to avoid alignment conflicts ---
+        # If R_dim/Z_dim are used as pandas indexes, reset them.
+        if R_dim in ds.indexes:
+            ds = ds.reset_index(R_dim, drop=True)
+        if Z_dim in ds.indexes:
+            ds = ds.reset_index(Z_dim, drop=True)
+    
+        # Drop old coordinate variables so we can replace them cleanly
+        for coord_name in ["R", "Z"]:
+            if coord_name in ds.variables:
+                ds = ds.drop_vars(coord_name)
+
+        # Update coordinates with explicit dims
+        ds = ds.assign_coords(
+            R=(R_dim, R_new),
+            Z=(Z_dim, Z_new),
+            psi_RZ=((R_dim, Z_dim), psi_new)
+        )
+    
+        # Update psi_RZ data variable with explicit dims
+        ds = ds.assign(
+            psi_RZ=((R_dim, Z_dim), psi_new)
+        )
+
+        ds["R"].attrs["units"] = ds["R"].attrs.get("units", "m")
+        ds["Z"].attrs["units"] = ds["Z"].attrs.get("units", "m")
+        ds["psi_RZ"].attrs["units"] = ds["psi_RZ"].attrs.get("units", "Wb")
+   
+        # Save back
+        self.data = ds
 
 
 class EquilibriumReaderPyro(FileReader, file_type="Pyrokinetics", reads=Equilibrium):

--- a/src/pyrokinetics/equilibrium/equilibrium.py
+++ b/src/pyrokinetics/equilibrium/equilibrium.py
@@ -1077,28 +1077,26 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
             setattr(new_equilibrium, key, deepcopy(value, memodict))
         return new_equilibrium
 
-    
     def upscale(self, R_upscale: int, Z_upscale: int):
         ds = self.data
-    
+
         # Get original 1D coordinates and their dimension names
         R_old = ds["R"].data
         Z_old = ds["Z"].data
         R_dim = ds["R"].dims[0]  # expected "R_dim"
         Z_dim = ds["Z"].dims[0]  # expected "Z_dim"
-        
+
         # Build new (uniform) upscaled coordinate arrays
         R_new = np.linspace(np.min(R_old), np.max(R_old), R_upscale * len(R_old))
         Z_new = np.linspace(np.min(Z_old), np.max(Z_old), Z_upscale * len(Z_old))
-    
+
         # Evaluate the spline on the new grid
         # Prefer passing 1D arrays if your spline follows RectBivariateSpline semantics:
         # psi_new = self._psi_RZ_spline(R_new, Z_new)  # shape (len(R_new), len(Z_new))
-    
+
         # If your UnitSpline2D expects mesh inputs, keep this (ensure 'ij' indexing):
         RR, ZZ = np.meshgrid(R_new, Z_new, indexing="ij")
-        psi_new = self._psi_RZ_spline(RR, ZZ)          # shape (len(R_new), len(Z_new))
-
+        psi_new = self._psi_RZ_spline(RR, ZZ)  # shape (len(R_new), len(Z_new))
 
         # --- Detach old indexes/coords to avoid alignment conflicts ---
         # If R_dim/Z_dim are used as pandas indexes, reset them.
@@ -1106,7 +1104,7 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
             ds = ds.reset_index(R_dim, drop=True)
         if Z_dim in ds.indexes:
             ds = ds.reset_index(Z_dim, drop=True)
-    
+
         # Drop old coordinate variables so we can replace them cleanly
         for coord_name in ["R", "Z"]:
             if coord_name in ds.variables:
@@ -1114,20 +1112,16 @@ class Equilibrium(DatasetWrapper, ReadableFromFile):
 
         # Update coordinates with explicit dims
         ds = ds.assign_coords(
-            R=(R_dim, R_new),
-            Z=(Z_dim, Z_new),
-            psi_RZ=((R_dim, Z_dim), psi_new)
+            R=(R_dim, R_new), Z=(Z_dim, Z_new), psi_RZ=((R_dim, Z_dim), psi_new)
         )
-    
+
         # Update psi_RZ data variable with explicit dims
-        ds = ds.assign(
-            psi_RZ=((R_dim, Z_dim), psi_new)
-        )
+        ds = ds.assign(psi_RZ=((R_dim, Z_dim), psi_new))
 
         ds["R"].attrs["units"] = ds["R"].attrs.get("units", "m")
         ds["Z"].attrs["units"] = ds["Z"].attrs.get("units", "m")
         ds["psi_RZ"].attrs["units"] = ds["psi_RZ"].attrs.get("units", "Wb")
-   
+
         # Save back
         self.data = ds
 

--- a/tests/equilibrium/test_equilibrium.py
+++ b/tests/equilibrium/test_equilibrium.py
@@ -703,14 +703,13 @@ def test_upscale_identity(circular_eq_func):
     # coords unchanged
     assert ds1["R"].data.units == ds0["R"].data.units
     assert_allclose(ds1["R"].data.magnitude, ds0["R"].data.magnitude)
-    
+
     assert ds1["Z"].data.units == ds0["Z"].data.units
     assert_allclose(ds1["Z"].data.magnitude, ds0["Z"].data.magnitude)
 
     # field unchanged
     assert ds1["psi_RZ"].data.units == ds0["psi_RZ"].data.units
     assert_allclose(ds1["psi_RZ"].data.magnitude, ds0["psi_RZ"].data.magnitude)
-
 
     # units attrs still present
     assert ds1["R"].data.units == ds0["R"].data.units
@@ -733,20 +732,26 @@ def test_upscale_sizes(circular_eq_func, R_fac, Z_fac):
     assert ds1.sizes["Z_dim"] == Z_fac * nZ0
     assert_array_equal(ds1["psi_RZ"].shape, (R_fac * nR0, Z_fac * nZ0))
 
-    
     # endpoints preserved by linspace(min,max,...)
     assert ds1["R"].data.units == ds0["R"].data.units
-    assert_allclose(ds1["R"].data.magnitude[0],  ds0["R"].data.magnitude[0])
+    assert_allclose(ds1["R"].data.magnitude[0], ds0["R"].data.magnitude[0])
     assert_allclose(ds1["R"].data.magnitude[-1], ds0["R"].data.magnitude[-1])
-    
+
     assert ds1["Z"].data.units == ds0["Z"].data.units
-    assert_allclose(ds1["Z"].data.magnitude[0],  ds0["Z"].data.magnitude[0])
+    assert_allclose(ds1["Z"].data.magnitude[0], ds0["Z"].data.magnitude[0])
     assert_allclose(ds1["Z"].data.magnitude[-1], ds0["Z"].data.magnitude[-1])
-    
+
     # psi_RZ corners preserved
     assert ds1["psi_RZ"].data.units == ds0["psi_RZ"].data.units
-    assert_allclose(ds1["psi_RZ"].data.magnitude[0, 0],   ds0["psi_RZ"].data.magnitude[0, 0])
-    assert_allclose(ds1["psi_RZ"].data.magnitude[-1, 0],  ds0["psi_RZ"].data.magnitude[-1, 0])
-    assert_allclose(ds1["psi_RZ"].data.magnitude[0, -1],  ds0["psi_RZ"].data.magnitude[0, -1])
-    assert_allclose(ds1["psi_RZ"].data.magnitude[-1, -1], ds0["psi_RZ"].data.magnitude[-1, -1])
-    
+    assert_allclose(
+        ds1["psi_RZ"].data.magnitude[0, 0], ds0["psi_RZ"].data.magnitude[0, 0]
+    )
+    assert_allclose(
+        ds1["psi_RZ"].data.magnitude[-1, 0], ds0["psi_RZ"].data.magnitude[-1, 0]
+    )
+    assert_allclose(
+        ds1["psi_RZ"].data.magnitude[0, -1], ds0["psi_RZ"].data.magnitude[0, -1]
+    )
+    assert_allclose(
+        ds1["psi_RZ"].data.magnitude[-1, -1], ds0["psi_RZ"].data.magnitude[-1, -1]
+    )

--- a/tests/equilibrium/test_equilibrium.py
+++ b/tests/equilibrium/test_equilibrium.py
@@ -203,6 +203,29 @@ def circular_eq(expected) -> Equilibrium:
     return eq
 
 
+@pytest.fixture(scope="function")
+def circular_eq_func(expected):
+    # same construction as circular_eq, but function-scoped so it can't leak mutations
+    return Equilibrium(
+        R=expected["R"],
+        Z=expected["Z"],
+        psi_RZ=expected["psi_RZ"],
+        psi=expected["psi"],
+        F=expected["F"],
+        FF_prime=expected["FF_prime"],
+        p=expected["p"],
+        p_prime=expected["p_prime"],
+        q=expected["q"],
+        R_major=expected["R_major"],
+        r_minor=expected["r_minor"],
+        Z_mid=expected["Z_mid"],
+        psi_lcfs=expected["psi_lcfs"],
+        a_minor=expected["a_minor"],
+        B_0=expected["B_0"],
+        I_p=expected["I_p"],
+    )
+
+
 _units = [units.m, units.cm]
 _cocos = list(range(1, 9)) + list(range(11, 19))
 _params = [{"len_units": u, "cocos": c} for u, c in product(_units, _cocos)]
@@ -664,3 +687,66 @@ def test_reverse_ipbt():
     for key, value in expected_on_axis.items():
         actual = getattr(eq, key)(0.0)
         assert np.isclose(actual.m, value)
+
+
+def test_upscale_identity(circular_eq_func):
+    eq = circular_eq_func
+    ds0 = eq.data.copy(deep=True)
+
+    eq.upscale(R_upscale=1, Z_upscale=1)
+    ds1 = eq.data
+
+    # sizes unchanged
+    assert ds1.sizes["R_dim"] == ds0.sizes["R_dim"]
+    assert ds1.sizes["Z_dim"] == ds0.sizes["Z_dim"]
+
+    # coords unchanged
+    assert ds1["R"].data.units == ds0["R"].data.units
+    assert_allclose(ds1["R"].data.magnitude, ds0["R"].data.magnitude)
+    
+    assert ds1["Z"].data.units == ds0["Z"].data.units
+    assert_allclose(ds1["Z"].data.magnitude, ds0["Z"].data.magnitude)
+
+    # field unchanged
+    assert ds1["psi_RZ"].data.units == ds0["psi_RZ"].data.units
+    assert_allclose(ds1["psi_RZ"].data.magnitude, ds0["psi_RZ"].data.magnitude)
+
+
+    # units attrs still present
+    assert ds1["R"].data.units == ds0["R"].data.units
+    assert ds1["Z"].data.units == ds0["Z"].data.units
+    assert ds1["psi_RZ"].data.units == ds0["psi_RZ"].data.units
+
+
+@pytest.mark.parametrize("R_fac,Z_fac", [(2, 2), (3, 2), (2, 4)])
+def test_upscale_sizes(circular_eq_func, R_fac, Z_fac):
+    eq = circular_eq_func
+    ds0 = eq.data.copy(deep=True)
+
+    nR0 = ds0.sizes["R_dim"]
+    nZ0 = ds0.sizes["Z_dim"]
+
+    eq.upscale(R_upscale=R_fac, Z_upscale=Z_fac)
+    ds1 = eq.data
+
+    assert ds1.sizes["R_dim"] == R_fac * nR0
+    assert ds1.sizes["Z_dim"] == Z_fac * nZ0
+    assert_array_equal(ds1["psi_RZ"].shape, (R_fac * nR0, Z_fac * nZ0))
+
+    
+    # endpoints preserved by linspace(min,max,...)
+    assert ds1["R"].data.units == ds0["R"].data.units
+    assert_allclose(ds1["R"].data.magnitude[0],  ds0["R"].data.magnitude[0])
+    assert_allclose(ds1["R"].data.magnitude[-1], ds0["R"].data.magnitude[-1])
+    
+    assert ds1["Z"].data.units == ds0["Z"].data.units
+    assert_allclose(ds1["Z"].data.magnitude[0],  ds0["Z"].data.magnitude[0])
+    assert_allclose(ds1["Z"].data.magnitude[-1], ds0["Z"].data.magnitude[-1])
+    
+    # psi_RZ corners preserved
+    assert ds1["psi_RZ"].data.units == ds0["psi_RZ"].data.units
+    assert_allclose(ds1["psi_RZ"].data.magnitude[0, 0],   ds0["psi_RZ"].data.magnitude[0, 0])
+    assert_allclose(ds1["psi_RZ"].data.magnitude[-1, 0],  ds0["psi_RZ"].data.magnitude[-1, 0])
+    assert_allclose(ds1["psi_RZ"].data.magnitude[0, -1],  ds0["psi_RZ"].data.magnitude[0, -1])
+    assert_allclose(ds1["psi_RZ"].data.magnitude[-1, -1], ds0["psi_RZ"].data.magnitude[-1, -1])
+    


### PR DESCRIPTION
Adds a method on the equilibrium object `pyro.eq.upscale(R_upscale, Z_upscale)`, it increases the resolution of the equilibrium `psi_RZ`. The method constructs a finer R–Z grid (scaled by the requested factors) and interpolates the existing `psi_RZ` values onto it.