### PR TITLE
Bugfix/load shape terms

### DIFF
--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -360,11 +360,11 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             zeta = self.data["geometry"].get("zeta", -local_geometry_data["sn"][2])
 
             s_delta = (
-                self.data["geometry"].get("s_delta", local_geometry_data["dsndr"][1])
-                / local_geometry_data["rho"]
+                self.data["geometry"].get("s_delta", local_geometry_data["dsndr"][1]*local_geometry_data["rho"])
+                / local_geometry_data["rho"])
             )
             s_zeta = (
-                self.data["geometry"].get("s_zeta", -local_geometry_data["dsndr"][2])
+                self.data["geometry"].get("s_zeta", -local_geometry_data["dsndr"][2]*local_geometry_data["rho"])
                 / local_geometry_data["rho"]
             )
 

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -361,7 +361,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
 
             s_delta = (
                 self.data["geometry"].get("s_delta", local_geometry_data["dsndr"][1]*local_geometry_data["rho"])
-                / local_geometry_data["rho"])
+                / local_geometry_data["rho"]
             )
             s_zeta = (
                 self.data["geometry"].get("s_zeta", -local_geometry_data["dsndr"][2]*local_geometry_data["rho"])

--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -360,11 +360,17 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
             zeta = self.data["geometry"].get("zeta", -local_geometry_data["sn"][2])
 
             s_delta = (
-                self.data["geometry"].get("s_delta", local_geometry_data["dsndr"][1]*local_geometry_data["rho"])
+                self.data["geometry"].get(
+                    "s_delta",
+                    local_geometry_data["dsndr"][1] * local_geometry_data["rho"],
+                )
                 / local_geometry_data["rho"]
             )
             s_zeta = (
-                self.data["geometry"].get("s_zeta", -local_geometry_data["dsndr"][2]*local_geometry_data["rho"])
+                self.data["geometry"].get(
+                    "s_zeta",
+                    -local_geometry_data["dsndr"][2] * local_geometry_data["rho"],
+                )
                 / local_geometry_data["rho"]
             )
 


### PR DESCRIPTION
Fixes erroneous local geometry calculation when loading gene input files that haven't specified s_delta and s_zeta, as rho has already been divided out of dsndr and dcndr near line 350.