### PR TITLE
Add back Z_EFF/Z_EFF_METHOD if legacy

### DIFF
--- a/src/pyrokinetics/gk_code/cgyro.py
+++ b/src/pyrokinetics/gk_code/cgyro.py
@@ -835,6 +835,9 @@ class GKInputCGYRO(GKInput, FileReader, file_type="CGYRO", reads=GKInput):
                 self.data.pop("Z_EFF")
             if "Z_EFF_METHOD" in self.data:
                 self.data.pop("Z_EFF_METHOD")
+        else:
+            self.data["Z_EFF_METHOD"] = 1
+            self.data["Z_EFF"] = local_species.zeff
 
         if "electron" in local_species.names:
             first_species = "electron"


### PR DESCRIPTION
Add `Z_EFF` and `Z_EFF_METHOD` when writing files in legacy format (this is the default at the moment)