### PR TITLE
Find the GENE geometry header length instead of assuming it

### DIFF
--- a/src/pyrokinetics/gk_code/gene.py
+++ b/src/pyrokinetics/gk_code/gene.py
@@ -37,6 +37,49 @@ from .gk_input import GKInput
 from .gk_output import Coords, Eigenvalues, Fields, Fluxes, GKOutput, Moments
 
 
+def read_gene_geometry_data(filename: PathLike) -> np.ndarray:
+    """
+    Read the columns of data that follow the ``&parameters`` header of a GENE
+    geometry output file.
+
+    The length of that header depends on which parameters GENE wrote, so it is
+    found by looking for the line closing the namelist rather than assumed. The
+    number of rows read is checked against the ``gridpoints`` entry of the
+    header, which should equal ``nz0``.
+
+    Parameters
+    ----------
+    filename
+        Path to a GENE geometry file, e.g. ``miller_0001``.
+
+    Returns
+    -------
+    np.ndarray
+        2D array of geometry data, with one row per point along the field line.
+    """
+    with open(filename) as f:
+        for line_number, line in enumerate(f):
+            if line.strip() == "/":
+                skiprows = line_number + 1
+                break
+        else:
+            raise ValueError(
+                f"Could not find the end of the '&parameters' namelist in the GENE "
+                f"geometry file {filename}"
+            )
+
+    geometry_data = np.loadtxt(filename, skiprows=skiprows)
+
+    gridpoints = f90nml.read(filename)["parameters"].get("gridpoints", None)
+    if gridpoints is not None and len(geometry_data) != gridpoints:
+        raise ValueError(
+            f"Read {len(geometry_data)} rows of geometry data from {filename}, but "
+            f"its header declares gridpoints = {gridpoints}"
+        )
+
+    return geometry_data
+
+
 class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
     """
     Class that can read GENE input files, and produce
@@ -587,11 +630,7 @@ class GKInputGENE(GKInput, FileReader, file_type="GENE", reads=GKInput):
                 if geo_dict["Lref"] == 0.0:
                     geo_dict["Lref"] = 1.0
 
-                skiprows = 19
-                if "edge_opt" in geometry_nml["parameters"].keys():
-                    skiprows += 1
-
-                geometry_data = np.loadtxt(geometry_filename, skiprows=skiprows)
+                geometry_data = read_gene_geometry_data(geometry_filename)
 
                 Z0 = self.data["geometry"].get("major_z", False)
                 if Z0:
@@ -2475,14 +2514,7 @@ class GKOutputReaderGENE(FileReader, file_type="GENE", reads=GKOutput):
         if gk_input.data["geometry"].get("norm_flux_projection", False):
             geometry_type = gk_input.data["geometry"]["magn_geometry"]
 
-            geometry_filename = raw_data[geometry_type]
-            geometry_nml = f90nml.read(geometry_filename)
-
-            skiprows = 19
-            if "edge_opt" in geometry_nml["parameters"].keys():
-                skiprows += 1
-
-            geometry_data = np.loadtxt(geometry_filename, skiprows=skiprows)
+            geometry_data = read_gene_geometry_data(raw_data[geometry_type])
 
             grho = np.sqrt(geometry_data[:, 0])
             jacob = geometry_data[:, -6]

--- a/tests/gk_code/test_gk_input_gene.py
+++ b/tests/gk_code/test_gk_input_gene.py
@@ -1,11 +1,13 @@
 import sys
 from pathlib import Path
 
+import f90nml
 import numpy as np
 import pytest
 
 from pyrokinetics import template_dir
 from pyrokinetics.gk_code import GKInputGENE
+from pyrokinetics.gk_code.gene import read_gene_geometry_data
 from pyrokinetics.local_geometry import LocalGeometryMiller
 from pyrokinetics.local_species import LocalSpecies
 from pyrokinetics.numerics import Numerics
@@ -15,6 +17,7 @@ sys.path.append(str(docs_dir))
 from examples import example_JETTO  # noqa
 
 template_file = template_dir / "input.gene"
+geometry_file = template_dir / "outputs" / "GENE_linear" / "miller_0001"
 
 
 @pytest.fixture
@@ -160,3 +163,57 @@ def test_drop_species(tmp_path):
     pyro.update_gk_code()
     n_species = pyro.local_species.nspec
     assert len(pyro.gk_input.data["species"]) == n_species
+
+
+def _write_geometry_file(path, extra_header_lines=()):
+    """Copy the reference geometry file, optionally adding entries to its
+    ``&parameters`` header, so the header length changes."""
+    lines = geometry_file.read_text().split("\n")
+    end_of_header = lines.index("/")
+    lines[end_of_header:end_of_header] = list(extra_header_lines)
+    path.write_text("\n".join(lines))
+    return path
+
+
+def test_read_gene_geometry_data():
+    """All gridpoints rows of data should be read, none dropped."""
+    data = read_gene_geometry_data(geometry_file)
+    gridpoints = f90nml.read(geometry_file)["parameters"]["gridpoints"]
+    assert len(data) == gridpoints
+
+
+@pytest.mark.parametrize(
+    "extra_header_lines",
+    [
+        (),
+        ("edge_opt =   0.0000000000000000E+00",),
+        ("edge_opt =   0.0000000000000000E+00", "my_parameter =   1"),
+    ],
+)
+def test_read_gene_geometry_data_header_length(tmp_path, extra_header_lines):
+    """The header holds a different number of entries depending on what GENE was
+    asked to do, so its length has to be found rather than assumed."""
+    reference = read_gene_geometry_data(geometry_file)
+    path = _write_geometry_file(tmp_path / "miller_0001", extra_header_lines)
+
+    np.testing.assert_allclose(read_gene_geometry_data(path), reference)
+
+
+def test_read_gene_geometry_data_row_count_mismatch(tmp_path):
+    """A header length that doesn't line up with 'gridpoints' should be reported
+    rather than silently returning short data."""
+    path = tmp_path / "miller_0001"
+    lines = geometry_file.read_text().split("\n")
+    del lines[lines.index("/") + 1]
+    path.write_text("\n".join(lines))
+
+    with pytest.raises(ValueError, match="gridpoints"):
+        read_gene_geometry_data(path)
+
+
+def test_read_gene_geometry_data_no_header(tmp_path):
+    path = tmp_path / "miller_0001"
+    path.write_text("1.0 2.0\n3.0 4.0\n")
+
+    with pytest.raises(ValueError, match="namelist"):
+        read_gene_geometry_data(path)


### PR DESCRIPTION
The number of header lines to skip when reading a GENE geometry output file was hard-coded as 19, plus 1 when 'edge_opt' was written. Both are one too many: the '&parameters' namelist closes on line 18 of the reference miller_0001 file, whose header has no 'edge_opt' entry. The first row of geometry data was therefore dropped, leaving the columns one point short of nz0 and shifted against the theta grid.

The header length depends on which parameters GENE was asked to write, so read_gene_geometry_data now finds the line closing the namelist rather than counting on a fixed number of entries, and checks the rows it read against the 'gridpoints' entry of the header so that a short read can't pass silently. Both callers use it: get_gene_geometry and the norm_flux_projection branch of _get_fluxes.

No existing test covered this path — get_gene_geometry only runs for 'tracer_efit' and 'gene' geometries, which no fixture uses with a geometry file alongside — so tests are added for the header length, the row-count check and a file with no header at all.

Bug and solution found by Claude.