### PR TITLE
Bugfix/nonlinear pyroscan coordinates

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -91,7 +91,6 @@ def select_kx_ky_time(
         time_mode=time_mode,
         tolerance_time_range=tolerance_time_range,
     )
-
     if sum_ky and "ky" in da.dims:
         da = da.sum(dim="ky")
 
@@ -159,7 +158,18 @@ def add_quantity(ds, name, arrays, base_shape, scan_coords):
         stacked = stacked * units
 
     dims = tuple(scan_coords.keys()) + last.dims
-    ds[name] = (dims, stacked)
+
+    arr = xr.DataArray(
+        stacked,
+        dims=dims,
+        coords={
+            **scan_coords,
+            **last.coords,
+        },
+    )
+
+    arr = arr.reset_coords(drop=True)
+    ds[name] = arr
 
     return ds
 

--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -130,7 +130,6 @@ def add_quantity(ds, name, arrays, base_shape, scan_coords):
         return ds
 
     last = arrays[-1]
-
     for dim in scan_coords:
         if dim in last.dims:
             last = last.squeeze(dim, drop=True)
@@ -594,13 +593,14 @@ class PyroScan:
         parameter_dict = {}
         coords = {}
         attrs = {}
-
+        coord_units = {}
         for name, values in self.parameter_dict.items():
             vals = np.asarray(values.magnitude)
 
             parameter_dict[name] = ((name,), vals)
             coords[name] = vals
             attrs[name + "_units"] = str(values.units)
+            coord_units[name] = values.units
 
         output_shape = tuple(len(v) for v in self.parameter_dict.values())
 
@@ -743,6 +743,9 @@ class PyroScan:
         ds = xr.Dataset(parameter_dict)
         for name, arrays in buffers.items():
             ds = add_quantity(ds, name, arrays, output_shape, coords)
+
+        for coord, units in coord_units.items():
+            ds[coord] = ds[coord].assign_attrs(units=units)
 
         self.gk_output = PyroScanGKOutput(ds)
 

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -159,9 +159,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(left[json_key], right[json_key]), (
-                        f"{left} != {right}"
-                    )
+                    assert np.allclose(
+                        left[json_key], right[json_key]
+                    ), f"{left} != {right}"
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -193,7 +193,8 @@ PYROSCAN_CONFIGS = [
     {
         "parameter_dict": {
             # Typical ky unit: 1/rho_ref in GENE/GS2
-            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
+            "ky": np.array([0.1, 0.2])
+            / units.rhoref_pyro
         },
         "runfile_dict": None,
     },
@@ -320,9 +321,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[
-                    species
-                ].inverse_ln = pyro.local_species.electron.inverse_ln
+                pyro.local_species[species].inverse_ln = (
+                    pyro.local_species.electron.inverse_ln
+                )
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -66,11 +66,6 @@ def test_pyroscan_read_tglf_nonlinear(json_dir, zip_path, nonlinear_tmp_path):
     pyro_scan.load_gk_output(load_fields=True)
     assert "phi" in pyro_scan.gk_output.data.data_vars
 
-    pyro_scan.load_gk_output(load_fields=True, sum_ky=False)
-    assert "phi" in pyro_scan.gk_output.data.data_vars
-    assert "ky" in pyro_scan.gk_output.data["phi"].coords
-    assert pyro_scan.gk_output.data["phi"].coords["ky"].size > 0
-
     pyro_scan.load_gk_output(load_fluxes=True)
     assert "particle" in pyro_scan.gk_output.data.data_vars
     assert "heat" in pyro_scan.gk_output.data.data_vars

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -55,7 +55,6 @@ def test_pyroscan_read_tglf_nonlinear(json_dir, zip_path, nonlinear_tmp_path):
     assert "apar" not in pyro_scan.gk_output.data.data_vars
     assert "ky" in pyro_scan.gk_output.data.coords
     assert pyro_scan.gk_output.data.coords["ky"].size > 0
-    breakpoint()
     assert "field" in pyro_scan.gk_output.data.coords
     assert pyro_scan.gk_output.data.coords["field"].size > 0
 
@@ -66,6 +65,11 @@ def test_pyroscan_read_tglf_nonlinear(json_dir, zip_path, nonlinear_tmp_path):
 
     pyro_scan.load_gk_output(load_fields=True)
     assert "phi" in pyro_scan.gk_output.data.data_vars
+
+    pyro_scan.load_gk_output(load_fields=True, sum_ky=False)
+    assert "phi" in pyro_scan.gk_output.data.data_vars
+    assert "ky" in pyro_scan.gk_output.data["phi"].coords
+    assert pyro_scan.gk_output.data["phi"].coords["ky"].size > 0
 
     pyro_scan.load_gk_output(load_fluxes=True)
     assert "particle" in pyro_scan.gk_output.data.data_vars

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -53,6 +53,11 @@ def test_pyroscan_read_tglf_nonlinear(json_dir, zip_path, nonlinear_tmp_path):
     assert "phi" not in pyro_scan.gk_output.data.data_vars
     assert "bpar" not in pyro_scan.gk_output.data.data_vars
     assert "apar" not in pyro_scan.gk_output.data.data_vars
+    assert "ky" in pyro_scan.gk_output.data.coords
+    assert pyro_scan.gk_output.data.coords["ky"].size > 0
+    breakpoint()
+    assert "field" in pyro_scan.gk_output.data.coords
+    assert pyro_scan.gk_output.data.coords["field"].size > 0
 
     pyro_scan.load_gk_output(load_fluxes=False)
     assert "particle" not in pyro_scan.gk_output.data.data_vars
@@ -149,9 +154,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(
-                        left[json_key], right[json_key]
-                    ), f"{left} != {right}"
+                    assert np.allclose(left[json_key], right[json_key]), (
+                        f"{left} != {right}"
+                    )
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -183,8 +188,7 @@ PYROSCAN_CONFIGS = [
     {
         "parameter_dict": {
             # Typical ky unit: 1/rho_ref in GENE/GS2
-            "ky": np.array([0.1, 0.2])
-            / units.rhoref_pyro
+            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
         },
         "runfile_dict": None,
     },
@@ -311,9 +315,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[species].inverse_ln = (
-                    pyro.local_species.electron.inverse_ln
-                )
+                pyro.local_species[
+                    species
+                ].inverse_ln = pyro.local_species.electron.inverse_ln
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -154,9 +154,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(left[json_key], right[json_key]), (
-                        f"{left} != {right}"
-                    )
+                    assert np.allclose(
+                        left[json_key], right[json_key]
+                    ), f"{left} != {right}"
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -188,7 +188,8 @@ PYROSCAN_CONFIGS = [
     {
         "parameter_dict": {
             # Typical ky unit: 1/rho_ref in GENE/GS2
-            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
+            "ky": np.array([0.1, 0.2])
+            / units.rhoref_pyro
         },
         "runfile_dict": None,
     },
@@ -315,9 +316,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[
-                    species
-                ].inverse_ln = pyro.local_species.electron.inverse_ln
+                pyro.local_species[species].inverse_ln = (
+                    pyro.local_species.electron.inverse_ln
+                )
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from pyrokinetics import Pyro, template_dir
+from pyrokinetics import Pyro, pyro, template_dir
 from pyrokinetics.pyroscan import PyroScan
 from pyrokinetics.units import ureg as units
 
@@ -50,26 +50,32 @@ def test_pyroscan_read_tglf_nonlinear(json_dir, zip_path, nonlinear_tmp_path):
     pyro_scan = PyroScan(pyroscan_json=json_path / "pyroscan.json", load_base_pyro=True)
 
     pyro_scan.load_gk_output(load_fields=False)
-    assert "phi" not in pyro_scan.gk_output.data.data_vars
-    assert "bpar" not in pyro_scan.gk_output.data.data_vars
-    assert "apar" not in pyro_scan.gk_output.data.data_vars
-    assert "ky" in pyro_scan.gk_output.data.coords
-    assert pyro_scan.gk_output.data.coords["ky"].size > 0
-    assert "field" in pyro_scan.gk_output.data.coords
-    assert pyro_scan.gk_output.data.coords["field"].size > 0
+    data = pyro_scan.gk_output.data
+    assert "phi" not in data.data_vars
+    assert "bpar" not in data.data_vars
+    assert "apar" not in data.data_vars
+    assert "ky" in data.coords
+    assert data.coords["ky"].size > 0
+    assert "gamma_exb" in data.coords
+    assert data.coords["gamma_exb"].size > 0
+    assert len(data.coords["gamma_exb"].attrs) > 0
+    assert "field" in data.coords
+    assert data.coords["field"].size > 0
 
     pyro_scan.load_gk_output(load_fluxes=False)
-    assert "particle" not in pyro_scan.gk_output.data.data_vars
-    assert "heat" not in pyro_scan.gk_output.data.data_vars
-    assert "momentum" not in pyro_scan.gk_output.data.data_vars
+    data = pyro_scan.gk_output.data
+    assert "particle" not in data.data_vars
+    assert "heat" not in data.data_vars
+    assert "momentum" not in data.data_vars
 
     pyro_scan.load_gk_output(load_fields=True)
     assert "phi" in pyro_scan.gk_output.data.data_vars
 
     pyro_scan.load_gk_output(load_fluxes=True)
-    assert "particle" in pyro_scan.gk_output.data.data_vars
-    assert "heat" in pyro_scan.gk_output.data.data_vars
-    assert "momentum" in pyro_scan.gk_output.data.data_vars
+    data = pyro_scan.gk_output.data
+    assert "particle" in data.data_vars
+    assert "heat" in data.data_vars
+    assert "momentum" in data.data_vars
 
 
 @pytest.mark.parametrize(
@@ -153,9 +159,9 @@ def assert_close_or_equal(attr, left_pyroscan, right_pyroscan):
                 if isinstance(left[json_key], (str, list, type(None), dict, Path)):
                     assert np.all(left[json_key] == right[json_key])
                 else:
-                    assert np.allclose(
-                        left[json_key], right[json_key]
-                    ), f"{left} != {right}"
+                    assert np.allclose(left[json_key], right[json_key]), (
+                        f"{left} != {right}"
+                    )
     else:
         if isinstance(left, (str, list, type(None), dict, Path)):
             assert np.all(left == right)
@@ -187,8 +193,7 @@ PYROSCAN_CONFIGS = [
     {
         "parameter_dict": {
             # Typical ky unit: 1/rho_ref in GENE/GS2
-            "ky": np.array([0.1, 0.2])
-            / units.rhoref_pyro
+            "ky": np.array([0.1, 0.2]) / units.rhoref_pyro
         },
         "runfile_dict": None,
     },
@@ -315,9 +320,9 @@ def test_apply_func(tmp_path):
     def maintain_quasineutrality(pyro):
         for species in pyro.local_species.names:
             if species != "electron":
-                pyro.local_species[species].inverse_ln = (
-                    pyro.local_species.electron.inverse_ln
-                )
+                pyro.local_species[
+                    species
+                ].inverse_ln = pyro.local_species.electron.inverse_ln
 
     parameter_kwargs = {}
     pyro_scan.add_parameter_func("aln", maintain_quasineutrality, parameter_kwargs)


### PR DESCRIPTION
There was a bug in my recent PR, which meant that coordinates didn't have the associated values. Basically ky was there but you could only index it by position not value. I have added the proper coordinate adding into the code, and updated the test to check for the correct behaviour  