### PR TITLE
Bugfix/duplicate self update

### DIFF
--- a/src/pyrokinetics/pyroscan.py
+++ b/src/pyrokinetics/pyroscan.py
@@ -446,8 +446,6 @@ class PyroScan:
 
         self.update_self_parameters()
 
-        self.update_self_parameters()
-
         # Iterate through all runs and write output
         for parameter, run_dir, pyro in zip(
             self.outer_product(), self.run_directories, self.pyro_dict.values()

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -476,3 +476,24 @@ def test_apply_func(tmp_path):
                 pyro.local_species.electron.inverse_ln
                 == pyro.local_species[species].inverse_ln
             )
+
+def test_parameter_func_not_applied_twice(tmp_path):
+    pyro = example_SCENE.main(tmp_path)
+
+    parameter_dict = {"alt": [1.0]}
+
+    pyro_scan = PyroScan(pyro, parameter_dict=parameter_dict)
+    pyro_scan.add_parameter_key("alt", "local_species", ["electron", "inverse_lt"])
+
+    def increment_electron(pyro):
+        pyro.local_species.electron.inverse_lt *= 2.0
+
+    pyro_scan.add_parameter_func("alt", increment_electron, {})
+
+    pyro_scan.write(file_name="test.input", base_directory=tmp_path)
+
+    # Now check value
+    for pyro_obj in pyro_scan.pyro_dict.values():
+        val = pyro_obj.local_species.electron.inverse_lt
+
+        assert np.isclose(val.magnitude, 2.0) 

--- a/tests/test_pyroscan.py
+++ b/tests/test_pyroscan.py
@@ -477,6 +477,7 @@ def test_apply_func(tmp_path):
                 == pyro.local_species[species].inverse_ln
             )
 
+
 def test_parameter_func_not_applied_twice(tmp_path):
     pyro = example_SCENE.main(tmp_path)
 
@@ -496,4 +497,4 @@ def test_parameter_func_not_applied_twice(tmp_path):
     for pyro_obj in pyro_scan.pyro_dict.values():
         val = pyro_obj.local_species.electron.inverse_lt
 
-        assert np.isclose(val.magnitude, 2.0) 
+        assert np.isclose(val.magnitude, 2.0)


### PR DESCRIPTION
Fix double application of `update_self_parameters `causing incorrect `add_parameter_func `behaviour. 

`self.update_self_parameters()' calls user-defined functions, calling it twice results in double application of user defined functions, which may give an incorrect scan output.

Removed the duplicate and added a test to make sure a function is only applied once.

Thanks @physycola for reporting this.