### PR TITLE
Fix load_gk_output crash on unitless scan parameters

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -601,12 +601,18 @@ class PyroScan:
         attrs = {}
         coord_units = {}
         for name, values in self.parameter_dict.items():
-            vals = np.asarray(values.magnitude)
+            # Unitless scan parameters are stored as plain arrays/lists.
+            if isinstance(values, Quantity):
+                vals = np.asarray(values.magnitude)
+                unit = values.units
+            else:
+                vals = np.asarray(values)
+                unit = ureg.dimensionless
 
             parameter_dict[name] = ((name,), vals)
             coords[name] = vals
-            attrs[name + "_units"] = str(values.units)
-            coord_units[name] = values.units
+            attrs[name + "_units"] = str(unit)
+            coord_units[name] = unit
 
         output_shape = tuple(len(v) for v in self.parameter_dict.values())
 

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -309,6 +309,39 @@ def test_create_single_run():
     assert new_run.run_parameters == run_parameters
 
 
+def test_pyroscan_reload_unitless_parameter(tmp_path):
+    """
+    Reload a PyroScan whose parameter has no units (e.g. dimensionless kappa
+    or integer ntheta). The reloaded scan must round-trip through pyroscan.json
+    and load_gk_output must iterate over unitless values without crashing.
+    """
+    pyro = example_SCENE.main(tmp_path)
+
+    parameter_dict = {
+        "kappa": np.array([1.5, 1.6, 1.7]),
+        "ntheta": np.array([16, 32]),
+    }
+
+    ps = PyroScan(pyro, parameter_dict=parameter_dict, base_directory=tmp_path)
+    ps.add_parameter_key("ntheta", "numerics", ["ntheta"])
+    ps.write(file_name="unitless.in", base_directory=tmp_path)
+
+    loaded = PyroScan(ps.base_pyro, pyroscan_json=tmp_path / "pyroscan.json")
+
+    assert set(loaded.parameter_dict) == set(parameter_dict)
+    for key, expected in parameter_dict.items():
+        actual = loaded.parameter_dict[key]
+        assert not hasattr(actual, "units"), f"{key} unexpectedly gained units"
+        np.testing.assert_allclose(np.asarray(actual), expected)
+
+    # load_gk_output once iterated parameter_dict values assuming each had
+    # .magnitude, which crashed for unitless parameters. Without real output
+    # files a FileNotFoundError is acceptable here; only AttributeError on
+    # .magnitude indicates the unit-handling bug.
+    with pytest.raises(FileNotFoundError):
+        loaded.load_gk_output()
+
+
 def test_apply_func(tmp_path):
     pyro = example_SCENE.main(tmp_path)
 


### PR DESCRIPTION
PyroScan.load_gk_output called .magnitude and .units on every entry of parameter_dict, raising AttributeError when a scan included a parameter without pint units (e.g. TGLF WIDTH/NBASIS_MAX, integer ntheta, or any parameter pyrokinetics did not auto-attach units to). Plain arrays now fall back to ureg.dimensionless.