### PR TITLE
Update dimensionality of mass to mref

### DIFF
--- a/src/pyrokinetics/normalisation.py
+++ b/src/pyrokinetics/normalisation.py
@@ -838,7 +838,7 @@ class SimulationNormalisation(Normalisation):
             add_deuterium = True
             hyrogenic_mass = kinetics.species_data["hydrogenic"].get_mass()
             deuterium_factor = (
-                ((1.0 * ureg.mref_deuterium) / hyrogenic_mass).to_base_units().m
+                (1.0 * ureg.deuterium_mass / hyrogenic_mass).to_base_units().m
             )
             self.define(f"mref_hydrogenic_{self.name} = {hyrogenic_mass}", units=True)
             base_mass = "hydrogenic"
@@ -895,6 +895,11 @@ class SimulationNormalisation(Normalisation):
             self.pyrokinetics.nref.dimensionality,
             lambda ureg, x: x.to(ureg.nref_electron).m * self.pyrokinetics.nref,
         )
+        self.context.add_transformation(
+            "[mref]",
+            self.pyrokinetics.mref.dimensionality,
+            lambda ureg, x: x.to(ureg.mref_deuterium).m * self.pyrokinetics.mref,
+        )
 
         # Transformations for mixed units because pint can't handle
         # them automatically.
@@ -942,7 +947,7 @@ class SimulationNormalisation(Normalisation):
         self.define(f"tref_electron_{self.name} = {tref_electron}", units=True)
         self.define(f"nref_electron_{self.name} = {nref_electron}", units=True)
 
-        self.define(f"mref_deuterium_{self.name} = mref_deuterium", units=True)
+        self.define(f"mref_deuterium_{self.name} = deuterium_mass", units=True)
 
         if lref_minor_radius and lref_major_radius:
             if aspect_ratio is None:
@@ -1060,6 +1065,11 @@ class SimulationNormalisation(Normalisation):
             "[nref]",
             self.pyrokinetics.nref.dimensionality,
             lambda ureg, x: x.to(ureg.nref_electron).m * self.pyrokinetics.nref,
+        )
+        self.context.add_transformation(
+            "[mref]",
+            self.pyrokinetics.mref.dimensionality,
+            lambda ureg, x: x.to(ureg.mref_deuterium).m * self.pyrokinetics.mref,
         )
 
         self.context.add_transformation(

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -265,9 +265,15 @@ class PyroUnitRegistry(pint.UnitRegistry):
         # WARNING: This might need refactoring to use a [mref] dimension
         # if we start having other possible reference masses
         self.define("mref_deuterium = [mref]")
-        self.define(f"mref_electron = {self.electron_mass} / {self.deuterium_mass} mref_deuterium")
-        self.define(f"mref_hydrogen = {self.hydrogen_mass} / {self.deuterium_mass} mref_deuterium")
-        self.define(f"mref_tritium = {self.tritium_mass} / {self.deuterium_mass} mref_deuterium")
+        self.define(
+            f"mref_electron = {self.electron_mass} / {self.deuterium_mass} mref_deuterium"
+        )
+        self.define(
+            f"mref_hydrogen = {self.hydrogen_mass} / {self.deuterium_mass} mref_deuterium"
+        )
+        self.define(
+            f"mref_tritium = {self.tritium_mass} / {self.deuterium_mass} mref_deuterium"
+        )
 
         # For each normalisation unit, we create a unique dimension for
         # that unit and convention

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -257,14 +257,17 @@ class PyroUnitRegistry(pint.UnitRegistry):
         self.define(
             f"tritium_mass = {physical_constants['triton mass'][0]} {physical_constants['triton mass'][1]}"
         )
+        self.define(
+            f"electron_mass = {physical_constants['electron mass'][0]} {physical_constants['electron mass'][1]}"
+        )
 
         # We can immediately define reference masses in physical units.
         # WARNING: This might need refactoring to use a [mref] dimension
         # if we start having other possible reference masses
-        self.define("mref_deuterium = deuterium_mass")
-        self.define("mref_electron = electron_mass")
-        self.define("mref_hydrogen = hydrogen_mass")
-        self.define("mref_tritium = tritium_mass")
+        self.define("mref_deuterium = [mref]")
+        self.define(f"mref_electron = {self.electron_mass} / {self.deuterium_mass} mref_deuterium")
+        self.define(f"mref_hydrogen = {self.hydrogen_mass} / {self.deuterium_mass} mref_deuterium")
+        self.define(f"mref_tritium = {self.tritium_mass} / {self.deuterium_mass} mref_deuterium")
 
         # For each normalisation unit, we create a unique dimension for
         # that unit and convention
@@ -272,7 +275,8 @@ class PyroUnitRegistry(pint.UnitRegistry):
         self.define("lref_minor_radius = [lref]")
         self.define("nref_electron = [nref]")
         self.define("tref_electron = [tref]")
-        self.define("vref_nrl = [vref] = ([tref] / [mref])**(0.5)")
+        self.define("[vref] = [tref] ** 0.5 / [mref] ** 0.5")
+        self.define("vref_nrl = [vref]")
         self.define(
             "rhoref_pyro = [rhoref] = ([tref] / [mref])**(0.5) * [mref] / [bref_B0])"
         )

--- a/src/pyrokinetics/units.py
+++ b/src/pyrokinetics/units.py
@@ -277,9 +277,8 @@ class PyroUnitRegistry(pint.UnitRegistry):
         self.define("tref_electron = [tref]")
         self.define("[vref] = [tref] ** 0.5 / [mref] ** 0.5")
         self.define("vref_nrl = [vref]")
-        self.define(
-            "rhoref_pyro = [rhoref] = ([tref] / [mref])**(0.5) * [mref] / [bref_B0])"
-        )
+        self.define("[rhoref] = [tref] ** 0.5 * [mref] ** 0.5 / [bref]")
+        self.define("rhoref_pyro = [rhoref]")
         self.define("beta_ref_ee_B0 = [beta_ref]")
 
         # vrefs are related by constant, so we can always define this one

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -66,6 +66,7 @@ def test_convert_velocities():
 
     assert velocity.to(ureg.vref_most_probable).m == 1.0 / np.sqrt(2)
     assert velocity.to(ureg.vref_most_probable).to(ureg.vref_nrl) == velocity
+    assert velocity.to((ureg.tref_electron / ureg.mref_deuterium)**0.5).m == 1.0
 
 
 def test_switch_convention():

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -283,6 +283,17 @@ def test_convert_vref_simulation_to_physical(geometry, kinetics):
     assert np.isclose((1 * ureg.vref_most_probable).to(norm.gs2), 1.0 * norm.gs2.vref)
 
 
+def test_convert_rhoref_simulation_to_physical(geometry, kinetics):
+    norm = SimulationNormalisation(
+        "test", geometry=geometry, kinetics=kinetics, psi_n=0.5
+    )
+
+    rhoref = 1 * ureg.rhoref_pyro
+    assert rhoref.to(ureg.vref_nrl * ureg.mref_deuterium / ureg.bref_B0).m == 1.0
+    assert np.isclose(rhoref.to(norm), 1.0 * norm.rhoref)
+    assert np.isclose((1 * ureg.rhoref_gs2).to(norm.gs2), 1.0 * norm.gs2.rhoref)
+
+
 def test_convert_single_unit_to_normalisation(geometry, kinetics):
     norm = SimulationNormalisation(
         "test", geometry=geometry, kinetics=kinetics, psi_n=0.5

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -66,7 +66,7 @@ def test_convert_velocities():
 
     assert velocity.to(ureg.vref_most_probable).m == 1.0 / np.sqrt(2)
     assert velocity.to(ureg.vref_most_probable).to(ureg.vref_nrl) == velocity
-    assert velocity.to((ureg.tref_electron / ureg.mref_deuterium)**0.5).m == 1.0
+    assert velocity.to((ureg.tref_electron / ureg.mref_deuterium) ** 0.5).m == 1.0
 
 
 def test_switch_convention():


### PR DESCRIPTION
In pyro there are two classes of units, simulation (`vref`, `tref` `nref` etc) and physical units (all in SI) for each of the reference values. In general it is possible to convert between simulation units without issue but when converting to SI, you need to specify a context under which you could transform sat `tref` to `keV`

However, somehow the simulation reference masses were defined in `kg` rather than making up a an dimension of `mref`. This means that before it wasn't possible to do the following

`(1 * ureg.vref_nrl).to((ureg.tref_electron / ureg.mref_deuterium)**0.5).m`

This corrects that so we now have a proper `mref` dimension which can be used to convert velocities.

Also allows for converting `rhoref` to its constituent units.
